### PR TITLE
Refactor file writers to remove Prettier formatting

### DIFF
--- a/apps/craft/src/core-generator/file-writer.ts
+++ b/apps/craft/src/core-generator/file-writer.ts
@@ -1,5 +1,4 @@
 import { promises as fs } from "fs";
-import { format } from "prettier";
 
 /**
  * Builds the complete operation file content with imports and function code
@@ -96,22 +95,14 @@ export async function ensureDirectory(dirPath: string): Promise<void> {
 }
 
 /**
- * Formats TypeScript code using Prettier
- */
-export async function formatTypeScript(code: string): Promise<string> {
-  return format(code, { parser: "typescript" });
-}
-
-/**
- * Writes formatted TypeScript content to a file
+ * Writes TypeScript content to a file
  */
 export async function writeFormattedFile(
   filePath: string,
   content: string,
 ): Promise<void> {
   try {
-    const formattedContent = await formatTypeScript(content);
-    await fs.writeFile(filePath, formattedContent);
+    await fs.writeFile(filePath, content);
   } catch (error) {
     throw new Error(`Failed to write file ${filePath}: ${error}`);
   }

--- a/apps/craft/src/schema-generator/file-generators.ts
+++ b/apps/craft/src/schema-generator/file-generators.ts
@@ -1,7 +1,5 @@
 import type { SchemaObject } from "openapi3-ts/oas31";
 
-import { format } from "prettier";
-
 import { zodSchemaToCode } from "./schema-converter.js";
 
 /**
@@ -96,12 +94,8 @@ export async function generateSchemaFile(
     content = `import { z } from 'zod';\n${importsSection}\n${schemaContent}\n${typeContent}`;
   }
 
-  const formattedContent = await format(content, {
-    parser: "typescript",
-  });
-
   return {
-    content: formattedContent,
+    content,
     fileName: `${name}.ts`,
   };
 }

--- a/apps/craft/src/server-generator/file-writer.ts
+++ b/apps/craft/src/server-generator/file-writer.ts
@@ -1,6 +1,5 @@
 import { promises as fs } from "fs";
 import path from "path";
-import prettier from "prettier";
 
 import type { OperationMetadata } from "../client-generator/operation-extractor.js";
 
@@ -41,15 +40,8 @@ ${operations
   .join("\n")}
 `;
 
-  const formatted = await prettier.format(indexContent, {
-    parser: "typescript",
-    semi: true,
-    singleQuote: false,
-    trailingComma: "all",
-  });
-
   const filePath = path.join(serverOperationsDir, "index.ts");
-  await fs.writeFile(filePath, formatted);
+  await fs.writeFile(filePath, indexContent);
 }
 
 /**
@@ -68,14 +60,6 @@ export async function writeServerOperationFile(
 
   const fullCode = imports ? `${imports}\n\n${wrapperCode}` : wrapperCode;
 
-  /* Format with Prettier */
-  const formatted = await prettier.format(fullCode, {
-    parser: "typescript",
-    semi: true,
-    singleQuote: false,
-    trailingComma: "all",
-  });
-
   const filePath = path.join(serverOperationsDir, `${operationId}.ts`);
-  await fs.writeFile(filePath, formatted);
+  await fs.writeFile(filePath, fullCode);
 }

--- a/apps/website/docs/cli-usage.md
+++ b/apps/website/docs/cli-usage.md
@@ -93,3 +93,19 @@ Each directory contains:
 
 The output directory will be created if it doesn't exist and existing files will
 be overwritten.
+
+## Formatting Generated Code
+
+For performance reasons, the CLI does not format the generated TypeScript files
+by default. To format them you may use [Biome](https://biomejs.dev/) running the
+following command in the output directory:
+
+```bash
+pnpx @biomejs/biome format --write .
+```
+
+Alternatively, you can use any other slower code formatter of your choice, e.g.
+
+```bash
+pnpx prettier --log-level=silent --write .
+```


### PR DESCRIPTION
Remove Prettier formatting from file writers for performance reasons and update documentation to guide users on formatting generated TypeScript files using alternative tools.