### PR TITLE
Fix getResponseContentType function and update version to 0.0.38

### DIFF
--- a/apps/craft/CHANGELOG.md
+++ b/apps/craft/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @apical-ts/craft
 
+## 0.0.38
+
+### Patch Changes
+
+- Fix unsafe access in getResponseContentType
+
 ## 0.0.37
 
 ### Patch Changes

--- a/apps/craft/package.json
+++ b/apps/craft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/craft",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "private": false,
   "description": "Generates fully-typed Zod v4 schemas and type-safe TypeScript REST API clients and server from OpenAPI 2.0, 3.0.x, and 3.1.x specifications.",
   "main": "dist/index.js",

--- a/apps/craft/src/client-generator/templates/config-templates.ts
+++ b/apps/craft/src/client-generator/templates/config-templates.ts
@@ -534,7 +534,9 @@ export function renderResponseParsingUtilities(): string {
 /* Normalize Content-Type header */
 export function getResponseContentType(response: MinimalResponse): string {
   const raw = response.headers.get("content-type");
-  return raw ? raw.split(";")[0].trim().toLowerCase() : "";
+  if (!raw) return "";
+  const firstPart = raw.split(";")[0];
+  return firstPart ? firstPart.trim().toLowerCase() : "";
 }`;
 }
 


### PR DESCRIPTION
Enhance error handling in the getResponseContentType function to safely manage undefined values. 