### PR TITLE
Fix response handling and add test for no body endpoint

### DIFF
--- a/apps/craft/src/client-generator/templates/function-body-templates.ts
+++ b/apps/craft/src/client-generator/templates/function-body-templates.ts
@@ -131,12 +131,9 @@ ${responseHandlers.join("\n")}
         defaultResponseHandler
           ? `
         /* Handle OpenAPI default response */
-${defaultResponseHandler}
-
-        /* Return error for truly unexpected status codes */`
+${defaultResponseHandler}`
           : `
-        /* Return error for unexpected status codes instead of throwing */`
-      }
+        /* Return error for unexpected status codes instead of throwing */
         return {
           kind: "unexpected-response",
           isValid: false,
@@ -146,7 +143,8 @@ ${defaultResponseHandler}
             response,
           },
           error: \`Unexpected response status: \${response.status}\`,
-        } as const;
+        } as const;`
+      }
       }
     }
   } catch (error) {

--- a/apps/craft/src/client-generator/templates/response-templates.ts
+++ b/apps/craft/src/client-generator/templates/response-templates.ts
@@ -48,6 +48,18 @@ export function renderDefaultResponseHandler(
           } satisfies ApiResponseWithParse<"default", typeof ${responseMapName}>;
           return manualResult as unknown as (TForceValidation extends true ? ApiResponseWithForcedParse<"default", typeof ${responseMapName}> : ApiResponseWithParse<"default", typeof ${responseMapName}>);
         }
+      } else {
+        /* Return error for unexpected status codes when no default response mapping exists */
+        return {
+          kind: "unexpected-response",
+          isValid: false,
+          result: {
+            data,
+            status: response.status,
+            response,
+          },
+          error: \`Unexpected response status: \${response.status}\`,
+        } as const;
       }`;
     } else {
       /* No schema or response map: return simple response for default */

--- a/apps/craft/tests/client-generator/function-body-templates.test.ts
+++ b/apps/craft/tests/client-generator/function-body-templates.test.ts
@@ -218,9 +218,10 @@ describe("function-body-templates", () => {
         "POST",
         true,
         ['    case "200": return { status: 200, data };'],
-        "finalHeaders['X-Custom'] = customHeader;",
-        "finalHeaders['Authorization'] = token;",
-        "url.searchParams.append('filter', filter);",
+        undefined, // no defaultResponseHandler
+        "    finalHeaders['X-Custom'] = customHeader;",
+        "    finalHeaders['Authorization'] = token;",
+        "    url.searchParams.append('filter', filter);",
       );
 
       expect(result).toContain(

--- a/apps/craft/tests/integrations/fixtures/test.yaml
+++ b/apps/craft/tests/integrations/fixtures/test.yaml
@@ -530,6 +530,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/DashedBodyTest"
 
+  /test-no-body:
+    get:
+      operationId: testNoBody
+      responses:
+        200:
+          description: Will send `Authenticated`
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+        default:
+          decription: Foo bar
+
 # -------------
 # Components
 # -------------

--- a/apps/craft/tests/integrations/fixtures/test.yaml
+++ b/apps/craft/tests/integrations/fixtures/test.yaml
@@ -541,7 +541,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Person"
         default:
-          decription: Foo bar
+          description: Foo bar
 
 # -------------
 # Components


### PR DESCRIPTION
Update response handling to manage unexpected status codes and introduce a test for an endpoint that does not return a body.