### PR TITLE
Enhance response handling with OpenAPI document support

### DIFF
--- a/apps/craft/src/client-generator/models/response-models.ts
+++ b/apps/craft/src/client-generator/models/response-models.ts
@@ -1,6 +1,6 @@
 /* Response analysis data structures and models */
 
-import type { OperationObject } from "openapi3-ts/oas31";
+import type { OpenAPIObject, OperationObject } from "openapi3-ts/oas31";
 
 /*
  * Information about content type detection for a response
@@ -49,6 +49,8 @@ export interface ResponseAnalysis {
 export interface ResponseAnalysisConfig {
   /* Whether the operation has a response content type map */
   hasResponseContentTypeMap?: boolean;
+  /* OpenAPI document for resolving component responses */
+  openApiDoc?: OpenAPIObject;
   /* The operation being analyzed */
   operation: OperationObject;
   /* Response map name to use for union type generation */

--- a/apps/craft/src/client-generator/models/response-models.ts
+++ b/apps/craft/src/client-generator/models/response-models.ts
@@ -63,8 +63,6 @@ export interface ResponseAnalysisConfig {
  * Information about a single response type for analysis
  */
 export interface ResponseInfo {
-  /* Content type for this response */
-  contentType: null | string;
   /* Whether this response has schema content */
   hasSchema: boolean;
   /* Parsing strategy for this response */

--- a/apps/craft/src/client-generator/operation-extractor.ts
+++ b/apps/craft/src/client-generator/operation-extractor.ts
@@ -9,6 +9,7 @@ import type {
 } from "openapi3-ts/oas31";
 
 import assert from "assert";
+import { isReferenceObject } from "openapi3-ts/oas31";
 
 /**
  * Content type mapping with schema information
@@ -121,6 +122,7 @@ export function extractRequestContentTypes(
  */
 export function extractResponseContentTypes(
   operation: OperationObject,
+  openApiDoc?: OpenAPIObject,
 ): ResponseContentTypes[] {
   const responseContentTypes: ResponseContentTypes[] = [];
 
@@ -128,18 +130,49 @@ export function extractResponseContentTypes(
     for (const [statusCode, response] of Object.entries(operation.responses)) {
       if (statusCode === "default") continue;
 
-      const responseObj = response as ResponseObject;
       const contentTypes: ContentTypeMapping[] = [];
 
-      if (responseObj.content) {
-        for (const [contentType, mediaType] of Object.entries(
-          responseObj.content,
-        )) {
-          if (mediaType.schema) {
-            contentTypes.push({
-              contentType,
-              schema: mediaType.schema,
-            });
+      // Handle $ref responses (components/responses)
+      if (isReferenceObject(response)) {
+        // Extract component response reference
+        const ref = response.$ref;
+        if (
+          ref.startsWith("#/components/responses/") &&
+          openApiDoc?.components?.responses
+        ) {
+          const responseName = ref.split("/").pop();
+          if (responseName) {
+            const componentResponse =
+              openApiDoc.components.responses[responseName];
+            if (componentResponse && !isReferenceObject(componentResponse)) {
+              // Extract content types from the resolved component response
+              if (componentResponse.content) {
+                for (const [contentType, mediaType] of Object.entries(
+                  componentResponse.content,
+                )) {
+                  if (mediaType.schema) {
+                    contentTypes.push({
+                      contentType,
+                      schema: mediaType.schema,
+                    });
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        const responseObj = response as ResponseObject;
+        if (responseObj.content) {
+          for (const [contentType, mediaType] of Object.entries(
+            responseObj.content,
+          )) {
+            if (mediaType.schema) {
+              contentTypes.push({
+                contentType,
+                schema: mediaType.schema,
+              });
+            }
           }
         }
       }

--- a/apps/craft/src/client-generator/operation-function-generator.ts
+++ b/apps/craft/src/client-generator/operation-function-generator.ts
@@ -79,6 +79,7 @@ export function extractOperationMetadata(
     functionName,
     typeImports,
     operationName,
+    doc,
   );
 
   /* Build parameter shapes */
@@ -101,6 +102,7 @@ export function extractOperationMetadata(
     typeImports,
     bodyInfo.shouldExportResponseMap,
     bodyInfo.shouldExportResponseMap ? bodyInfo.responseMapTypeName : undefined,
+    doc,
   );
 
   /* Security overrides/auth headers */
@@ -281,6 +283,7 @@ function collectBodyAndContentTypes(
   functionName: string,
   typeImports: Set<string>,
   operationName: string,
+  doc: OpenAPIObject,
 ) {
   let bodyTypeInfo: ReturnType<typeof resolveRequestBodyType> | undefined;
   let requestContentType: string | undefined;
@@ -295,7 +298,7 @@ function collectBodyAndContentTypes(
   const requestMapTypeName = `${operationName}RequestMap`;
   const responseMapTypeName = `${operationName}ResponseMap`;
 
-  const contentTypeMaps = generateContentTypeMaps(operation);
+  const contentTypeMaps = generateContentTypeMaps(operation, doc);
   contentTypeMaps.typeImports.forEach((imp) => typeImports.add(imp));
 
   let requestContentTypes: string[] = [];

--- a/apps/craft/src/client-generator/response-analysis.ts
+++ b/apps/craft/src/client-generator/response-analysis.ts
@@ -1,6 +1,10 @@
 /* Pure analysis functions for response processing */
 
-import type { OperationObject, ResponseObject } from "openapi3-ts/oas31";
+import type {
+  OpenAPIObject,
+  OperationObject,
+  ResponseObject,
+} from "openapi3-ts/oas31";
 
 import assert from "assert";
 import { isReferenceObject } from "openapi3-ts/oas31";
@@ -14,6 +18,7 @@ import type {
 } from "./models/response-models.js";
 
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
+import { extractResponseContentTypes } from "./operation-extractor.js";
 import { getResponseContentType } from "./utils.js";
 
 // Interfaces (alphabetical keys inside)
@@ -53,6 +58,7 @@ export function analyzeResponseStructure(
 ): ResponseAnalysis {
   const {
     hasResponseContentTypeMap = false,
+    openApiDoc,
     operation,
     responseMapName,
     typeImports,
@@ -62,6 +68,7 @@ export function analyzeResponseStructure(
     operation,
     typeImports,
     hasResponseContentTypeMap,
+    openApiDoc,
   );
 
   // Derive response map name for union types
@@ -241,6 +248,7 @@ function collectResponses(
   operation: OperationObject,
   typeImports: Set<string>,
   hasResponseContentTypeMap: boolean,
+  openApiDoc?: OpenAPIObject,
 ) {
   const responses: ResponseInfo[] = [];
   let defaultResponseInfo: ResponseInfo | undefined;
@@ -249,24 +257,65 @@ function collectResponses(
     return { defaultResponseInfo, responses };
   }
 
-  const responseCodes = Object.keys(operation.responses).filter(
-    (code) => code !== "default",
+  // Use extractResponseContentTypes to get resolved response content types
+  const responseContentTypes = extractResponseContentTypes(
+    operation,
+    openApiDoc,
   );
-  responseCodes.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
 
-  for (const code of responseCodes) {
-    const response = operation.responses[code] as ResponseObject;
-    responses.push(
-      buildResponseTypeInfo(
-        code,
-        response,
-        operation,
-        typeImports,
+  // Convert the extracted content types to ResponseInfo objects
+  for (const responseGroup of responseContentTypes) {
+    const statusCode = responseGroup.statusCode;
+    const contentTypes = responseGroup.contentTypes;
+
+    if (contentTypes.length > 0) {
+      // For now, take the first content type (usually application/json)
+      const firstContentType = contentTypes[0];
+      const contentType = firstContentType.contentType;
+      const schema = firstContentType.schema;
+
+      let typeName: null | string = null;
+      let hasSchema = false;
+
+      if (schema) {
+        hasSchema = true;
+        typeName = resolveResponseTypeName(
+          schema,
+          operation,
+          statusCode,
+          typeImports,
+        );
+      }
+
+      const contentTypeAnalysis: ContentTypeAnalysis = {
+        allContentTypes: contentTypes.map((ct) => ct.contentType),
+        hasJsonLike: contentTypes.some((ct) => ct.contentType.includes("json")),
+        hasMixedContentTypes: false, // Will be set below
+        hasNonJson: contentTypes.some((ct) => !ct.contentType.includes("json")),
+      };
+      contentTypeAnalysis.hasMixedContentTypes =
+        contentTypeAnalysis.hasJsonLike && contentTypeAnalysis.hasNonJson;
+
+      const parsingStrategy = determineParsingStrategy(
+        contentType,
+        hasSchema,
+        contentTypeAnalysis,
         hasResponseContentTypeMap,
-      ),
-    );
+      );
+
+      const responseInfo: ResponseInfo = {
+        contentType,
+        hasSchema,
+        parsingStrategy,
+        statusCode,
+        typeName,
+      };
+
+      responses.push(responseInfo);
+    }
   }
 
+  // Handle default response if present (not handled by extractResponseContentTypes)
   if (operation.responses.default) {
     const response = operation.responses.default as ResponseObject;
     defaultResponseInfo = buildResponseTypeInfo(

--- a/apps/craft/src/client-generator/response-analysis.ts
+++ b/apps/craft/src/client-generator/response-analysis.ts
@@ -1,10 +1,6 @@
 /* Pure analysis functions for response processing */
 
-import type {
-  OpenAPIObject,
-  OperationObject,
-  ResponseObject,
-} from "openapi3-ts/oas31";
+import type { OperationObject, ResponseObject } from "openapi3-ts/oas31";
 
 import assert from "assert";
 import { isReferenceObject } from "openapi3-ts/oas31";
@@ -18,7 +14,6 @@ import type {
 } from "./models/response-models.js";
 
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
-import { extractResponseContentTypes } from "./operation-extractor.js";
 import { getResponseContentType } from "./utils.js";
 
 // Interfaces (alphabetical keys inside)
@@ -58,7 +53,6 @@ export function analyzeResponseStructure(
 ): ResponseAnalysis {
   const {
     hasResponseContentTypeMap = false,
-    openApiDoc,
     operation,
     responseMapName,
     typeImports,
@@ -68,7 +62,6 @@ export function analyzeResponseStructure(
     operation,
     typeImports,
     hasResponseContentTypeMap,
-    openApiDoc,
   );
 
   // Derive response map name for union types
@@ -105,31 +98,40 @@ export function buildResponseTypeInfo(
   typeImports: Set<string>,
   hasResponseContentTypeMap: boolean,
 ): ResponseInfo {
-  const contentType = getResponseContentType(response);
   const contentTypeAnalysis = analyzeContentTypes(response);
 
   let typeName: null | string = null;
   let hasSchema = false;
 
-  if (contentType && response.content?.[contentType]?.schema) {
-    hasSchema = true;
-    typeName = resolveResponseTypeName(
-      response.content[contentType].schema,
-      operation,
-      statusCode,
-      typeImports,
-    );
+  /* Check if ANY content type has a schema */
+  if (response.content) {
+    for (const [, mediaType] of Object.entries(response.content)) {
+      if (mediaType.schema) {
+        hasSchema = true;
+        if (!typeName) {
+          /* Use the first schema we find for type name resolution */
+          typeName = resolveResponseTypeName(
+            mediaType.schema,
+            operation,
+            statusCode,
+            typeImports,
+          );
+        }
+      }
+    }
   }
 
+  /* Use getResponseContentType for display purposes only - doesn't affect hasSchema logic */
+  const displayContentType = getResponseContentType(response);
+
   const parsingStrategy = determineParsingStrategy(
-    contentType || "",
+    displayContentType || "",
     hasSchema,
     contentTypeAnalysis,
     hasResponseContentTypeMap,
   );
 
   return {
-    contentType,
     hasSchema,
     parsingStrategy,
     statusCode,
@@ -200,7 +202,7 @@ function buildUnionTypes({
   const unionTypes: string[] = [];
   const mapName = responseMapName;
   const pushStandard = (info: ResponseInfo) => {
-    const dataType = info.contentType ? "unknown" : "void";
+    const dataType = info.hasSchema ? "unknown" : "void";
     const statusLiteral =
       info.statusCode === "default" ? '"default"' : info.statusCode;
     unionTypes.push(`ApiResponse<${statusLiteral}, ${dataType}>`);
@@ -248,7 +250,6 @@ function collectResponses(
   operation: OperationObject,
   typeImports: Set<string>,
   hasResponseContentTypeMap: boolean,
-  openApiDoc?: OpenAPIObject,
 ) {
   const responses: ResponseInfo[] = [];
   let defaultResponseInfo: ResponseInfo | undefined;
@@ -257,65 +258,28 @@ function collectResponses(
     return { defaultResponseInfo, responses };
   }
 
-  // Use extractResponseContentTypes to get resolved response content types
-  const responseContentTypes = extractResponseContentTypes(
-    operation,
-    openApiDoc,
+  /* Process all response status codes, not just those with content types */
+  const responseCodes = Object.keys(operation.responses).filter(
+    (code) => code !== "default",
   );
+  responseCodes.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
 
-  // Convert the extracted content types to ResponseInfo objects
-  for (const responseGroup of responseContentTypes) {
-    const statusCode = responseGroup.statusCode;
-    const contentTypes = responseGroup.contentTypes;
+  for (const code of responseCodes) {
+    const response = operation.responses[code] as ResponseObject;
 
-    if (contentTypes.length > 0) {
-      // For now, take the first content type (usually application/json)
-      const firstContentType = contentTypes[0];
-      const contentType = firstContentType.contentType;
-      const schema = firstContentType.schema;
+    /* Use buildResponseTypeInfo for consistent handling of all responses */
+    const responseInfo = buildResponseTypeInfo(
+      code,
+      response,
+      operation,
+      typeImports,
+      hasResponseContentTypeMap,
+    );
 
-      let typeName: null | string = null;
-      let hasSchema = false;
-
-      if (schema) {
-        hasSchema = true;
-        typeName = resolveResponseTypeName(
-          schema,
-          operation,
-          statusCode,
-          typeImports,
-        );
-      }
-
-      const contentTypeAnalysis: ContentTypeAnalysis = {
-        allContentTypes: contentTypes.map((ct) => ct.contentType),
-        hasJsonLike: contentTypes.some((ct) => ct.contentType.includes("json")),
-        hasMixedContentTypes: false, // Will be set below
-        hasNonJson: contentTypes.some((ct) => !ct.contentType.includes("json")),
-      };
-      contentTypeAnalysis.hasMixedContentTypes =
-        contentTypeAnalysis.hasJsonLike && contentTypeAnalysis.hasNonJson;
-
-      const parsingStrategy = determineParsingStrategy(
-        contentType,
-        hasSchema,
-        contentTypeAnalysis,
-        hasResponseContentTypeMap,
-      );
-
-      const responseInfo: ResponseInfo = {
-        contentType,
-        hasSchema,
-        parsingStrategy,
-        statusCode,
-        typeName,
-      };
-
-      responses.push(responseInfo);
-    }
+    responses.push(responseInfo);
   }
 
-  // Handle default response if present (not handled by extractResponseContentTypes)
+  // Handle default response if present
   if (operation.responses.default) {
     const response = operation.responses.default as ResponseObject;
     defaultResponseInfo = buildResponseTypeInfo(

--- a/apps/craft/src/client-generator/responses.ts
+++ b/apps/craft/src/client-generator/responses.ts
@@ -1,4 +1,4 @@
-import type { OperationObject } from "openapi3-ts/oas31";
+import type { OpenAPIObject, OperationObject } from "openapi3-ts/oas31";
 
 import assert from "assert";
 
@@ -49,6 +49,7 @@ export interface ResponseTypeInfo {
  */
 export function generateContentTypeMaps(
   operation: OperationObject,
+  doc?: OpenAPIObject,
 ): ContentTypeMaps {
   assert(operation.operationId, "Operation ID is required");
   const typeImports = new Set<string>();
@@ -63,6 +64,7 @@ export function generateContentTypeMaps(
     operation,
     operationId,
     typeImports,
+    doc,
   );
 
   return {
@@ -85,10 +87,12 @@ export function generateResponseHandlers(
   typeImports: Set<string>,
   hasResponseContentTypeMap = false,
   responseMapName?: string,
+  openApiDoc?: OpenAPIObject,
 ): ResponseHandlerResult {
   /* Analyze the response structure */
   const analysis = analyzeResponseStructure({
     hasResponseContentTypeMap,
+    openApiDoc,
     operation,
     responseMapName,
     typeImports,
@@ -147,9 +151,16 @@ function buildResponseContentTypeMap(
   operation: OperationObject,
   operationId: string,
   typeImports: Set<string>,
+  doc?: OpenAPIObject,
 ) {
   /* Use shared response mapping logic with correct structure */
-  const result = generateResponseMap(operation, operationId, typeImports);
+  const result = generateResponseMap(
+    operation,
+    operationId,
+    typeImports,
+    doc,
+    {},
+  );
 
   /* Merge type imports */
   result.typeImports.forEach((imp) => typeImports.add(imp));

--- a/apps/craft/src/client-generator/templates/response-templates.ts
+++ b/apps/craft/src/client-generator/templates/response-templates.ts
@@ -12,9 +12,9 @@ export function renderDefaultResponseHandler(
   defaultResponseInfo: ResponseInfo,
   responseMapName?: string,
 ): string {
-  const { contentType, typeName } = defaultResponseInfo;
+  const { typeName } = defaultResponseInfo;
 
-  if (typeName || contentType) {
+  if (defaultResponseInfo.hasSchema || typeName) {
     /* Use string-literal indexing for the default response */
     if (defaultResponseInfo.hasSchema && responseMapName) {
       /* Generate dynamic validation logic for default response */
@@ -79,7 +79,7 @@ export function renderResponseHandler(
   responseInfo: ResponseInfo,
   responseMapName?: string,
 ): string {
-  const { contentType, statusCode, typeName } = responseInfo;
+  const { statusCode, typeName } = responseInfo;
 
   // OpenAPI default responses are handled with a special case that excludes expected status codes
   // We'll generate them in a special way later in the function body template
@@ -87,7 +87,7 @@ export function renderResponseHandler(
     return ""; // Default responses are handled separately
   }
 
-  if (typeName || contentType) {
+  if (responseInfo.hasSchema || typeName) {
     /* Use string-literal indexing for numeric HTTP status codes to preserve literal key types */
     if (responseInfo.hasSchema && responseMapName) {
       /* Always generate dynamic validation logic (forceValidation flag removed) */

--- a/apps/craft/src/server-generator/operation-wrapper-generator.ts
+++ b/apps/craft/src/server-generator/operation-wrapper-generator.ts
@@ -138,7 +138,7 @@ export function generateServerOperationWrapper(
     : "";
 
   /* Build response map */
-  const responseMapCode = buildServerResponseMap(metadata, typeImports);
+  const responseMapCode = buildServerResponseMap(metadata, typeImports, doc);
 
   /* Render the complete wrapper function */
   const wrapperCode = renderServerOperationWrapper({

--- a/apps/craft/src/server-generator/templates/server-operation-templates.ts
+++ b/apps/craft/src/server-generator/templates/server-operation-templates.ts
@@ -1,3 +1,5 @@
+import type { OpenAPIObject } from "openapi3-ts/oas31";
+
 import type { ParameterGroups } from "../../client-generator/models/parameter-models.js";
 import type { ServerOperationMetadata } from "../operation-wrapper-generator.js";
 
@@ -55,6 +57,7 @@ export type ${mapName} = typeof ${mapName};`;
 export function buildServerResponseMap(
   metadata: ServerOperationMetadata,
   typeImports: Set<string>,
+  doc?: OpenAPIObject,
 ): string {
   /* Generate response union type using existing logic */
   const unionResult = generateResponseUnion(
@@ -62,6 +65,7 @@ export function buildServerResponseMap(
     metadata.operationId,
     typeImports,
     { useStrictSchemas: true }, // Use strict schemas for server responses
+    doc,
   );
 
   /* Generate response map using shared logic */
@@ -69,6 +73,7 @@ export function buildServerResponseMap(
     metadata.operation,
     metadata.operationId,
     typeImports,
+    doc,
     { useStrictSchemas: true }, // Use strict schemas for server responses
   );
 

--- a/apps/craft/src/shared/response-maps.ts
+++ b/apps/craft/src/shared/response-maps.ts
@@ -1,6 +1,10 @@
 /* Shared response mapping logic with correct structure */
 
-import { isReferenceObject, type OperationObject } from "openapi3-ts/oas31";
+import {
+  isReferenceObject,
+  type OpenAPIObject,
+  type OperationObject,
+} from "openapi3-ts/oas31";
 
 import { extractResponseContentTypes } from "../client-generator/operation-extractor.js";
 import {
@@ -45,6 +49,7 @@ export function generateResponseMap(
   operation: OperationObject,
   operationId: string,
   typeImports: Set<string>,
+  openApiDoc?: OpenAPIObject,
   options: ResponseMapOptions = {},
 ): ResponseMapResult {
   let defaultContentType: null | string = null;
@@ -54,7 +59,10 @@ export function generateResponseMap(
   const statusCodes: string[] = [];
   const allContentTypes = new Set<string>();
 
-  const responseContentTypes = extractResponseContentTypes(operation);
+  const responseContentTypes = extractResponseContentTypes(
+    operation,
+    openApiDoc,
+  );
   if (responseContentTypes.length === 0) {
     return {
       contentTypeCount,

--- a/apps/craft/src/shared/response-union-generator.ts
+++ b/apps/craft/src/shared/response-union-generator.ts
@@ -1,6 +1,6 @@
 /* Shared response union generation logic */
 
-import type { OperationObject } from "openapi3-ts/oas31";
+import type { OpenAPIObject, OperationObject } from "openapi3-ts/oas31";
 
 import { extractResponseContentTypes } from "../client-generator/operation-extractor.js";
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
@@ -45,6 +45,7 @@ export function generateResponseUnion(
   operationId: string,
   typeImports: Set<string>,
   options: ResponseUnionOptions = {},
+  openApiDoc?: OpenAPIObject,
 ): ResponseUnionResult {
   const unionMembers: ResponseUnionMember[] = [];
   const responseTypeName = `${sanitizeIdentifier(operationId)}Response`;
@@ -63,7 +64,10 @@ export function generateResponseUnion(
     allStatusCodes.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
 
     /* Extract responses that have content/schema */
-    const responseContentTypes = extractResponseContentTypes(operation);
+    const responseContentTypes = extractResponseContentTypes(
+      operation,
+      openApiDoc,
+    );
     const statusCodesWithContent = new Set(
       responseContentTypes.map((r) => r.statusCode),
     );

--- a/apps/craft/tests/client-generator/response-analysis.test.ts
+++ b/apps/craft/tests/client-generator/response-analysis.test.ts
@@ -183,7 +183,6 @@ describe("response-analysis", () => {
 
       expect(result.statusCode).toBe("200");
       expect(result.typeName).toBe("User");
-      expect(result.contentType).toBe("application/json");
       expect(result.hasSchema).toBe(true);
       expect(result.parsingStrategy.useValidation).toBe(true);
       expect(result.parsingStrategy.isJsonLike).toBe(true);
@@ -219,7 +218,6 @@ describe("response-analysis", () => {
 
       expect(result.statusCode).toBe("201");
       expect(result.typeName).toBe("CreateUser201Response");
-      expect(result.contentType).toBe("application/json");
       expect(result.hasSchema).toBe(true);
       expect(typeImports.has("CreateUser201Response")).toBe(true);
     });
@@ -245,9 +243,99 @@ describe("response-analysis", () => {
 
       expect(result.statusCode).toBe("204");
       expect(result.typeName).toBeNull();
-      expect(result.contentType).toBeNull();
       expect(result.hasSchema).toBe(false);
       expect(result.parsingStrategy.useValidation).toBe(false);
+    });
+
+    it("should detect schema in any content type, not just the first", () => {
+      const response: ResponseObject = {
+        description: "Success",
+        content: {
+          "text/plain": {}, // No schema
+          "application/json": {
+            schema: { $ref: "#/components/schemas/User" },
+          },
+        },
+      };
+
+      const operation: OperationObject = {
+        operationId: "getUser",
+        responses: { "200": response },
+      };
+
+      const typeImports = new Set<string>();
+      const result = buildResponseTypeInfo(
+        "200",
+        response,
+        operation,
+        typeImports,
+        false,
+      );
+
+      expect(result.statusCode).toBe("200");
+      expect(result.hasSchema).toBe(true);
+      expect(result.typeName).toBe("User");
+      expect(typeImports.has("User")).toBe(true);
+    });
+
+    it("should use schema from non-JSON content type if JSON has no schema", () => {
+      const response: ResponseObject = {
+        description: "Success",
+        content: {
+          "application/json": {}, // No schema
+          "text/xml": {
+            schema: { type: "string" },
+          },
+        },
+      };
+
+      const operation: OperationObject = {
+        operationId: "getData",
+        responses: { "200": response },
+      };
+
+      const typeImports = new Set<string>();
+      const result = buildResponseTypeInfo(
+        "200",
+        response,
+        operation,
+        typeImports,
+        false,
+      );
+
+      expect(result.statusCode).toBe("200");
+      expect(result.hasSchema).toBe(true);
+      expect(result.typeName).toBe("GetData200Response");
+      expect(typeImports.has("GetData200Response")).toBe(true);
+    });
+
+    it("should handle multiple content types all without schemas", () => {
+      const response: ResponseObject = {
+        description: "Success",
+        content: {
+          "application/json": {}, // No schema
+          "text/plain": {}, // No schema
+          "text/xml": {}, // No schema
+        },
+      };
+
+      const operation: OperationObject = {
+        operationId: "getData",
+        responses: { "200": response },
+      };
+
+      const typeImports = new Set<string>();
+      const result = buildResponseTypeInfo(
+        "200",
+        response,
+        operation,
+        typeImports,
+        false,
+      );
+
+      expect(result.statusCode).toBe("200");
+      expect(result.hasSchema).toBe(false);
+      expect(result.typeName).toBeNull();
     });
   });
 


### PR DESCRIPTION
Add support for extracting content types from OpenAPI documents, improving response handling by allowing the resolution of component responses. This change enhances the overall response mapping and content type generation processes.