### PR TITLE
Fix response schema handling for OpenAPI response references (client and server)

### DIFF
--- a/apps/craft/src/client-generator/models/response-models.ts
+++ b/apps/craft/src/client-generator/models/response-models.ts
@@ -1,6 +1,6 @@
 /* Response analysis data structures and models */
 
-import type { OperationObject } from "openapi3-ts/oas31";
+import type { OpenAPIObject, OperationObject } from "openapi3-ts/oas31";
 
 /*
  * Information about content type detection for a response
@@ -47,6 +47,8 @@ export interface ResponseAnalysis {
  * Configuration for analyzing responses
  */
 export interface ResponseAnalysisConfig {
+  /* OpenAPI document for resolving response references */
+  doc?: OpenAPIObject;
   /* Whether the operation has a response content type map */
   hasResponseContentTypeMap?: boolean;
   /* The operation being analyzed */

--- a/apps/craft/src/client-generator/operation-extractor.ts
+++ b/apps/craft/src/client-generator/operation-extractor.ts
@@ -4,11 +4,12 @@ import type {
   ParameterObject,
   ReferenceObject,
   RequestBodyObject,
-  ResponseObject,
   SchemaObject,
 } from "openapi3-ts/oas31";
 
 import assert from "assert";
+
+import { resolveResponse } from "./utils.js";
 
 /**
  * Content type mapping with schema information
@@ -121,6 +122,7 @@ export function extractRequestContentTypes(
  */
 export function extractResponseContentTypes(
   operation: OperationObject,
+  doc?: OpenAPIObject,
 ): ResponseContentTypes[] {
   const responseContentTypes: ResponseContentTypes[] = [];
 
@@ -128,7 +130,9 @@ export function extractResponseContentTypes(
     for (const [statusCode, response] of Object.entries(operation.responses)) {
       if (statusCode === "default") continue;
 
-      const responseObj = response as ResponseObject;
+      const responseObj = resolveResponse(response, doc);
+      if (!responseObj) continue;
+
       const contentTypes: ContentTypeMapping[] = [];
 
       if (responseObj.content) {

--- a/apps/craft/src/client-generator/operation-function-generator.ts
+++ b/apps/craft/src/client-generator/operation-function-generator.ts
@@ -79,6 +79,7 @@ export function extractOperationMetadata(
     functionName,
     typeImports,
     operationName,
+    doc,
   );
 
   /* Build parameter shapes */
@@ -101,6 +102,7 @@ export function extractOperationMetadata(
     typeImports,
     bodyInfo.shouldExportResponseMap,
     bodyInfo.shouldExportResponseMap ? bodyInfo.responseMapTypeName : undefined,
+    doc,
   );
 
   /* Security overrides/auth headers */
@@ -281,6 +283,7 @@ function collectBodyAndContentTypes(
   functionName: string,
   typeImports: Set<string>,
   operationName: string,
+  doc: OpenAPIObject,
 ) {
   let bodyTypeInfo: ReturnType<typeof resolveRequestBodyType> | undefined;
   let requestContentType: string | undefined;
@@ -295,7 +298,7 @@ function collectBodyAndContentTypes(
   const requestMapTypeName = `${operationName}RequestMap`;
   const responseMapTypeName = `${operationName}ResponseMap`;
 
-  const contentTypeMaps = generateContentTypeMaps(operation);
+  const contentTypeMaps = generateContentTypeMaps(operation, doc);
   contentTypeMaps.typeImports.forEach((imp) => typeImports.add(imp));
 
   let requestContentTypes: string[] = [];

--- a/apps/craft/src/client-generator/response-analysis.ts
+++ b/apps/craft/src/client-generator/response-analysis.ts
@@ -1,6 +1,10 @@
 /* Pure analysis functions for response processing */
 
-import type { OperationObject, ResponseObject } from "openapi3-ts/oas31";
+import type {
+  OpenAPIObject,
+  OperationObject,
+  ResponseObject,
+} from "openapi3-ts/oas31";
 
 import assert from "assert";
 import { isReferenceObject } from "openapi3-ts/oas31";
@@ -14,7 +18,7 @@ import type {
 } from "./models/response-models.js";
 
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
-import { getResponseContentType } from "./utils.js";
+import { getResponseContentType, resolveResponse } from "./utils.js";
 
 // Interfaces (alphabetical keys inside)
 interface BuildUnionTypesParams {
@@ -52,6 +56,7 @@ export function analyzeResponseStructure(
   config: ResponseAnalysisConfig,
 ): ResponseAnalysis {
   const {
+    doc,
     hasResponseContentTypeMap = false,
     operation,
     responseMapName,
@@ -62,6 +67,7 @@ export function analyzeResponseStructure(
     operation,
     typeImports,
     hasResponseContentTypeMap,
+    doc,
   );
 
   // Derive response map name for union types
@@ -241,6 +247,7 @@ function collectResponses(
   operation: OperationObject,
   typeImports: Set<string>,
   hasResponseContentTypeMap: boolean,
+  doc?: OpenAPIObject,
 ) {
   const responses: ResponseInfo[] = [];
   let defaultResponseInfo: ResponseInfo | undefined;
@@ -255,11 +262,14 @@ function collectResponses(
   responseCodes.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
 
   for (const code of responseCodes) {
-    const response = operation.responses[code] as ResponseObject;
+    const responseOrRef = operation.responses[code];
+    const responseObj = resolveResponse(responseOrRef, doc);
+    if (!responseObj) continue;
+
     responses.push(
       buildResponseTypeInfo(
         code,
-        response,
+        responseObj,
         operation,
         typeImports,
         hasResponseContentTypeMap,
@@ -268,14 +278,17 @@ function collectResponses(
   }
 
   if (operation.responses.default) {
-    const response = operation.responses.default as ResponseObject;
-    defaultResponseInfo = buildResponseTypeInfo(
-      "default",
-      response,
-      operation,
-      typeImports,
-      hasResponseContentTypeMap,
-    );
+    const responseOrRef = operation.responses.default;
+    const responseObj = resolveResponse(responseOrRef, doc);
+    if (responseObj) {
+      defaultResponseInfo = buildResponseTypeInfo(
+        "default",
+        responseObj,
+        operation,
+        typeImports,
+        hasResponseContentTypeMap,
+      );
+    }
   }
 
   return { defaultResponseInfo, responses };

--- a/apps/craft/src/client-generator/responses.ts
+++ b/apps/craft/src/client-generator/responses.ts
@@ -1,4 +1,4 @@
-import type { OperationObject } from "openapi3-ts/oas31";
+import type { OpenAPIObject, OperationObject } from "openapi3-ts/oas31";
 
 import assert from "assert";
 
@@ -49,6 +49,7 @@ export interface ResponseTypeInfo {
  */
 export function generateContentTypeMaps(
   operation: OperationObject,
+  doc?: OpenAPIObject,
 ): ContentTypeMaps {
   assert(operation.operationId, "Operation ID is required");
   const typeImports = new Set<string>();
@@ -63,6 +64,7 @@ export function generateContentTypeMaps(
     operation,
     operationId,
     typeImports,
+    doc,
   );
 
   return {
@@ -85,9 +87,11 @@ export function generateResponseHandlers(
   typeImports: Set<string>,
   hasResponseContentTypeMap = false,
   responseMapName?: string,
+  doc?: OpenAPIObject,
 ): ResponseHandlerResult {
   /* Analyze the response structure */
   const analysis = analyzeResponseStructure({
+    doc,
     hasResponseContentTypeMap,
     operation,
     responseMapName,
@@ -147,9 +151,16 @@ function buildResponseContentTypeMap(
   operation: OperationObject,
   operationId: string,
   typeImports: Set<string>,
+  doc?: OpenAPIObject,
 ) {
   /* Use shared response mapping logic with correct structure */
-  const result = generateResponseMap(operation, operationId, typeImports);
+  const result = generateResponseMap(
+    operation,
+    operationId,
+    typeImports,
+    {},
+    doc,
+  );
 
   /* Merge type imports */
   result.typeImports.forEach((imp) => typeImports.add(imp));

--- a/apps/craft/src/client-generator/responses.ts
+++ b/apps/craft/src/client-generator/responses.ts
@@ -154,13 +154,7 @@ function buildResponseContentTypeMap(
   doc?: OpenAPIObject,
 ) {
   /* Use shared response mapping logic with correct structure */
-  const result = generateResponseMap(
-    operation,
-    operationId,
-    typeImports,
-    {},
-    doc,
-  );
+  const result = generateResponseMap(operation, operationId, typeImports, doc);
 
   /* Merge type imports */
   result.typeImports.forEach((imp) => typeImports.add(imp));

--- a/apps/craft/src/client-generator/utils.ts
+++ b/apps/craft/src/client-generator/utils.ts
@@ -2,6 +2,14 @@
  * Utility functions for string manipulation and validation
  */
 
+import type {
+  OpenAPIObject,
+  ReferenceObject,
+  ResponseObject,
+} from "openapi3-ts/oas31";
+
+import { isReferenceObject } from "openapi3-ts/oas31";
+
 /**
  * Generates URL path with parameter interpolation
  */
@@ -39,6 +47,71 @@ export function getResponseContentType(
   // Return the first content type if no JSON found
   const contentTypes = Object.keys(response.content);
   return contentTypes.length > 0 ? contentTypes[0] : null;
+}
+
+/**
+ * Resolves a response (either direct ResponseObject or ReferenceObject) to a ResponseObject
+ * @param responseOrRef The response object or reference to resolve
+ * @param doc The OpenAPI document for resolving references (optional)
+ * @returns The resolved ResponseObject or undefined if resolution fails
+ */
+export function resolveResponse(
+  responseOrRef: ReferenceObject | ResponseObject,
+  doc?: OpenAPIObject,
+): ResponseObject | undefined {
+  if (isReferenceObject(responseOrRef)) {
+    if (doc) {
+      const resolved = resolveResponseReference(responseOrRef.$ref, doc);
+      if (!resolved) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `⚠️ Could not resolve response reference: ${responseOrRef.$ref}`,
+        );
+        return undefined;
+      }
+      return resolved;
+    } else {
+      // Skip reference objects if no document to resolve against
+      return undefined;
+    }
+  } else {
+    return responseOrRef;
+  }
+}
+
+/**
+ * Resolves a response reference within an OpenAPI document
+ * @param ref The reference string (e.g., "#/components/responses/DocumentResponse")
+ * @param doc The OpenAPI document containing the referenced response
+ * @returns The resolved ResponseObject or undefined if not found
+ */
+export function resolveResponseReference(
+  ref: string,
+  doc: OpenAPIObject,
+): ResponseObject | undefined {
+  if (!ref.startsWith("#/components/responses/")) {
+    return undefined;
+  }
+
+  const responseName = ref.replace("#/components/responses/", "");
+  const response = doc.components?.responses?.[responseName];
+
+  if (!response) {
+    return undefined;
+  }
+
+  // The resolved response should be a ResponseObject, not a ReferenceObject
+  // If it's still a reference, we'd need recursive resolution, but OpenAPI bundling
+  // should have resolved this already
+  if (isReferenceObject(response)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `⚠️ Nested response reference not resolved: ${ref} -> ${response.$ref}`,
+    );
+    return undefined;
+  }
+
+  return response;
 }
 
 /**

--- a/apps/craft/src/server-generator/operation-wrapper-generator.ts
+++ b/apps/craft/src/server-generator/operation-wrapper-generator.ts
@@ -138,7 +138,7 @@ export function generateServerOperationWrapper(
     : "";
 
   /* Build response map */
-  const responseMapCode = buildServerResponseMap(metadata, typeImports);
+  const responseMapCode = buildServerResponseMap(metadata, typeImports, doc);
 
   /* Render the complete wrapper function */
   const wrapperCode = renderServerOperationWrapper({

--- a/apps/craft/src/server-generator/templates/server-operation-templates.ts
+++ b/apps/craft/src/server-generator/templates/server-operation-templates.ts
@@ -1,3 +1,5 @@
+import type { OpenAPIObject } from "openapi3-ts/oas31";
+
 import type { ParameterGroups } from "../../client-generator/models/parameter-models.js";
 import type { ServerOperationMetadata } from "../operation-wrapper-generator.js";
 
@@ -55,6 +57,7 @@ export type ${mapName} = typeof ${mapName};`;
 export function buildServerResponseMap(
   metadata: ServerOperationMetadata,
   typeImports: Set<string>,
+  doc: OpenAPIObject,
 ): string {
   /* Generate response union type using existing logic */
   const unionResult = generateResponseUnion(
@@ -62,6 +65,7 @@ export function buildServerResponseMap(
     metadata.operationId,
     typeImports,
     { useStrictSchemas: true }, // Use strict schemas for server responses
+    doc, // Pass document for response reference resolution
   );
 
   /* Generate response map using shared logic */
@@ -70,6 +74,7 @@ export function buildServerResponseMap(
     metadata.operationId,
     typeImports,
     { useStrictSchemas: true }, // Use strict schemas for server responses
+    doc, // Pass document for response reference resolution
   );
 
   /* Add type imports */

--- a/apps/craft/src/server-generator/templates/server-operation-templates.ts
+++ b/apps/craft/src/server-generator/templates/server-operation-templates.ts
@@ -73,8 +73,8 @@ export function buildServerResponseMap(
     metadata.operation,
     metadata.operationId,
     typeImports,
-    { useStrictSchemas: true }, // Use strict schemas for server responses
     doc, // Pass document for response reference resolution
+    { useStrictSchemas: true }, // Use strict schemas for server responses
   );
 
   /* Add type imports */

--- a/apps/craft/src/shared/response-maps.ts
+++ b/apps/craft/src/shared/response-maps.ts
@@ -52,74 +52,59 @@ export function generateResponseMap(
   operation: OperationObject,
   operationId: string,
   typeImports: Set<string>,
-  options: ResponseMapOptions = {},
   doc?: OpenAPIObject,
+  options: ResponseMapOptions = {},
 ): ResponseMapResult {
-  const defaultContentType = { value: null as null | string };
   let contentTypeCount = 0;
   let responseMapType = "{}";
   let shouldGenerateResponseMap = false;
-  const statusCodes: string[] = [];
-  const allContentTypes = new Set<string>();
 
   const responseContentTypes = extractResponseContentTypes(operation, doc);
   if (responseContentTypes.length === 0) {
     return {
       contentTypeCount,
-      defaultContentType: defaultContentType.value,
+      defaultContentType: null,
       responseMapType,
       shouldGenerateResponseMap,
-      statusCodes,
+      statusCodes: [],
       typeImports: new Set(),
     };
   }
 
-  /* Build status code to content type mapping */
-  const statusToContentTypes: Record<
-    string,
-    { contentType: string; typeName: string }[]
-  > = {};
-
   // Build mappings from response content types
-  buildStatusToContentTypes(
+  const buildResult = buildStatusToContentTypes(
     responseContentTypes,
     operationId,
     typeImports,
     options,
-    statusCodes,
-    statusToContentTypes,
-    allContentTypes,
-    defaultContentType,
   );
 
   // Handle default response
-  handleDefaultResponse(
+  const defaultResult = handleDefaultResponse(
     operation,
     operationId,
-    typeImports,
+    buildResult.updatedTypeImports,
     options,
-    statusCodes,
-    statusToContentTypes,
-    allContentTypes,
-    defaultContentType,
+    buildResult.statusCodes,
+    buildResult.statusToContentTypes,
+    buildResult.allContentTypes,
+    buildResult.defaultContentType,
   );
 
-  contentTypeCount = allContentTypes.size;
+  contentTypeCount = defaultResult.allContentTypes.size;
   shouldGenerateResponseMap =
-    statusCodes.length > 1 ||
-    contentTypeCount > 1 ||
-    Object.keys(statusToContentTypes).length > 0;
+    defaultResult.statusCodes.length > 0 || contentTypeCount > 1;
 
   // Build response map type string
-  responseMapType = buildResponseMapType(statusToContentTypes);
+  responseMapType = buildResponseMapType(defaultResult.statusToContentTypes);
 
   return {
     contentTypeCount,
-    defaultContentType: defaultContentType.value,
+    defaultContentType: defaultResult.defaultContentType,
     responseMapType,
     shouldGenerateResponseMap,
-    statusCodes,
-    typeImports,
+    statusCodes: defaultResult.statusCodes,
+    typeImports: defaultResult.updatedTypeImports,
   };
 }
 
@@ -163,14 +148,25 @@ function buildStatusToContentTypes(
   operationId: string,
   typeImports: Set<string>,
   options: ResponseMapOptions,
-  statusCodes: string[],
+): {
+  allContentTypes: Set<string>;
+  defaultContentType: null | string;
+  statusCodes: string[];
   statusToContentTypes: Record<
     string,
     { contentType: string; typeName: string }[]
-  >,
-  allContentTypes: Set<string>,
-  defaultContentType: { value: null | string },
-): void {
+  >;
+  updatedTypeImports: Set<string>;
+} {
+  const statusCodes: string[] = [];
+  const statusToContentTypes: Record<
+    string,
+    { contentType: string; typeName: string }[]
+  > = {};
+  const allContentTypes = new Set<string>();
+  let defaultContentType: null | string = null;
+  const updatedTypeImports = new Set(typeImports);
+
   for (const group of responseContentTypes) {
     if (group.contentTypes.length === 0) continue;
 
@@ -181,20 +177,20 @@ function buildStatusToContentTypes(
       const ct = mapping.contentType;
       allContentTypes.add(ct);
 
-      if (!defaultContentType.value) defaultContentType.value = ct;
+      if (!defaultContentType) defaultContentType = ct;
 
       const typeName = options.useStrictSchemas
         ? resolveStrictSchemaTypeName(
             mapping.schema,
             operationId,
             `${group.statusCode}Response`,
-            typeImports,
+            updatedTypeImports,
           )
         : resolveSchemaTypeName(
             mapping.schema,
             operationId,
             `${group.statusCode}Response`,
-            typeImports,
+            updatedTypeImports,
           );
 
       statusToContentTypes[group.statusCode].push({
@@ -203,6 +199,14 @@ function buildStatusToContentTypes(
       });
     }
   }
+
+  return {
+    allContentTypes,
+    defaultContentType,
+    statusCodes,
+    statusToContentTypes,
+    updatedTypeImports,
+  };
 }
 
 /**
@@ -219,8 +223,23 @@ function handleDefaultResponse(
     { contentType: string; typeName: string }[]
   >,
   allContentTypes: Set<string>,
-  defaultContentType: { value: null | string },
-): void {
+  defaultContentType: null | string,
+): {
+  allContentTypes: Set<string>;
+  defaultContentType: null | string;
+  statusCodes: string[];
+  statusToContentTypes: Record<
+    string,
+    { contentType: string; typeName: string }[]
+  >;
+  updatedTypeImports: Set<string>;
+} {
+  const updatedStatusCodes = [...statusCodes];
+  const updatedStatusToContentTypes = { ...statusToContentTypes };
+  const updatedAllContentTypes = new Set(allContentTypes);
+  let updatedDefaultContentType = defaultContentType;
+  const updatedTypeImports = new Set(typeImports);
+
   if (operation.responses && "default" in operation.responses) {
     const defaultResponse = operation.responses.default;
     if (defaultResponse && !isReferenceObject(defaultResponse)) {
@@ -237,23 +256,33 @@ function handleDefaultResponse(
                 mediaType.schema,
                 operationId,
                 `DefaultResponse`,
-                typeImports,
+                updatedTypeImports,
               )
             : resolveSchemaTypeName(
                 mediaType.schema,
                 operationId,
                 `DefaultResponse`,
-                typeImports,
+                updatedTypeImports,
               );
-          allContentTypes.add(contentType);
-          if (!defaultContentType.value) defaultContentType.value = contentType;
+          updatedAllContentTypes.add(contentType);
+          if (!updatedDefaultContentType) {
+            updatedDefaultContentType = contentType;
+          }
           defaultContentTypes.push({ contentType, typeName });
         }
         if (defaultContentTypes.length > 0) {
-          statusCodes.push("default");
-          statusToContentTypes["default"] = defaultContentTypes;
+          updatedStatusCodes.push("default");
+          updatedStatusToContentTypes["default"] = defaultContentTypes;
         }
       }
     }
   }
+
+  return {
+    allContentTypes: updatedAllContentTypes,
+    defaultContentType: updatedDefaultContentType,
+    statusCodes: updatedStatusCodes,
+    statusToContentTypes: updatedStatusToContentTypes,
+    updatedTypeImports,
+  };
 }

--- a/apps/craft/src/shared/response-maps.ts
+++ b/apps/craft/src/shared/response-maps.ts
@@ -80,7 +80,7 @@ export function generateResponseMap(
   );
 
   // Handle default response
-  const defaultResult = handleDefaultResponse(
+  const updatedResult = applyDefaultResponse(
     operation,
     operationId,
     buildResult.updatedTypeImports,
@@ -91,20 +91,98 @@ export function generateResponseMap(
     buildResult.defaultContentType,
   );
 
-  contentTypeCount = defaultResult.allContentTypes.size;
+  contentTypeCount = updatedResult.allContentTypes.size;
   shouldGenerateResponseMap =
-    defaultResult.statusCodes.length > 0 || contentTypeCount > 1;
+    updatedResult.statusCodes.length > 0 || contentTypeCount > 1;
 
   // Build response map type string
-  responseMapType = buildResponseMapType(defaultResult.statusToContentTypes);
+  responseMapType = buildResponseMapType(updatedResult.statusToContentTypes);
 
   return {
     contentTypeCount,
-    defaultContentType: defaultResult.defaultContentType,
+    defaultContentType: updatedResult.defaultContentType,
     responseMapType,
     shouldGenerateResponseMap,
-    statusCodes: defaultResult.statusCodes,
-    typeImports: defaultResult.updatedTypeImports,
+    statusCodes: updatedResult.statusCodes,
+    typeImports: updatedResult.updatedTypeImports,
+  };
+}
+
+/**
+ * Helper to handle default response
+ */
+function applyDefaultResponse(
+  operation: OperationObject,
+  operationId: string,
+  typeImports: Set<string>,
+  options: ResponseMapOptions,
+  statusCodes: string[],
+  statusToContentTypes: Record<
+    string,
+    { contentType: string; typeName: string }[]
+  >,
+  allContentTypes: Set<string>,
+  defaultContentType: null | string,
+): {
+  allContentTypes: Set<string>;
+  defaultContentType: null | string;
+  statusCodes: string[];
+  statusToContentTypes: Record<
+    string,
+    { contentType: string; typeName: string }[]
+  >;
+  updatedTypeImports: Set<string>;
+} {
+  const updatedStatusCodes = [...statusCodes];
+  const updatedStatusToContentTypes = { ...statusToContentTypes };
+  const updatedAllContentTypes = new Set(allContentTypes);
+  let updatedDefaultContentType = defaultContentType;
+  const updatedTypeImports = new Set(typeImports);
+
+  if (operation.responses && "default" in operation.responses) {
+    const defaultResponse = operation.responses.default;
+    if (defaultResponse && !isReferenceObject(defaultResponse)) {
+      const content = defaultResponse.content;
+      if (content) {
+        const defaultContentTypes: {
+          contentType: string;
+          typeName: string;
+        }[] = [];
+        for (const [contentType, mediaType] of Object.entries(content)) {
+          if (!mediaType.schema) continue;
+          const typeName = options.useStrictSchemas
+            ? resolveStrictSchemaTypeName(
+                mediaType.schema,
+                operationId,
+                `DefaultResponse`,
+                updatedTypeImports,
+              )
+            : resolveSchemaTypeName(
+                mediaType.schema,
+                operationId,
+                `DefaultResponse`,
+                updatedTypeImports,
+              );
+          updatedAllContentTypes.add(contentType);
+          if (!updatedDefaultContentType) {
+            updatedDefaultContentType = contentType;
+          }
+          defaultContentTypes.push({ contentType, typeName });
+        }
+        if (defaultContentTypes.length > 0) {
+          updatedStatusCodes.push("default");
+          updatedStatusToContentTypes["default"] = defaultContentTypes;
+        }
+      }
+    }
+  }
+
+  return {
+    allContentTypes: updatedAllContentTypes,
+    defaultContentType: updatedDefaultContentType,
+    statusCodes: updatedStatusCodes,
+    statusToContentTypes: updatedStatusToContentTypes,
+    updatedTypeImports,
   };
 }
 
@@ -205,84 +283,6 @@ function buildStatusToContentTypes(
     defaultContentType,
     statusCodes,
     statusToContentTypes,
-    updatedTypeImports,
-  };
-}
-
-/**
- * Helper to handle default response
- */
-function handleDefaultResponse(
-  operation: OperationObject,
-  operationId: string,
-  typeImports: Set<string>,
-  options: ResponseMapOptions,
-  statusCodes: string[],
-  statusToContentTypes: Record<
-    string,
-    { contentType: string; typeName: string }[]
-  >,
-  allContentTypes: Set<string>,
-  defaultContentType: null | string,
-): {
-  allContentTypes: Set<string>;
-  defaultContentType: null | string;
-  statusCodes: string[];
-  statusToContentTypes: Record<
-    string,
-    { contentType: string; typeName: string }[]
-  >;
-  updatedTypeImports: Set<string>;
-} {
-  const updatedStatusCodes = [...statusCodes];
-  const updatedStatusToContentTypes = { ...statusToContentTypes };
-  const updatedAllContentTypes = new Set(allContentTypes);
-  let updatedDefaultContentType = defaultContentType;
-  const updatedTypeImports = new Set(typeImports);
-
-  if (operation.responses && "default" in operation.responses) {
-    const defaultResponse = operation.responses.default;
-    if (defaultResponse && !isReferenceObject(defaultResponse)) {
-      const content = defaultResponse.content;
-      if (content) {
-        const defaultContentTypes: {
-          contentType: string;
-          typeName: string;
-        }[] = [];
-        for (const [contentType, mediaType] of Object.entries(content)) {
-          if (!mediaType.schema) continue;
-          const typeName = options.useStrictSchemas
-            ? resolveStrictSchemaTypeName(
-                mediaType.schema,
-                operationId,
-                `DefaultResponse`,
-                updatedTypeImports,
-              )
-            : resolveSchemaTypeName(
-                mediaType.schema,
-                operationId,
-                `DefaultResponse`,
-                updatedTypeImports,
-              );
-          updatedAllContentTypes.add(contentType);
-          if (!updatedDefaultContentType) {
-            updatedDefaultContentType = contentType;
-          }
-          defaultContentTypes.push({ contentType, typeName });
-        }
-        if (defaultContentTypes.length > 0) {
-          updatedStatusCodes.push("default");
-          updatedStatusToContentTypes["default"] = defaultContentTypes;
-        }
-      }
-    }
-  }
-
-  return {
-    allContentTypes: updatedAllContentTypes,
-    defaultContentType: updatedDefaultContentType,
-    statusCodes: updatedStatusCodes,
-    statusToContentTypes: updatedStatusToContentTypes,
     updatedTypeImports,
   };
 }

--- a/apps/craft/src/shared/response-maps.ts
+++ b/apps/craft/src/shared/response-maps.ts
@@ -1,8 +1,15 @@
 /* Shared response mapping logic with correct structure */
 
-import { isReferenceObject, type OperationObject } from "openapi3-ts/oas31";
+import {
+  isReferenceObject,
+  type OpenAPIObject,
+  type OperationObject,
+} from "openapi3-ts/oas31";
 
-import { extractResponseContentTypes } from "../client-generator/operation-extractor.js";
+import {
+  extractResponseContentTypes,
+  type ResponseContentTypes,
+} from "../client-generator/operation-extractor.js";
 import {
   resolveSchemaTypeName,
   resolveStrictSchemaTypeName,
@@ -46,19 +53,20 @@ export function generateResponseMap(
   operationId: string,
   typeImports: Set<string>,
   options: ResponseMapOptions = {},
+  doc?: OpenAPIObject,
 ): ResponseMapResult {
-  let defaultContentType: null | string = null;
+  const defaultContentType = { value: null as null | string };
   let contentTypeCount = 0;
   let responseMapType = "{}";
   let shouldGenerateResponseMap = false;
   const statusCodes: string[] = [];
   const allContentTypes = new Set<string>();
 
-  const responseContentTypes = extractResponseContentTypes(operation);
+  const responseContentTypes = extractResponseContentTypes(operation, doc);
   if (responseContentTypes.length === 0) {
     return {
       contentTypeCount,
-      defaultContentType,
+      defaultContentType: defaultContentType.value,
       responseMapType,
       shouldGenerateResponseMap,
       statusCodes,
@@ -72,6 +80,97 @@ export function generateResponseMap(
     { contentType: string; typeName: string }[]
   > = {};
 
+  // Build mappings from response content types
+  buildStatusToContentTypes(
+    responseContentTypes,
+    operationId,
+    typeImports,
+    options,
+    statusCodes,
+    statusToContentTypes,
+    allContentTypes,
+    defaultContentType,
+  );
+
+  // Handle default response
+  handleDefaultResponse(
+    operation,
+    operationId,
+    typeImports,
+    options,
+    statusCodes,
+    statusToContentTypes,
+    allContentTypes,
+    defaultContentType,
+  );
+
+  contentTypeCount = allContentTypes.size;
+  shouldGenerateResponseMap =
+    statusCodes.length > 1 ||
+    contentTypeCount > 1 ||
+    Object.keys(statusToContentTypes).length > 0;
+
+  // Build response map type string
+  responseMapType = buildResponseMapType(statusToContentTypes);
+
+  return {
+    contentTypeCount,
+    defaultContentType: defaultContentType.value,
+    responseMapType,
+    shouldGenerateResponseMap,
+    statusCodes,
+    typeImports,
+  };
+}
+
+/**
+ * Helper to build response map type string
+ */
+function buildResponseMapType(
+  statusToContentTypes: Record<
+    string,
+    { contentType: string; typeName: string }[]
+  >,
+): string {
+  if (Object.keys(statusToContentTypes).length === 0) {
+    return "{}";
+  }
+
+  const statusMappings: string[] = Object.entries(statusToContentTypes).map(
+    ([statusCode, contentTypeMappings]) => {
+      const contentMappings = contentTypeMappings
+        .map(
+          ({ contentType, typeName }) => `    "${contentType}": ${typeName},`,
+        )
+        .join("\n");
+
+      return `  "${statusCode}": {
+${contentMappings}
+  },`;
+    },
+  );
+
+  return `{
+${statusMappings.join("\n")}
+}`;
+}
+
+/**
+ * Helper to build status to content type mappings
+ */
+function buildStatusToContentTypes(
+  responseContentTypes: ResponseContentTypes[],
+  operationId: string,
+  typeImports: Set<string>,
+  options: ResponseMapOptions,
+  statusCodes: string[],
+  statusToContentTypes: Record<
+    string,
+    { contentType: string; typeName: string }[]
+  >,
+  allContentTypes: Set<string>,
+  defaultContentType: { value: null | string },
+): void {
   for (const group of responseContentTypes) {
     if (group.contentTypes.length === 0) continue;
 
@@ -82,7 +181,7 @@ export function generateResponseMap(
       const ct = mapping.contentType;
       allContentTypes.add(ct);
 
-      if (!defaultContentType) defaultContentType = ct;
+      if (!defaultContentType.value) defaultContentType.value = ct;
 
       const typeName = options.useStrictSchemas
         ? resolveStrictSchemaTypeName(
@@ -104,15 +203,33 @@ export function generateResponseMap(
       });
     }
   }
+}
 
-  // Handle default response (catch-all) if present with content
+/**
+ * Helper to handle default response
+ */
+function handleDefaultResponse(
+  operation: OperationObject,
+  operationId: string,
+  typeImports: Set<string>,
+  options: ResponseMapOptions,
+  statusCodes: string[],
+  statusToContentTypes: Record<
+    string,
+    { contentType: string; typeName: string }[]
+  >,
+  allContentTypes: Set<string>,
+  defaultContentType: { value: null | string },
+): void {
   if (operation.responses && "default" in operation.responses) {
     const defaultResponse = operation.responses.default;
     if (defaultResponse && !isReferenceObject(defaultResponse)) {
       const content = defaultResponse.content;
       if (content) {
-        const defaultContentTypes: { contentType: string; typeName: string }[] =
-          [];
+        const defaultContentTypes: {
+          contentType: string;
+          typeName: string;
+        }[] = [];
         for (const [contentType, mediaType] of Object.entries(content)) {
           if (!mediaType.schema) continue;
           const typeName = options.useStrictSchemas
@@ -129,7 +246,7 @@ export function generateResponseMap(
                 typeImports,
               );
           allContentTypes.add(contentType);
-          if (!defaultContentType) defaultContentType = contentType;
+          if (!defaultContentType.value) defaultContentType.value = contentType;
           defaultContentTypes.push({ contentType, typeName });
         }
         if (defaultContentTypes.length > 0) {
@@ -139,36 +256,4 @@ export function generateResponseMap(
       }
     }
   }
-
-  contentTypeCount = allContentTypes.size;
-  shouldGenerateResponseMap = statusCodes.length > 1 || contentTypeCount > 1;
-
-  if (Object.keys(statusToContentTypes).length > 0) {
-    const statusMappings: string[] = Object.entries(statusToContentTypes).map(
-      ([statusCode, contentTypeMappings]) => {
-        const contentMappings = contentTypeMappings
-          .map(
-            ({ contentType, typeName }) => `    "${contentType}": ${typeName},`,
-          )
-          .join("\n");
-
-        return `  "${statusCode}": {
-${contentMappings}
-  },`;
-      },
-    );
-
-    responseMapType = `{
-${statusMappings.join("\n")}
-}`;
-  }
-
-  return {
-    contentTypeCount,
-    defaultContentType,
-    responseMapType,
-    shouldGenerateResponseMap,
-    statusCodes,
-    typeImports,
-  };
 }

--- a/apps/craft/src/shared/response-union-generator.ts
+++ b/apps/craft/src/shared/response-union-generator.ts
@@ -1,6 +1,6 @@
 /* Shared response union generation logic */
 
-import type { OperationObject } from "openapi3-ts/oas31";
+import type { OpenAPIObject, OperationObject } from "openapi3-ts/oas31";
 
 import { extractResponseContentTypes } from "../client-generator/operation-extractor.js";
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
@@ -45,6 +45,7 @@ export function generateResponseUnion(
   operationId: string,
   typeImports: Set<string>,
   options: ResponseUnionOptions = {},
+  doc?: OpenAPIObject,
 ): ResponseUnionResult {
   const unionMembers: ResponseUnionMember[] = [];
   const responseTypeName = `${sanitizeIdentifier(operationId)}Response`;
@@ -63,7 +64,7 @@ export function generateResponseUnion(
     allStatusCodes.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
 
     /* Extract responses that have content/schema */
-    const responseContentTypes = extractResponseContentTypes(operation);
+    const responseContentTypes = extractResponseContentTypes(operation, doc);
     const statusCodesWithContent = new Set(
       responseContentTypes.map((r) => r.statusCode),
     );

--- a/apps/craft/tests/client-generator/response-references.test.ts
+++ b/apps/craft/tests/client-generator/response-references.test.ts
@@ -1,0 +1,196 @@
+import type { OperationObject, OpenAPIObject } from "openapi3-ts/oas31";
+
+import { describe, expect, it } from "vitest";
+
+import { extractResponseContentTypes } from "../../src/client-generator/operation-extractor.js";
+
+describe("client-generator response references", () => {
+  describe("extractResponseContentTypes", () => {
+    it("should handle response with direct content schema", () => {
+      const operation: OperationObject = {
+        operationId: "testDirect",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Document",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = extractResponseContentTypes(operation);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].statusCode).toBe("200");
+      expect(result[0].contentTypes).toHaveLength(1);
+      expect(result[0].contentTypes[0].contentType).toBe("application/json");
+      expect(result[0].contentTypes[0].schema).toEqual({
+        $ref: "#/components/schemas/Document",
+      });
+    });
+
+    it("should handle response with $ref to components/responses when no document provided", () => {
+      const operation: OperationObject = {
+        operationId: "createDocument",
+        responses: {
+          "200": {
+            $ref: "#/components/responses/DocumentResponse",
+          },
+        },
+      };
+
+      const result = extractResponseContentTypes(operation);
+
+      // Without document, should skip reference objects
+      expect(result).toHaveLength(0);
+    });
+
+    it("should resolve response with $ref to components/responses when document provided", () => {
+      const operation: OperationObject = {
+        operationId: "createDocument",
+        responses: {
+          "200": {
+            $ref: "#/components/responses/DocumentResponse",
+          },
+        },
+      };
+
+      const doc: OpenAPIObject = {
+        openapi: "3.1.0",
+        info: { title: "Test", version: "1.0.0" },
+        components: {
+          responses: {
+            DocumentResponse: {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/Document",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = extractResponseContentTypes(operation, doc);
+
+      // With document, should resolve the reference and extract content
+      expect(result).toHaveLength(1);
+      expect(result[0].statusCode).toBe("200");
+      expect(result[0].contentTypes).toHaveLength(1);
+      expect(result[0].contentTypes[0].contentType).toBe("application/json");
+      expect(result[0].contentTypes[0].schema).toEqual({
+        $ref: "#/components/schemas/Document",
+      });
+    });
+
+    it("should handle mixed direct and referenced responses", () => {
+      const operation: OperationObject = {
+        operationId: "mixedResponses",
+        responses: {
+          "200": {
+            $ref: "#/components/responses/DocumentResponse",
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Error",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const doc: OpenAPIObject = {
+        openapi: "3.1.0",
+        info: { title: "Test", version: "1.0.0" },
+        components: {
+          responses: {
+            DocumentResponse: {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/Document",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = extractResponseContentTypes(operation, doc);
+
+      // Should extract both responses
+      expect(result).toHaveLength(2);
+
+      // Sort by status code for consistent testing
+      const sortedResult = result.sort((a, b) =>
+        a.statusCode.localeCompare(b.statusCode),
+      );
+
+      expect(sortedResult[0].statusCode).toBe("200");
+      expect(sortedResult[0].contentTypes[0].contentType).toBe(
+        "application/json",
+      );
+      expect(sortedResult[0].contentTypes[0].schema).toEqual({
+        $ref: "#/components/schemas/Document",
+      });
+
+      expect(sortedResult[1].statusCode).toBe("400");
+      expect(sortedResult[1].contentTypes[0].contentType).toBe(
+        "application/json",
+      );
+      expect(sortedResult[1].contentTypes[0].schema).toEqual({
+        $ref: "#/components/schemas/Error",
+      });
+    });
+
+    it("should handle unresolvable response references gracefully", () => {
+      const operation: OperationObject = {
+        operationId: "unresolvableRef",
+        responses: {
+          "200": {
+            $ref: "#/components/responses/NonExistentResponse",
+          },
+        },
+      };
+
+      const doc: OpenAPIObject = {
+        openapi: "3.1.0",
+        info: { title: "Test", version: "1.0.0" },
+        components: {
+          responses: {
+            // DocumentResponse exists but NonExistentResponse doesn't
+            DocumentResponse: {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/Document",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = extractResponseContentTypes(operation, doc);
+
+      // Should skip unresolvable references
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/apps/craft/tests/integrations/createDocument-reference.test.ts
+++ b/apps/craft/tests/integrations/createDocument-reference.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createDocument,
+  CreateDocumentResponseMap,
+} from "./generated/client/createDocument";
+
+describe("createDocument response reference integration", () => {
+  it("should have correctly populated response map", () => {
+    // Verify that the response map is not empty and contains the correct structure
+    expect(CreateDocumentResponseMap).toEqual({
+      "200": {
+        "application/json": expect.any(Object), // Should be the documentalias Zod schema
+      },
+    });
+
+    // Verify the schema is actually a Zod schema by checking for parse method
+    const schema = CreateDocumentResponseMap["200"]["application/json"];
+    expect(typeof schema.parse).toBe("function");
+  });
+
+  it("should have correct TypeScript signature for response types", () => {
+    // This test verifies the TypeScript types are correct at compile time
+    // If the response reference resolution worked correctly, the function should:
+    // 1. Accept the Document type in request body
+    // 2. Return ApiResponseWithForcedParse<200, typeof CreateDocumentResponseMap>
+
+    // Mock a successful response for type checking
+    const mockDocument = {
+      id: "doc-123",
+      title: "Test Document",
+      createdAt: "2023-01-01T00:00:00Z",
+    };
+
+    // The function call should compile without errors - this validates the types
+    const promise = createDocument(
+      { body: mockDocument },
+      {
+        baseURL: "http://example.com",
+        fetch: async () => {
+          // Mock a successful response
+          return new Response(JSON.stringify(mockDocument), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        },
+        headers: {},
+        forceValidation: true,
+      },
+    );
+
+    // Verify the return type is a Promise
+    expect(promise).toBeInstanceOf(Promise);
+  });
+
+  it("should handle response reference resolution in type system", () => {
+    // Test that the response map type correctly maps to the Document schema
+    // This verifies that the $ref resolution worked for type generation
+
+    type ResponseMapType = typeof CreateDocumentResponseMap;
+    type Status200Type = ResponseMapType["200"];
+    type JsonType = Status200Type["application/json"];
+
+    // At compile time, JsonType should be the document schema
+    // At runtime, we can verify it's a proper Zod schema
+    const schema = CreateDocumentResponseMap["200"]["application/json"];
+
+    // Verify it can parse valid document data
+    const validDocument = {
+      id: "doc-456",
+      title: "Another Test Document",
+      createdAt: "2023-01-02T00:00:00Z",
+    };
+
+    expect(() => schema.parse(validDocument)).not.toThrow();
+
+    // Verify it rejects invalid data
+    const invalidDocument = {
+      id: "doc-789",
+      // missing required title and createdAt
+    };
+
+    expect(() => schema.parse(invalidDocument)).toThrow();
+  });
+});


### PR DESCRIPTION
This pull request adds support for resolving OpenAPI response references throughout the client and server code generation logic. Now, when an operation’s response uses a `$ref` to reference a response in the OpenAPI document’s components, the code will properly resolve and use the referenced response definition. This change improves compatibility with OpenAPI specs that use shared responses and ensures correct type generation and response handling.