### PR TITLE
refactor: replace 'success' with 'isValid' in API response handling

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,7 +27,7 @@
       "label": "Remove old generated test",
       "type": "shell",
       "command": "rm",
-      "args": ["-rf", "tests/integrations/generated"],
+      "args": ["-rf", "apps/craft/tests/integrations/generated"],
       "group": "build"
     }
   ]

--- a/apps/craft/README.md
+++ b/apps/craft/README.md
@@ -238,7 +238,7 @@ Recommended pattern:
 ```ts
 const result = await getPetById({ petId: "123" });
 
-if (result.success === false) {
+if (result.isValid === false) {
   console.error("Operation failed:", result.kind, result.error);
 } else if (result.status === 200) {
   console.log("Pet (raw):", result.data);
@@ -253,7 +253,7 @@ if (result.success === false) {
 
 Client calls never throw exceptions. Instead, all errors are returned as part of
 the response union, providing a consistent and type-safe error handling
-experience. You can branch on either `result.success === false` or the presence
+experience. You can branch on either `result.isValid === false` or the presence
 of the `kind` field; both are valid.
 
 ### Error Types
@@ -302,7 +302,7 @@ type ApiResponseError =
 ```ts
 const result = await getPetById({ petId: "123" });
 
-if (!result.success) {
+if (!result.isValid) {
   // You don't have to handle all errors like this, but you can.
   switch (result.kind) {
     case "unexpected-response":
@@ -385,7 +385,7 @@ async function demonstrateClient() {
   const lazyPetsResponse = await findPetsByStatus({
     query: { status: "available" },
   });
-  if (lazyPetsResponse.success === true && lazyPetsResponse.status === 200) {
+  if (lazyPetsResponse.isValid === true && lazyPetsResponse.status === 200) {
     lazyPetsResponse.parse();
   }
 
@@ -398,7 +398,7 @@ async function demonstrateClient() {
   const petsResponse1 = await lazyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse1.success === true && petsResponse1.status === 200) {
+  if (petsResponse1.isValid === true && petsResponse1.status === 200) {
     petsResponse1.parse();
   }
 
@@ -410,7 +410,7 @@ async function demonstrateClient() {
     },
     { ...globalConfig, forceValidation: true },
   );
-  if (greedyPetResponse.success === true && greedyPetResponse.status === 200) {
+  if (greedyPetResponse.isValid === true && greedyPetResponse.status === 200) {
     // automatic validation: .parsed available
     greedyPetResponse.parsed;
   }
@@ -424,7 +424,7 @@ async function demonstrateClient() {
   const petsResponse2 = await greedyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse2.success === true && petsResponse2.status === 200) {
+  if (petsResponse2.isValid === true && petsResponse2.status === 200) {
     // bound automatic validation: .parsed available
     petsResponse2.parsed;
   }
@@ -452,7 +452,7 @@ These objects never throw; you inspect the returned value to act accordingly.
 ```ts
 const result = await getUserProfile({ userId: "123" });
 
-if (result.success) {
+if (result.isValid) {
   if (result.status === 200) {
     const outcome = result.parse();
     if ("parsed" in outcome) {
@@ -533,7 +533,7 @@ const client = configureOperations(
 );
 
 const result = await client.getUserProfile({ userId: "123" });
-if (result.success && result.status === 200) {
+if (result.isValid && result.status === 200) {
   if (isParsed(result)) {
     console.log("User:", result.parsed.name);
   } else if (result.kind === "parse-error") {
@@ -654,7 +654,7 @@ const res = await testMultiContentTypes(
   },
 );
 
-if (res.success && res.status === 200) {
+if (res.isValid && res.status === 200) {
   const outcome = res.parse();
   if (isParsed(outcome)) {
     console.log(outcome.parsed);

--- a/apps/craft/examples/README.md
+++ b/apps/craft/examples/README.md
@@ -167,7 +167,7 @@ Generated server wrappers expect handlers that follow this pattern:
 
 ```typescript
 const handler: getPetByIdHandler = async (params) => {
-  if (!params.success) {
+  if (!params.isValid) {
     // Handle validation errors
     return { status: 400 };
   }
@@ -207,7 +207,7 @@ const response = await findPetsByStatus(
   localConfig,
 );
 
-if (response.success && response.status === 200) {
+if (response.isValid && response.status === 200) {
   const data = response.parse();
   if (isParsed(data)) {
     console.log("Pets:", data.parsed);

--- a/apps/craft/examples/client-examples/force-validation.ts
+++ b/apps/craft/examples/client-examples/force-validation.ts
@@ -13,7 +13,7 @@ async function demonstrateClient() {
   const lazyPetsResponse = await findPetsByStatus({
     query: { status: "available" },
   });
-  if (lazyPetsResponse.success === true && lazyPetsResponse.status === 200) {
+  if (lazyPetsResponse.isValid === true && lazyPetsResponse.status === 200) {
     lazyPetsResponse.parse();
   }
 
@@ -26,7 +26,7 @@ async function demonstrateClient() {
   const petsResponse1 = await lazyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse1.success === true && petsResponse1.status === 200) {
+  if (petsResponse1.isValid === true && petsResponse1.status === 200) {
     petsResponse1.parse();
   }
 
@@ -38,7 +38,7 @@ async function demonstrateClient() {
     },
     { ...globalConfig, forceValidation: true },
   );
-  if (greedyPetResponse.success === true && greedyPetResponse.status === 200) {
+  if (greedyPetResponse.isValid === true && greedyPetResponse.status === 200) {
     // automatic validation: .parsed available
     greedyPetResponse.parsed;
   }
@@ -52,7 +52,7 @@ async function demonstrateClient() {
   const petsResponse2 = await greedyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse2.success === true && petsResponse2.status === 200) {
+  if (petsResponse2.isValid === true && petsResponse2.status === 200) {
     // bound automatic validation: .parsed available
     petsResponse2.parsed;
   }

--- a/apps/craft/examples/client-examples/multi-content-types.ts
+++ b/apps/craft/examples/client-examples/multi-content-types.ts
@@ -40,7 +40,7 @@ async function demonstrateClient() {
     },
   );
 
-  if (!ret.success) {
+  if (!ret.isValid) {
     console.error("Error:", ret.error);
   } else if (ret.status === 200) {
     console.log("Raw data:", ret.data);

--- a/apps/craft/src/client-generator/templates/config-templates.ts
+++ b/apps/craft/src/client-generator/templates/config-templates.ts
@@ -12,7 +12,7 @@ export function renderApiResponseTypes(): string {
  */
 export type ApiResponse<S extends number, T> =
   | {
-      readonly success: true;
+      readonly isValid: true;
       readonly status: S;
       readonly data: T;
       readonly response: Response;
@@ -32,7 +32,7 @@ type ApiResponseErrorResult = {
  * Represents all possible error conditions that can occur during an operation
  */
 export type ApiResponseError = {
-  readonly success: false;
+  readonly isValid: false;
 } & (
   | {
       readonly kind: "unexpected-error";
@@ -82,7 +82,7 @@ export type ApiResponseWithParse<
   S extends number,
   Map extends Record<string, Record<string, any>>,
 > = {
-  readonly success: true;
+  readonly isValid: true;
   readonly status: S;
   readonly data: unknown;
   readonly response: Response;
@@ -109,7 +109,7 @@ export type ApiResponseWithForcedParse<
   S extends number,
   Map extends Record<string, Record<string, any>>,
 > = {
-  readonly success: true;
+  readonly isValid: true;
   readonly status: S;
   readonly data: unknown;
   readonly response: Response;

--- a/apps/craft/src/client-generator/templates/function-body-templates.ts
+++ b/apps/craft/src/client-generator/templates/function-body-templates.ts
@@ -130,7 +130,7 @@ ${responseHandlers.join("\n")}
         /* Return error for unexpected status codes instead of throwing */
         return {
           kind: "unexpected-response",
-          success: false,
+          isValid: false,
           result: {
             data,
             status: response.status,
@@ -142,7 +142,7 @@ ${responseHandlers.join("\n")}
     }
   } catch (error) {
     return {
-      success: false,
+      isValid: false,
       kind: "unexpected-error",
       error,
     } as const;
@@ -159,7 +159,7 @@ export function renderHeadersObject(config: HeaderConfiguration): string {
       config.authHeaders &&
       config.authHeaders.length > 0
         ? `...Object.fromEntries(
-      Object.entries(config.headers).filter(([key]) => 
+      Object.entries(config.headers).filter(([key]) =>
         !['${config.authHeaders.join("', '")}'].includes(key)
       )
     ),`
@@ -177,7 +177,7 @@ ${config.acceptHeaderLogic}`
       config.authHeaders &&
       config.authHeaders.length > 0
         ? `...Object.fromEntries(
-      Object.entries(config.headers).filter(([key]) => 
+      Object.entries(config.headers).filter(([key]) =>
         !['${config.authHeaders.join("', '")}'].includes(key)
       )
     ),`

--- a/apps/craft/src/client-generator/templates/response-templates.ts
+++ b/apps/craft/src/client-generator/templates/response-templates.ts
@@ -24,14 +24,14 @@ ${!responseInfo.hasSchema ? "      const data = undefined;" : ""}
         /* Force validation: automatically parse and return result */
         const parseResult = parseApiResponseUnknownData(minimalResponse, data, ${responseMapName}["${statusCode}"], config.deserializers ?? {});
         if ("parsed" in parseResult) {
-          const forcedResult = { success: true as const, status: ${statusCode} as const, data, response, parsed: parseResult } satisfies ApiResponseWithForcedParse<${statusCode}, typeof ${responseMapName}>;
+          const forcedResult = { isValid: true as const, status: ${statusCode} as const, data, response, parsed: parseResult } satisfies ApiResponseWithForcedParse<${statusCode}, typeof ${responseMapName}>;
           // Need a bridge assertion to the conditional return type because generic TForceValidation isn't narrowed by runtime branch
           return forcedResult as unknown as (TForceValidation extends true ? ApiResponseWithForcedParse<${statusCode}, typeof ${responseMapName}> : ApiResponseWithParse<${statusCode}, typeof ${responseMapName}>);
         }
         if (parseResult.kind) {
           const errorResult = {
             ...parseResult,
-            success: false as const,
+            isValid: false as const,
             result: { data, status: ${statusCode}, response },
           } satisfies ApiResponseError;
           return errorResult;
@@ -40,7 +40,7 @@ ${!responseInfo.hasSchema ? "      const data = undefined;" : ""}
       } else {
         /* Manual validation: provide parse method */
         const manualResult = {
-          success: true as const,
+          isValid: true as const,
           status: ${statusCode} as const,
           data,
           response,
@@ -53,13 +53,13 @@ ${!responseInfo.hasSchema ? "      const data = undefined;" : ""}
       /* No schema or response map: return simple response */
       return `    case ${statusCode}: {
 ${!responseInfo.hasSchema ? "      const data = undefined;" : ""}
-  return { success: true as const, status: ${statusCode} as const, data, response };
+  return { isValid: true as const, status: ${statusCode} as const, data, response };
     }`;
     }
   }
 
   return `    case ${statusCode}:
-  return { success: true as const, status: ${statusCode} as const, data: undefined, response };`;
+  return { isValid: true as const, status: ${statusCode} as const, data: undefined, response };`;
 }
 
 /*

--- a/apps/craft/tests/client-generator/error-handling.test.ts
+++ b/apps/craft/tests/client-generator/error-handling.test.ts
@@ -95,7 +95,6 @@ describe("error handling in client generator", () => {
         typeImports,
         true,
         "TestOperationResponseMap",
-        false,
       );
 
       /* Should include parse method that calls parseApiResponseUnknownData */
@@ -130,7 +129,6 @@ describe("error handling in client generator", () => {
         typeImports,
         true,
         "TestOperationResponseMap",
-        true,
       );
 
       /* Should include error handling in force validation mode */
@@ -140,7 +138,7 @@ describe("error handling in client generator", () => {
       );
       expect(responseHandler).toContain('if ("parsed" in parseResult)');
       expect(responseHandler).toContain("if (parseResult.kind");
-      expect(responseHandler).toContain("success: false");
+      expect(responseHandler).toContain("isValid: false");
       /* Force validation should directly return parsed result or error, not provide a parse method */
     });
   });

--- a/apps/craft/tests/client-generator/force-validation.test.ts
+++ b/apps/craft/tests/client-generator/force-validation.test.ts
@@ -102,7 +102,7 @@ describe("force validation flag", () => {
       );
       expect(result.responseHandlers[0]).toContain("parsed: parseResult");
       expect(result.responseHandlers[0]).toContain("if (parseResult.kind)");
-      expect(result.responseHandlers[0]).toContain("success: false");
+      expect(result.responseHandlers[0]).toContain("isValid: false");
 
       /* Should also contain manual validation branch */
       expect(result.responseHandlers[0]).toContain("} else {");

--- a/apps/craft/tests/client-generator/response-templates.test.ts
+++ b/apps/craft/tests/client-generator/response-templates.test.ts
@@ -26,7 +26,7 @@ describe("response-templates", () => {
 
       expect(result).toContain("case 204:");
       expect(result).toContain(
-        "return { success: true as const, status: 204 as const, data: undefined, response };",
+        "return { isValid: true as const, status: 204 as const, data: undefined, response };",
       );
     });
 
@@ -48,7 +48,7 @@ describe("response-templates", () => {
       expect(result).toContain("case 200: {");
       expect(result).toContain("const data = undefined");
       expect(result).toContain(
-        "return { success: true as const, status: 200 as const, data, response };",
+        "return { isValid: true as const, status: 200 as const, data, response };",
       );
     });
   });

--- a/apps/craft/tests/integrations/dashed-body.test.ts
+++ b/apps/craft/tests/integrations/dashed-body.test.ts
@@ -44,7 +44,7 @@ describe("Dashed body properties integration", () => {
     });
 
     // The mock server (Prism) will echo a 200 only if spec matches.
-    if ("success" in response && response.success) {
+    if ("isValid" in response && response.isValid) {
       expect(response.status).toBe(200);
       // Manually parse/validate (lazy) since forceValidation false by default
       const parsed = await response.parse();

--- a/apps/craft/tests/integrations/express-server-wrapper.test.ts
+++ b/apps/craft/tests/integrations/express-server-wrapper.test.ts
@@ -102,7 +102,7 @@ describe("Express server wrappers integration", () => {
           wrapper: testParameterWithDashWrapper,
         },
         async (params) => {
-          if (!params.success) {
+          if (!params.isValid) {
             /* Map validation errors to an allowed fallback status (500) */
             return { status: 500 } as const;
           }
@@ -118,7 +118,7 @@ describe("Express server wrappers integration", () => {
       const adapter = localCreateExpressAdapter(
         { path: r.path, method: r.method, wrapper: testWithTwoParamsWrapper },
         async (params) => {
-          if (!params.success) return { status: 500 } as const;
+          if (!params.isValid) return { status: 500 } as const;
           return { status: 200, data: params.value } as const;
         },
       );
@@ -131,7 +131,7 @@ describe("Express server wrappers integration", () => {
       const adapter = localCreateExpressAdapter(
         { path: r.path, method: r.method, wrapper: testCoercionWrapper },
         async (params) => {
-          if (!params.success) return { status: 500 } as const;
+          if (!params.isValid) return { status: 500 } as const;
           return { status: 200, data: params.value } as const;
         },
       );

--- a/apps/craft/tests/integrations/operations/binary-upload.test.ts
+++ b/apps/craft/tests/integrations/operations/binary-upload.test.ts
@@ -41,7 +41,7 @@ describe("octet-stream binary upload integration", () => {
     });
 
     // Assert: operation should either succeed with 200, or return an error-like object
-    if ("success" in response && response.success) {
+    if ("isValid" in response && response.isValid) {
       expect(response.status).toBe(200);
     } else if ("kind" in response) {
       // Unexpected-response error object - ensure it is shaped as expected
@@ -62,7 +62,7 @@ describe("octet-stream binary upload integration", () => {
       contentType: { request: "application/octet-stream" },
     });
 
-    if ("success" in octetResponse && octetResponse.success) {
+    if ("isValid" in octetResponse && octetResponse.isValid) {
       expect(octetResponse.status).toBe(200);
     } else if ("kind" in octetResponse) {
       expect(octetResponse.kind).toBe("unexpected-response");

--- a/apps/craft/tests/integrations/operations/security.test.ts
+++ b/apps/craft/tests/integrations/operations/security.test.ts
@@ -380,7 +380,7 @@ describe("Security Operations", () => {
 
       // Assert - Should return error result instead of throwing
       expect(result).toBeDefined();
-      expect(result.success).toBe(false);
+      expect(result.isValid).toBe(false);
       expect(result.kind).toBe("unexpected-error");
       expect(result.error).toBeDefined();
     });

--- a/apps/craft/tests/integrations/server-generator/strict-validation-behavior.test.ts
+++ b/apps/craft/tests/integrations/server-generator/strict-validation-behavior.test.ts
@@ -13,13 +13,13 @@ describe("Strict validation behavior", () => {
 
     // @ts-expect-error
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.success) {
+      if (params.isValid) {
         return {
           status: 200,
           contentType: "application/json",
           data: mockData.newModel(),
         };
-      } else if (!params.success && params.kind === "body-error") {
+      } else if (!params.isValid && params.kind === "body-error") {
         validationErrorReceived = true;
         actualError = params.error;
         return {
@@ -30,7 +30,7 @@ describe("Strict validation behavior", () => {
       }
 
       throw new Error(
-        `Unexpected validation error: ${!params.success ? params.kind : "unknown"}`,
+        `Unexpected validation error: ${!params.isValid ? params.kind : "unknown"}`,
       );
     };
 
@@ -64,7 +64,7 @@ describe("Strict validation behavior", () => {
 
   it("should accept request body without extra properties", async () => {
     const handler: testMultiContentTypesHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         expect(params.value.body).toEqual({
           id: "test-123",
           name: "Test Object",
@@ -77,7 +77,7 @@ describe("Strict validation behavior", () => {
       }
 
       throw new Error(
-        `Unexpected validation error: ${"success" in params && !params.success ? params.kind : "unknown"}`,
+        `Unexpected validation error: ${"isValid" in params && !params.isValid ? params.kind : "unknown"}`,
       );
     };
 

--- a/apps/craft/tests/integrations/server-generator/testAuthBearer.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testAuthBearer.test.ts
@@ -11,7 +11,7 @@ describe("testAuthBearer operation integration tests", () => {
   it("should return 200 with valid Person when all required parameters are provided", async () => {
     // Arrange: Setup the Express route with the generated wrapper
     const handler: testAuthBearerHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         // Validate that required query parameters are present
         expect(params.value.query.qr).toBeDefined();
         expect(params.value.query.qr).toBe("test-required");
@@ -62,8 +62,8 @@ describe("testAuthBearer operation integration tests", () => {
 
     const handler: testAuthBearerHandler = async (params) => {
       if (
-        "success" in params &&
-        !params.success &&
+        "isValid" in params &&
+        !params.isValid &&
         params.kind === "query-error"
       ) {
         validationErrorReceived = true;
@@ -121,8 +121,8 @@ describe("testAuthBearer operation integration tests", () => {
 
     const handler: testAuthBearerHandler = async (params) => {
       if (
-        "success" in params &&
-        !params.success &&
+        "isValid" in params &&
+        !params.isValid &&
         params.kind === "query-error"
       ) {
         cursorValidationFailed = true;
@@ -178,7 +178,7 @@ describe("testAuthBearer operation integration tests", () => {
     // Arrange
     // Note: After fixing the bug, optional parameters are now properly optional
     const handler: testAuthBearerHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         // Only qr should be required according to OpenAPI spec
         expect(params.value.query.qr).toBe("required-only");
         // Optional parameters should be undefined when not provided

--- a/apps/craft/tests/integrations/server-generator/testAuthBearerHttp.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testAuthBearerHttp.test.ts
@@ -10,7 +10,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should return 503 with TestAuthBearerHttp503Response", async () => {
     // Arrange: Setup handler to return 503 status
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         expect(params.value.query.qr).toBe("test-503");
 
         return {
@@ -52,7 +52,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should return 504 with ProblemDetails (application/problem+json)", async () => {
     // Arrange: Setup handler to return 504 status with ProblemDetails
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         expect(params.value.query.qr).toBe("test-504");
 
         return {
@@ -99,8 +99,8 @@ describe("testAuthBearerHttp operation integration tests", () => {
 
     const handler: testAuthBearerHttpHandler = async (params) => {
       if (
-        "success" in params &&
-        !params.success &&
+        "isValid" in params &&
+        !params.isValid &&
         params.kind === "query-error"
       ) {
         validationErrorReceived = true;
@@ -156,7 +156,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should validate different content types properly", async () => {
     // Arrange: Test both content types work
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         const contentType = params.value.query.qr;
 
         if (contentType === "json") {

--- a/apps/craft/tests/integrations/server-generator/testMultiContentTypes.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testMultiContentTypes.test.ts
@@ -10,7 +10,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle JSON content type request and response", async () => {
     // Arrange: Handler that accepts JSON and returns JSON
     const handler: testMultiContentTypesHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         expect(params.value.body).toBeDefined();
         expect(params.value.body).toMatchObject({
           id: "test-123",
@@ -55,7 +55,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle custom JSON content type response", async () => {
     // Arrange: Handler that returns custom vnd JSON
     const handler: testMultiContentTypesHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         return {
           status: 200,
           contentType: "application/vnd.custom+json",
@@ -99,7 +99,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle form-urlencoded content type", async () => {
     // Arrange: Handler that accepts form data
     const handler: testMultiContentTypesHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         expect(params.value.body).toBeDefined();
         // Form-encoded data might be parsed differently
 
@@ -144,8 +144,8 @@ describe("testMultiContentTypes operation integration tests", () => {
 
     const handler: testMultiContentTypesHandler = async (params) => {
       if (
-        "success" in params &&
-        !params.success &&
+        "isValid" in params &&
+        !params.isValid &&
         params.kind === "body-error"
       ) {
         validationErrorReceived = true;
@@ -200,7 +200,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle unknown content types gracefully", async () => {
     // Arrange: Handler that accepts any content type
     const handler: testMultiContentTypesHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if ("isValid" in params && params.isValid) {
         // Should still receive the body even with unknown content type
         // Body might be undefined for unknown content types, which is acceptable
 
@@ -213,8 +213,8 @@ describe("testMultiContentTypes operation integration tests", () => {
           },
         };
       } else if (
-        "success" in params &&
-        !params.success &&
+        "isValid" in params &&
+        !params.isValid &&
         params.kind === "body-error"
       ) {
         // If there's a body validation error with unknown content type, that's also acceptable

--- a/apps/craft/tests/integrations/server-generator/testParameterWithDash.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testParameterWithDash.test.ts
@@ -13,7 +13,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
   it("should return 200 with all parameters correctly validated and passed", async () => {
     // Arrange: Setup handler to validate all parameter types
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.success) {
+      if (params.isValid) {
         // Validate path parameters
         expect(params.value.path["path-param"]).toBe("test-path-param");
 
@@ -65,7 +65,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let pathValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (!params.success) {
+      if (!params.isValid) {
         pathValidationFailed = true;
         // Check that path validation failed for minimum length
         const pathError = params.error.issues.find((issue) =>
@@ -122,7 +122,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let queryValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (!params.success) {
+      if (!params.isValid) {
         queryValidationFailed = true;
         // Check that request-id validation failed for minimum length
         const requestIdError = params.error.issues.find((issue) =>
@@ -179,7 +179,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let headerValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (!params.success) {
+      if (!params.isValid) {
         headerValidationFailed = true;
         // Check that header validation failed
         expect(params.error.issues.length).toBeGreaterThan(0);
@@ -231,7 +231,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     // (foo-bar -> fooBar, path-param -> pathParam, etc.)
     const handler: testParameterWithDashHandler = async (params) => {
       console.log(params);
-      if (params.success) {
+      if (params.isValid) {
         // The generated wrapper should transform kebab-case to camelCase
         expect(params.value.query).toHaveProperty("fooBar");
         expect(params.value.query).toHaveProperty("requestId");

--- a/apps/craft/tests/integrations/simple.test.ts
+++ b/apps/craft/tests/integrations/simple.test.ts
@@ -66,7 +66,7 @@ describe("Working Integration Test Demo", () => {
       },
     });
 
-    if ("success" in response && response.success) {
+    if ("isValid" in response && response.isValid) {
       // If it succeeds, verify response
       expect(response.status).toBe(201);
     } else if ("kind" in response) {
@@ -95,7 +95,7 @@ describe("Working Integration Test Demo", () => {
       body: formData,
     });
 
-    if ("success" in response && response.success) {
+    if ("isValid" in response && response.isValid) {
       expect(response.status).toBe(200);
     } else if ("kind" in response) {
       // Expected to fail with auth (401) or validation (400) error
@@ -114,7 +114,7 @@ describe("Working Integration Test Demo", () => {
     // Act - testBinaryFileDownload also requires global auth
     const response = await client.testBinaryFileDownload({});
 
-    if ("success" in response && response.success) {
+    if ("isValid" in response && response.isValid) {
       expect(response.status).toBe(200);
       expect(response.response.headers.get("content-type")).toContain(
         "application/octet-stream",
@@ -160,7 +160,7 @@ describe("Working Integration Test Demo", () => {
     // Should return an error object instead of throwing
     if ("kind" in result) {
       expect(result.kind).toBe("unexpected-response");
-      expect(result.success).toBe(false);
+      expect(result.isValid).toBe(false);
       expect(result.result.status).toBe(401);
       expect(result.error).toContain("Unexpected response status: 401");
       expect(result.result.data).toBeDefined();

--- a/apps/craft/tests/server-generator-comprehensive.test.ts
+++ b/apps/craft/tests/server-generator-comprehensive.test.ts
@@ -86,7 +86,7 @@ describe("server-generator comprehensive validation", () => {
     expect(result.wrapperCode).toContain("bodyParse.success");
 
     /* Verify success handler call */
-    expect(result.wrapperCode).toContain("success: true");
+    expect(result.wrapperCode).toContain("isValid: true");
     expect(result.wrapperCode).toContain("value: {");
     expect(result.wrapperCode).toContain("query: queryParse.data");
     expect(result.wrapperCode).toContain("path: pathParse.data");
@@ -136,7 +136,7 @@ describe("server-generator comprehensive validation", () => {
     /* Should include handler type with discriminated union */
     expect(result.wrapperCode).toContain("testOperationHandler");
     expect(result.wrapperCode).toContain(
-      "{ success: true; value: testOperationParsedParams }",
+      "{ isValid: true; value: testOperationParsedParams }",
     );
     expect(result.wrapperCode).toContain("testOperationValidationError");
   });

--- a/apps/craft/tests/server-generator-exact-match.test.ts
+++ b/apps/craft/tests/server-generator-exact-match.test.ts
@@ -76,21 +76,21 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify error handling with correct error types */
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "query-error", error: queryParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "query-error", error: queryParse\.error, isValid: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "path-error", error: pathParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "path-error", error: pathParse\.error, isValid: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "headers-error", error: headersParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "headers-error", error: headersParse\.error, isValid: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "body-error", error: bodyParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "body-error", error: bodyParse\.error, isValid: false \}\)/,
     );
 
     /* Verify success handler call with all parameters */
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{\s*success: true,\s*value: \{\s*query: queryParse\.data,\s*path: pathParse\.data,\s*headers: headersParse\.data,\s*body: parsedBody\s*\},?\s*\}\)/,
+      /return handler\(\{\s*isValid: true,\s*value: \{\s*query: queryParse\.data,\s*path: pathParse\.data,\s*headers: headersParse\.data,\s*body: parsedBody\s*\},?\s*\}\)/,
     );
 
     /* Verify discriminated union types are correctly defined */
@@ -108,7 +108,7 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify handler type includes both success and error cases */
     expect(result.wrapperCode).toMatch(
-      /petFindByStatusHandler = \(\s*params: \{ success: true; value: petFindByStatusParsedParams \} \| petFindByStatusValidationError,?\s*\) => Promise<petFindByStatusResponse>/,
+      /petFindByStatusHandler = \(\s*params: \{ isValid: true; value: petFindByStatusParsedParams \} \| petFindByStatusValidationError,?\s*\) => Promise<petFindByStatusResponse>/,
     );
   });
 

--- a/apps/craft/tests/server-generator.test.ts
+++ b/apps/craft/tests/server-generator.test.ts
@@ -50,7 +50,7 @@ describe("server-generator operation wrapper", () => {
     expect(result.wrapperCode).toContain('kind: "path-error"');
     expect(result.wrapperCode).toContain('kind: "headers-error"');
     expect(result.wrapperCode).toContain('kind: "body-error"');
-    expect(result.wrapperCode).toContain("success: true");
+    expect(result.wrapperCode).toContain("isValid: true");
   });
 
   it("should use strict validation for server input types (query, path, headers)", () => {


### PR DESCRIPTION
- Updated all instances of 'success' to 'isValid' in API response types and handling logic across the codebase.
- Modified related tests to reflect the change in response structure.
- Adjusted task command for removing generated tests to point to the correct directory.