### PR TITLE
feat: Add specific fetch error handling to client operations 

### DIFF
--- a/apps/craft/src/client-generator/templates/config-templates.ts
+++ b/apps/craft/src/client-generator/templates/config-templates.ts
@@ -149,6 +149,10 @@ export type ApiResponseError = {
       readonly error: unknown;
     }
   | {
+      readonly kind: "fetch-error";
+      readonly error: unknown;
+    }
+  | {
       readonly kind: "unexpected-response";
       readonly result: ApiResponseErrorResult;
       readonly error: string;

--- a/apps/craft/src/client-generator/templates/function-body-templates.ts
+++ b/apps/craft/src/client-generator/templates/function-body-templates.ts
@@ -103,27 +103,40 @@ ${headersContent}
     const url = new URL(\`${finalPath}\`, config.baseURL);
     ${queryParamLines ? `    ${queryParamLines}` : ""}
 
-    const response = await config.fetch(url.toString(), {
-      method: "${method.toUpperCase()}",
-      headers: finalHeaders,${
-        hasBody
-          ? `
-      body: bodyContent,`
-          : ""
-      }
-    });
+    /* Inner try/catch for fetch-specific errors */
+    let response: Response;
+    let data: unknown;
+    let minimalResponse: { status: number; headers: Map<string, string> };
 
-    /*
-     * The response body is consumed immediately to prevent holding onto the raw
-     * response stream. A new, lightweight response object is created with only
-     * the necessary properties, and headers are copied to a Map to break the
-     * reference to the original response object.
-     */
-    const data = await parseResponseBody(response);
-    const minimalResponse = {
-      status: response.status,
-      headers: new Map(response.headers.entries()),
-    };
+    try {
+      response = await config.fetch(url.toString(), {
+        method: "${method.toUpperCase()}",
+        headers: finalHeaders,${
+          hasBody
+            ? `
+        body: bodyContent,`
+            : ""
+        }
+      });
+
+      /*
+       * The response body is consumed immediately to prevent holding onto the raw
+       * response stream. A new, lightweight response object is created with only
+       * the necessary properties, and headers are copied to a Map to break the
+       * reference to the original response object.
+       */
+      data = await parseResponseBody(response);
+      minimalResponse = {
+        status: response.status,
+        headers: new Map(response.headers.entries()),
+      };
+    } catch (error) {
+      return {
+        isValid: false,
+        kind: "fetch-error",
+        error,
+      } as const;
+    }
 
     switch (response.status) {
 ${responseHandlers.join("\n")}

--- a/apps/craft/tests/client-generator/fetch-error-handling.test.ts
+++ b/apps/craft/tests/client-generator/fetch-error-handling.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import { generateOperationFunction } from "../../src/client-generator/operation-function-generator.js";
+
+describe("Fetch Error Handling", () => {
+  it("should generate inner try/catch around fetch request", () => {
+    const pathKey = "/test";
+    const method = "get";
+    const operation = {
+      operationId: "testOperation",
+      responses: {
+        "200": {
+          description: "Success",
+          content: {
+            "application/json": {
+              schema: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const doc = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {},
+    };
+
+    const result = generateOperationFunction(
+      pathKey,
+      method,
+      operation,
+      [],
+      doc,
+    );
+
+    /* Verify inner try/catch structure is present */
+    expect(result.functionCode).toContain(
+      "/* Inner try/catch for fetch-specific errors */",
+    );
+    expect(result.functionCode).toContain("let response: Response;");
+    expect(result.functionCode).toContain("let data: unknown;");
+    expect(result.functionCode).toContain(
+      "let minimalResponse: { status: number; headers: Map<string, string> };",
+    );
+
+    /* Verify fetch is wrapped in inner try/catch */
+    expect(result.functionCode).toContain("try {");
+    expect(result.functionCode).toContain(
+      "response = await config.fetch(url.toString(), {",
+    );
+    expect(result.functionCode).toContain(
+      "data = await parseResponseBody(response);",
+    );
+    expect(result.functionCode).toContain("} catch (error) {");
+
+    /* Verify fetch-error is returned in inner catch */
+    expect(result.functionCode).toContain(`return {
+        isValid: false,
+        kind: "fetch-error",
+        error,
+      } as const;`);
+
+    /* Verify outer try/catch still exists for unexpected errors */
+    expect(result.functionCode).toContain(`return {
+      isValid: false,
+      kind: "unexpected-error",
+      error,
+    } as const;`);
+  });
+
+  it("should handle operation with body correctly", () => {
+    const pathKey = "/test";
+    const method = "post";
+    const operation = {
+      operationId: "testPostOperation",
+      requestBody: {
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Created",
+          content: {
+            "application/json": {
+              schema: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const doc = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {},
+    };
+
+    const result = generateOperationFunction(
+      pathKey,
+      method,
+      operation,
+      [],
+      doc,
+    );
+
+    /* Verify fetch call includes body parameter and is wrapped in inner try/catch */
+    expect(result.functionCode).toContain('method: "POST"');
+    expect(result.functionCode).toContain("body: bodyContent,");
+    expect(result.functionCode).toContain(
+      "/* Inner try/catch for fetch-specific errors */",
+    );
+    expect(result.functionCode).toContain('kind: "fetch-error"');
+  });
+
+  it("should preserve existing error handling for non-fetch errors", () => {
+    const pathKey = "/test";
+    const method = "get";
+    const operation = {
+      operationId: "testOperation",
+      responses: {
+        "200": {
+          description: "Success",
+          content: {
+            "application/json": {
+              schema: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const doc = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {},
+    };
+
+    const result = generateOperationFunction(
+      pathKey,
+      method,
+      operation,
+      [],
+      doc,
+    );
+
+    /* Verify both inner and outer error handling exist */
+    const fetchErrorIndex = result.functionCode.indexOf('kind: "fetch-error"');
+    const unexpectedErrorIndex = result.functionCode.indexOf(
+      'kind: "unexpected-error"',
+    );
+
+    expect(fetchErrorIndex).toBeGreaterThan(-1);
+    expect(unexpectedErrorIndex).toBeGreaterThan(-1);
+    expect(unexpectedErrorIndex).toBeGreaterThan(fetchErrorIndex); // unexpected-error should come after fetch-error
+  });
+});


### PR DESCRIPTION
This pull request improves error handling for API client code generation by introducing a dedicated mechanism for catching and reporting fetch-specific errors. The changes add an inner try/catch block around the fetch request, introduce a new error type for fetch errors, and provide comprehensive tests to ensure correct behavior. These improvements make error handling more robust and allow client code to distinguish between network-related issues and other unexpected errors.