### PR TITLE
Update default forceValidation to true

### DIFF
--- a/apps/craft/CHANGELOG.md
+++ b/apps/craft/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @apical-ts/craft
 
+## 0.0.27
+
+### Patch Changes
+
+- Remove generated unreachable code
+
 ## 0.0.26
 
 ### Patch Changes

--- a/apps/craft/package.json
+++ b/apps/craft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/craft",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": false,
   "description": "Generates fully-typed Zod v4 schemas and type-safe TypeScript REST API clients and server from OpenAPI 2.0, 3.0.x, and 3.1.x specifications.",
   "main": "dist/index.js",

--- a/apps/craft/src/client-generator/templates/config-templates.ts
+++ b/apps/craft/src/client-generator/templates/config-templates.ts
@@ -234,7 +234,7 @@ export const globalConfig: GlobalConfig = {
   baseURL: '${server.defaultBaseURL}',
   fetch: fetch,
   headers: {},
-  forceValidation: false
+  forceValidation: true
 };
 
 /* A minimal, serializable representation of a fetch Response */

--- a/apps/craft/src/client-generator/templates/operation-templates.ts
+++ b/apps/craft/src/client-generator/templates/operation-templates.ts
@@ -91,7 +91,7 @@ export function buildGenericParams(
   const genericParts: string[] = [];
 
   /* Always include TForceValidation parameter for dynamic force validation */
-  genericParts.push("TForceValidation extends boolean = false");
+  genericParts.push("TForceValidation extends boolean = true");
 
   if (config.shouldGenerateRequestMap) {
     const defaultReq =

--- a/apps/craft/tests/client-generator/operation-templates.test.ts
+++ b/apps/craft/tests/client-generator/operation-templates.test.ts
@@ -34,7 +34,7 @@ describe("operation-templates", () => {
       const result = buildGenericParams(config);
 
       expect(result.genericParams).toBe(
-        "<TForceValidation extends boolean = false>",
+        "<TForceValidation extends boolean = true>",
       );
       expect(result.updatedReturnType).toBe("ApiResponse<200, User>");
     });
@@ -61,7 +61,7 @@ describe("operation-templates", () => {
       const result = buildGenericParams(config);
 
       expect(result.genericParams).toBe(
-        '<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json">',
+        '<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json">',
       );
       expect(result.updatedReturnType).toBe("ApiResponse<200, User>");
     });
@@ -88,7 +88,7 @@ describe("operation-templates", () => {
       const result = buildGenericParams(config);
 
       expect(result.genericParams).toBe(
-        '<TForceValidation extends boolean = false, TResponseContentType extends { [K in keyof TestResponseMap]: keyof TestResponseMap[K]; }[keyof TestResponseMap] = "application/json">',
+        '<TForceValidation extends boolean = true, TResponseContentType extends { [K in keyof TestResponseMap]: keyof TestResponseMap[K]; }[keyof TestResponseMap] = "application/json">',
       );
       expect(result.updatedReturnType).toBe("ApiResponse<200, User>");
     });
@@ -116,7 +116,7 @@ describe("operation-templates", () => {
       const result = buildGenericParams(config);
 
       expect(result.genericParams).toBe(
-        '<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json", TResponseContentType extends { [K in keyof TestResponseMap]: keyof TestResponseMap[K]; }[keyof TestResponseMap] = "application/xml">',
+        '<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json", TResponseContentType extends { [K in keyof TestResponseMap]: keyof TestResponseMap[K]; }[keyof TestResponseMap] = "application/xml">',
       );
       expect(result.updatedReturnType).toBe("ApiResponse<200, User>");
     });
@@ -142,7 +142,7 @@ describe("operation-templates", () => {
       const result = buildGenericParams(config);
 
       expect(result.genericParams).toBe(
-        '<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json", TResponseContentType extends { [K in keyof TestResponseMap]: keyof TestResponseMap[K]; }[keyof TestResponseMap] = "application/json">',
+        '<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json", TResponseContentType extends { [K in keyof TestResponseMap]: keyof TestResponseMap[K]; }[keyof TestResponseMap] = "application/json">',
       );
       expect(result.updatedReturnType).toBe("ApiResponse<200, User>");
     });
@@ -340,7 +340,7 @@ describe("operation-templates", () => {
         functionName: "testOperation",
         summary: "/** Test operation */\n",
         genericParams:
-          '<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json">',
+          '<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json">',
         parameterDeclaration:
           "{ body }: { body: TestRequestMap[TRequestContentType] }",
         parameterInterface: "{ body: TestRequestMap[TRequestContentType] }",
@@ -355,19 +355,19 @@ describe("operation-templates", () => {
       expect(result).toBe(
         "export type TestRequestMap = { 'application/json': User; };\n\n" +
           "/** Test operation */\n" +
-          'export function testOperation<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
+          'export function testOperation<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
           "  params: { body: TestRequestMap[TRequestContentType] },\n" +
           "  config: GlobalConfig & { forceValidation: true }\n" +
           "): Promise<ApiResponse<200, User>>;\n" +
-          'export function testOperation<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
+          'export function testOperation<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
           "  params: { body: TestRequestMap[TRequestContentType] },\n" +
           "  config: GlobalConfig & { forceValidation: false }\n" +
           "): Promise<ApiResponse<200, User>>;\n" +
-          'export function testOperation<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
+          'export function testOperation<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
           "  params: { body: TestRequestMap[TRequestContentType] },\n" +
           "  config?: GlobalConfig\n" +
           "): Promise<ApiResponse<200, User>>;\n" +
-          'export async function testOperation<TForceValidation extends boolean = false, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
+          'export async function testOperation<TForceValidation extends boolean = true, TRequestContentType extends keyof TestRequestMap = "application/json">(\n' +
           "  { body }: { body: TestRequestMap[TRequestContentType] },\n" +
           "  config: GlobalConfig = globalConfig\n" +
           "): Promise<ApiResponse<200, User>> {\n" +
@@ -380,7 +380,7 @@ describe("operation-templates", () => {
       const config: OperationFunctionRenderConfig = {
         functionName: "testOperation",
         summary: "",
-        genericParams: "<TForceValidation extends boolean = false>",
+        genericParams: "<TForceValidation extends boolean = true>",
         parameterDeclaration: "{}: {} = {}",
         parameterInterface: "{}",
         updatedReturnType: "ApiResponse<200, User>",
@@ -391,19 +391,19 @@ describe("operation-templates", () => {
       const result = renderOperationFunction(config);
 
       expect(result).toBe(
-        "export function testOperation<TForceValidation extends boolean = false>(\n" +
+        "export function testOperation<TForceValidation extends boolean = true>(\n" +
           "  params: {},\n" +
           "  config: GlobalConfig & { forceValidation: true }\n" +
           "): Promise<ApiResponse<200, User>>;\n" +
-          "export function testOperation<TForceValidation extends boolean = false>(\n" +
+          "export function testOperation<TForceValidation extends boolean = true>(\n" +
           "  params: {},\n" +
           "  config: GlobalConfig & { forceValidation: false }\n" +
           "): Promise<ApiResponse<200, User>>;\n" +
-          "export function testOperation<TForceValidation extends boolean = false>(\n" +
+          "export function testOperation<TForceValidation extends boolean = true>(\n" +
           "  params: {},\n" +
           "  config?: GlobalConfig\n" +
           "): Promise<ApiResponse<200, User>>;\n" +
-          "export async function testOperation<TForceValidation extends boolean = false>(\n" +
+          "export async function testOperation<TForceValidation extends boolean = true>(\n" +
           "  {}: {} = {},\n" +
           "  config: GlobalConfig = globalConfig\n" +
           "): Promise<ApiResponse<200, User>> {\n" +

--- a/apps/examples/client-examples/force-validation.ts
+++ b/apps/examples/client-examples/force-validation.ts
@@ -8,53 +8,56 @@ import { getInventory } from "../generated/client/getInventory.js";
 import { getPetById } from "../generated/client/getPetById.js";
 
 async function demonstrateClient() {
-  // Manual validation bound client
-  // default configuration forceValidation=false
-  const lazyPetsResponse = await findPetsByStatus({
-    query: { status: "available" },
-  });
-  if (lazyPetsResponse.isValid === true && lazyPetsResponse.status === 200) {
-    lazyPetsResponse.parse();
-  }
-
-  // Manual validation bound client
-  // using configureOperation with forceValidation=false
-  const lazyClient = configureOperations(
-    { findPetsByStatus, getInventory, getPetById },
-    { ...globalConfig, forceValidation: false },
-  );
-  const petsResponse1 = await lazyClient.findPetsByStatus({
-    query: { status: "available" },
-  });
-  if (petsResponse1.isValid === true && petsResponse1.status === 200) {
-    petsResponse1.parse();
-  }
-
   // Automatic validation bound client
-  // overridden per op configuration forceValidation=true
-  const greedyPetResponse = await findPetsByStatus(
-    {
-      query: { status: "available" },
-    },
-    { ...globalConfig, forceValidation: true },
-  );
-  if (greedyPetResponse.isValid === true && greedyPetResponse.status === 200) {
+  // default configuration forceValidation=true
+  const greedyPetsResponse = await findPetsByStatus({
+    query: { status: "available" },
+  });
+  if (
+    greedyPetsResponse.isValid === true &&
+    greedyPetsResponse.status === 200
+  ) {
     // automatic validation: .parsed available
-    greedyPetResponse.parsed[0].name;
+    greedyPetsResponse.parsed[0].name;
   }
 
   // Automatic validation bound client
-  // with configureOperation and forceValidation=true
+  // using configureOperation with forceValidation=true
   const greedyClient = configureOperations(
     { findPetsByStatus, getInventory, getPetById },
     { ...globalConfig, forceValidation: true },
   );
-  const petsResponse2 = await greedyClient.findPetsByStatus({
+  const petsResponse1 = await greedyClient.findPetsByStatus({
+    query: { status: "available" },
+  });
+  if (petsResponse1.isValid === true && petsResponse1.status === 200) {
+    // bound automatic validation: .parsed available
+    petsResponse1.parsed;
+  }
+
+  // Manual validation bound client
+  // overridden per op configuration forceValidation=false
+  const lazyPetResponse = await findPetsByStatus(
+    {
+      query: { status: "available" },
+    },
+    { ...globalConfig, forceValidation: false },
+  );
+  if (lazyPetResponse.isValid === true && lazyPetResponse.status === 200) {
+    lazyPetResponse.parse();
+  }
+
+  // Manual validation bound client
+  // with configureOperation and forceValidation=false
+  const lazyClient = configureOperations(
+    { findPetsByStatus, getInventory, getPetById },
+    { ...globalConfig, forceValidation: false },
+  );
+  const petsResponse2 = await lazyClient.findPetsByStatus({
     query: { status: "available" },
   });
   if (petsResponse2.isValid === true && petsResponse2.status === 200) {
-    // bound automatic validation: .parsed available
-    petsResponse2.parsed;
+    petsResponse2.parse();
   }
 }
 

--- a/apps/website/docs/client-generation/define-configuration.md
+++ b/apps/website/docs/client-generation/define-configuration.md
@@ -231,14 +231,15 @@ if needed.
 
 **Type**: `boolean`  
 **Required**: No  
-**Default**: `false`
+**Default**: `true`
 
-When `true`, forces validation of response data even when the operation would
-normally skip it. This is useful for:
+When `false `, skips validation of response data even when the operation would
+normally validate it. This is useful for:
 
-- Development environments where you want strict validation
-- Testing scenarios where you need to ensure response correctness
-- APIs that might return unexpected data structures
+- Production environments where performance is critical and you trust the API to
+  return correct data
+- APIs with inconsistent response structures where strict validation may cause
+  issues
 
 ```typescript
 const config = {

--- a/apps/website/docs/client-generation/response-handling.md
+++ b/apps/website/docs/client-generation/response-handling.md
@@ -4,9 +4,9 @@ Each operation returns a discriminated union: either a successful API response
 (`success: true` with a `status` code) or an error object (`success: false`)
 with a `kind` discriminator.
 
-Validation is opt-in by default (success responses expose a `parse()` method).
-You can enable automatic validation at runtime by providing
-`forceValidation: true` in the configuration you pass to an operation or via
+Validation is opt-out by default (success responses expose a `parsed` field).
+You can disable automatic validation at runtime by providing
+`forceValidation: false` in the configuration you pass to an operation or via
 `configureOperations`.
 
 ## Recommended Pattern
@@ -36,7 +36,7 @@ When an operation succeeds, the response object includes:
 - **`data`**: The raw response payload from the server
 - **`parse()`**: Method to validate and parse the response (when
   `forceValidation: false`)
-- **`parsed`**: Pre-validated data (when `forceValidation: true`)
+- **`parsed`**: Pre-validated data (when `forceValidation: true` - default)
 
 ### Error Responses
 

--- a/apps/website/docs/supported-features.md
+++ b/apps/website/docs/supported-features.md
@@ -29,9 +29,8 @@ experience.
 - 🛠️ **Operation-based client generation**: Generates one function per
   operation, with strong typing and per-operation configuration—no need for
   blacklisting operations you don't need!
-- 🛡️ **Zod v4 runtime validation (opt-in or automatic)**: Invoke
-  `response.parse()` manually, or enable `forceValidation: true` at runtime for
-  automatic validation
+- 🛡️ **Zod v4 runtime validation (automatic or manual)**: Get parsed responses
+  automatically or call `response.parse()` as needed
 - 📦 **Small footprint**: Generates each operation and schema/type in its own
   file for maximum tree-shaking and modularity
 - 🚀 **Fast code generation**: Optimized for quick generation times, even with

--- a/test-validation-default.js
+++ b/test-validation-default.js
@@ -1,0 +1,39 @@
+// Quick test to verify the default validation behavior has changed
+console.log("Testing default forceValidation behavior...");
+
+// Read the generated config file
+const fs = require("fs");
+const configPath = "./apps/examples/generated/client/config.ts";
+
+if (fs.existsSync(configPath)) {
+  const content = fs.readFileSync(configPath, "utf8");
+
+  // Check if the default is now true
+  if (content.includes("forceValidation: true")) {
+    console.log("✅ SUCCESS: Default forceValidation is now true");
+  } else if (content.includes("forceValidation: false")) {
+    console.log("❌ FAIL: Default forceValidation is still false");
+  } else {
+    console.log("❓ UNKNOWN: Could not find forceValidation setting");
+  }
+
+  // Check if function signatures use the new default
+  const findPetsPath = "./apps/examples/generated/client/findPetsByStatus.ts";
+  if (fs.existsSync(findPetsPath)) {
+    const functionContent = fs.readFileSync(findPetsPath, "utf8");
+
+    if (functionContent.includes("TForceValidation extends boolean = true")) {
+      console.log("✅ SUCCESS: Function signatures now default to true");
+    } else if (
+      functionContent.includes("TForceValidation extends boolean = false")
+    ) {
+      console.log("❌ FAIL: Function signatures still default to false");
+    } else {
+      console.log(
+        "❓ UNKNOWN: Could not find TForceValidation in function signature"
+      );
+    }
+  }
+} else {
+  console.log("❌ FAIL: Generated config file not found");
+}


### PR DESCRIPTION
Change the default behavior of forceValidation to true, enhancing validation consistency across the application. Update documentation and examples to reflect this change. Remove unreachable code and increment the version number accordingly.