### PR TITLE
Add buildFormData helper for multipart/form-data handling

### DIFF
--- a/apps/craft/src/client-generator/templates/request-body-templates.ts
+++ b/apps/craft/src/client-generator/templates/request-body-templates.ts
@@ -32,23 +32,9 @@ export const DEFAULT_CONTENT_TYPE_HANDLERS: ContentTypeHandlerConfig = {
     requiresFormData: false,
   },
   "multipart/form-data": {
-    bodyProcessing: `(() => {
-      const formData = new FormData();
-      if (body) {
-        Object.entries(body).forEach(([key, value]) => {
-          if (value !== undefined) {
-            if (value instanceof File || value instanceof Blob) {
-              formData.append(key, value);
-            } else if (typeof value === 'string') {
-              formData.append(key, value);
-            } else {
-              formData.append(key, JSON.stringify(value));
-            }
-          }
-        });
-      }
-      return formData;
-    })()`,
+    /* Use generated helper to build FormData; this avoids emitting
+     environment-dependent instanceof checks inline in generated files. */
+    bodyProcessing: "buildFormData(body)",
     contentTypeHeader: "",
     requiresFormData: true,
   },

--- a/apps/craft/src/core-generator/file-writer.ts
+++ b/apps/craft/src/core-generator/file-writer.ts
@@ -55,6 +55,11 @@ export function buildOperationImports(
     configImports.push("formUrlEncode");
   }
 
+  /* Add buildFormData helper import when multipart/form-data handling is used */
+  if (functionCode && functionCode.includes("buildFormData(")) {
+    configImports.push("buildFormData");
+  }
+
   /* RequestBody alias used by generated operation body typing */
   if (functionCode && functionCode.includes("RequestBody")) {
     configImports.push("RequestBody");


### PR DESCRIPTION
Introduce a helper function to streamline the creation of FormData from plain objects, enhancing the handling of multipart/form-data requests. Update relevant imports and templates to utilize this new helper, reducing redundancy and improving code maintainability.