### PR TITLE
Enhance import statements in buildOperationImports function

### DIFF
--- a/apps/craft/CHANGELOG.md
+++ b/apps/craft/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @apical-ts/craft
 
+## 0.0.37
+
+### Patch Changes
+
+- Split imports in generated client operations in order to work with
+  verbatimModuleSyntax
+
 ## 0.0.36
 
 ### Patch Changes

--- a/apps/craft/package.json
+++ b/apps/craft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/craft",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": false,
   "description": "Generates fully-typed Zod v4 schemas and type-safe TypeScript REST API clients and server from OpenAPI 2.0, 3.0.x, and 3.1.x specifications.",
   "main": "dist/index.js",

--- a/apps/craft/src/core-generator/file-writer.ts
+++ b/apps/craft/src/core-generator/file-writer.ts
@@ -119,7 +119,3 @@ export async function writeTypeScriptFile(
     throw new Error(`Failed to write file ${filePath}: ${error}`);
   }
 }
-  } catch (error) {
-    throw new Error(`Failed to write file ${filePath}: ${error}`);
-  }
-}

--- a/apps/craft/src/core-generator/file-writer.ts
+++ b/apps/craft/src/core-generator/file-writer.ts
@@ -71,18 +71,14 @@ export function buildOperationImports(
   const imports: string[] = [];
 
   /* Add type imports from config */
-  if (configTypeImports.length > 0) {
-    imports.push(
-      `import type { ${configTypeImports.join(", ")} } from "./config.js";`,
-    );
-  }
+  imports.push(
+    `import type { ${configTypeImports.join(", ")} } from "./config.js";`,
+  );
 
   /* Add value imports from config */
-  if (configValueImports.length > 0) {
-    imports.push(
-      `import { ${configValueImports.join(", ")} } from "./config.js";`,
-    );
-  }
+  imports.push(
+    `import { ${configValueImports.join(", ")} } from "./config.js";`,
+  );
 
   /* Add Zod import if needed for parameter schemas */
   if (typeImports.has("z")) {
@@ -119,6 +115,10 @@ export async function writeTypeScriptFile(
 ): Promise<void> {
   try {
     await fs.writeFile(filePath, content);
+  } catch (error) {
+    throw new Error(`Failed to write file ${filePath}: ${error}`);
+  }
+}
   } catch (error) {
     throw new Error(`Failed to write file ${filePath}: ${error}`);
   }

--- a/apps/craft/src/core-generator/file-writer.ts
+++ b/apps/craft/src/core-generator/file-writer.ts
@@ -12,14 +12,15 @@ export function buildOperationFileContent(
 }
 
 /**
- * Builds import statements for operation files
+ * Builds import statements for operation files with separate type and value imports
  *
  * @example
  * ```javascript
  * const typeImports = new Set(['User', 'Pet']);
  * const imports = buildOperationImports(typeImports);
  * // Result: [
- * //   "import { globalConfig, GlobalConfig, ApiResponse, parseResponseBody } from './config.js';",
+ * //   "import type { GlobalConfig, ApiResponse, ApiResponseError } from './config.js';",
+ * //   "import { globalConfig, parseResponseBody, parseApiResponseUnknownData } from './config.js';",
  * //   "import { User } from '../schemas/User.js';",
  * //   "import { Pet } from '../schemas/Pet.js';",
  * // ]
@@ -29,59 +30,69 @@ export function buildOperationImports(
   typeImports: Set<string>,
   functionCode?: string,
 ): string[] {
-  /* Determine which config types are needed based on function content */
-  const configImports = [
+  /* Categorize config imports into types and runtime values */
+  const configTypeImports = ["GlobalConfig", "ApiResponse", "ApiResponseError"];
+  const configValueImports = [
     "globalConfig",
-    "GlobalConfig",
-    "ApiResponse",
     "parseResponseBody",
     "parseApiResponseUnknownData",
-    "ApiResponseError",
   ];
 
   /* Add ApiResponseWithParse if used in the function */
   if (functionCode && functionCode.includes("ApiResponseWithParse")) {
-    configImports.push("ApiResponseWithParse");
+    configTypeImports.push("ApiResponseWithParse");
   }
 
   /* Add ApiResponseWithForcedParse if used in the function */
   if (functionCode && functionCode.includes("ApiResponseWithForcedParse")) {
-    configImports.push("ApiResponseWithForcedParse");
+    configTypeImports.push("ApiResponseWithForcedParse");
   }
 
   /* Add createForcedParseResponse helper function if used */
   if (functionCode && functionCode.includes("createForcedParseResponse")) {
-    configImports.push("createForcedParseResponse");
+    configValueImports.push("createForcedParseResponse");
   }
 
   /* Add formUrlEncode helper import when operation body handling uses urlencoded serialization */
   if (functionCode && functionCode.includes("formUrlEncode(")) {
-    configImports.push("formUrlEncode");
+    configValueImports.push("formUrlEncode");
   }
 
   /* Add buildFormData helper import when multipart/form-data handling is used */
   if (functionCode && functionCode.includes("buildFormData(")) {
-    configImports.push("buildFormData");
+    configValueImports.push("buildFormData");
   }
 
   /* RequestBody alias used by generated operation body typing */
   if (functionCode && functionCode.includes("RequestBody")) {
-    configImports.push("RequestBody");
+    configTypeImports.push("RequestBody");
   }
 
-  const imports = [
-    `import { ${configImports.join(", ")} } from './config.js';`,
-  ];
+  const imports: string[] = [];
+
+  /* Add type imports from config */
+  if (configTypeImports.length > 0) {
+    imports.push(
+      `import type { ${configTypeImports.join(", ")} } from "./config.js";`,
+    );
+  }
+
+  /* Add value imports from config */
+  if (configValueImports.length > 0) {
+    imports.push(
+      `import { ${configValueImports.join(", ")} } from "./config.js";`,
+    );
+  }
 
   /* Add Zod import if needed for parameter schemas */
   if (typeImports.has("z")) {
-    imports.push(`import { z } from 'zod';`);
+    imports.push(`import { z } from "zod";`);
   }
 
   /* Add schema imports */
   const schemaImports = Array.from(typeImports)
     .filter((type) => type !== "z") // Exclude Zod import
-    .map((type) => `import { ${type} } from '../schemas/${type}.js';`);
+    .map((type) => `import { ${type} } from "../schemas/${type}.js";`);
 
   imports.push(...schemaImports);
 


### PR DESCRIPTION
Separate type and value imports in the generated client operations to improve compatibility with verbatim module syntax. 

Fix #24 