### PR TITLE
Keep original names for query and path parameters

### DIFF
--- a/apps/craft/src/client-generator/index.ts
+++ b/apps/craft/src/client-generator/index.ts
@@ -107,4 +107,4 @@ export {
   renderOperationFunction,
 } from "./templates/operation-templates.js";
 
-export { toCamelCase, toValidVariableName } from "./utils.js";
+export { toValidVariableName } from "./utils.js";

--- a/apps/craft/src/client-generator/models/parameter-models.ts
+++ b/apps/craft/src/client-generator/models/parameter-models.ts
@@ -14,8 +14,18 @@ export interface ParameterAnalysis {
     varName: string;
   }[];
   optionalityRules: ParameterOptionalityRules;
-  pathProperties: string[];
-  queryProperties: { isRequired: boolean; name: string }[];
+  pathProperties: {
+    isRequired: boolean;
+    name: string;
+    needsQuoting: boolean;
+    varName: string;
+  }[];
+  queryProperties: {
+    isRequired: boolean;
+    name: string;
+    needsQuoting: boolean;
+    varName: string;
+  }[];
   securityHeaderProperties: {
     headerName: string;
     isRequired: boolean;

--- a/apps/craft/src/client-generator/parameters.ts
+++ b/apps/craft/src/client-generator/parameters.ts
@@ -23,7 +23,7 @@ import {
   renderParameterHandling,
   renderParameterInterface,
 } from "./templates/parameter-templates.js";
-import { toCamelCase, toValidVariableName } from "./utils.js";
+import { toValidVariableName } from "./utils.js";
 
 /* Re-export types for backward compatibility */
 export type {
@@ -58,15 +58,28 @@ export function analyzeParameters(
   const optionalityRules = determineParameterOptionalityRules(structure);
 
   /* Analyze path parameters */
-  const pathProperties = structure.processed.pathParams.map((param) =>
-    toCamelCase(param.name),
-  );
+  const pathProperties = structure.processed.pathParams.map((param) => {
+    const varName = toValidVariableName(param.name);
+    const needsQuoting = param.name !== varName;
+    return {
+      isRequired: param.required === true,
+      name: needsQuoting ? param.name : varName,
+      needsQuoting,
+      varName,
+    };
+  });
 
   /* Analyze query parameters */
-  const queryProperties = structure.processed.queryParams.map((param) => ({
-    isRequired: param.required === true,
-    name: toCamelCase(param.name),
-  }));
+  const queryProperties = structure.processed.queryParams.map((param) => {
+    const varName = toValidVariableName(param.name);
+    const needsQuoting = param.name !== varName;
+    return {
+      isRequired: param.required === true,
+      name: needsQuoting ? param.name : varName,
+      needsQuoting,
+      varName,
+    };
+  });
 
   /* Analyze header parameters */
   const headerProperties = structure.processed.headerParams.map((param) => {

--- a/apps/craft/src/client-generator/parameters.ts
+++ b/apps/craft/src/client-generator/parameters.ts
@@ -56,45 +56,22 @@ export function analyzeParameters(
   );
 
   const optionalityRules = determineParameterOptionalityRules(structure);
+  const { headerParams, pathParams, queryParams } = structure.processed;
 
-  /* Analyze path parameters */
-  const pathProperties = structure.processed.pathParams.map((param) => {
-    const varName = toValidVariableName(param.name);
-    const needsQuoting = param.name !== varName;
-    return {
-      isRequired: param.required === true,
-      name: needsQuoting ? param.name : varName,
-      needsQuoting,
-      varName,
-    };
-  });
+  const analyzeParameterGroup = (params: ParameterObject[]) =>
+    params.map((param) => {
+      const varName = toValidVariableName(param.name);
+      return {
+        isRequired: param.required === true,
+        name: param.name,
+        needsQuoting: param.name !== varName,
+        varName,
+      };
+    });
 
-  /* Analyze query parameters */
-  const queryProperties = structure.processed.queryParams.map((param) => {
-    const varName = toValidVariableName(param.name);
-    const needsQuoting = param.name !== varName;
-    return {
-      isRequired: param.required === true,
-      name: needsQuoting ? param.name : varName,
-      needsQuoting,
-      varName,
-    };
-  });
-
-  /* Analyze header parameters */
-  const headerProperties = structure.processed.headerParams.map((param) => {
-    const varName = toValidVariableName(param.name);
-    /*
-     * Use the variable name directly for the property name when quoting is not required.
-     */
-    const needsQuoting = param.name !== varName;
-    return {
-      isRequired: param.required === true,
-      name: needsQuoting ? param.name : varName,
-      needsQuoting,
-      varName,
-    };
-  });
+  const pathProperties = analyzeParameterGroup(pathParams);
+  const queryProperties = analyzeParameterGroup(queryParams);
+  const headerProperties = analyzeParameterGroup(headerParams);
 
   /* Analyze security headers */
   const securityHeaderProperties = structure.processed.securityHeaders.map(

--- a/apps/craft/src/client-generator/templates/parameter-templates.ts
+++ b/apps/craft/src/client-generator/templates/parameter-templates.ts
@@ -2,7 +2,7 @@ import type { ParameterObject } from "openapi3-ts/oas31";
 
 import type { ParameterAnalysis } from "../models/parameter-models.js";
 
-import { toCamelCase, toValidVariableName } from "../utils.js";
+import { toValidVariableName } from "../utils.js";
 
 /**
  * Renders destructured parameters for function signature
@@ -15,12 +15,27 @@ export function renderDestructuredParameters(
 
   // Path parameters
   if (structure.processed.pathParams.length > 0) {
-    destructureParams.push(`path: { ${analysis.pathProperties.join(", ")} }`);
+    const pathProperties: string[] = [];
+    analysis.pathProperties.forEach((prop) => {
+      if (prop.needsQuoting) {
+        pathProperties.push(`"${prop.name}": ${prop.varName}`);
+      } else {
+        pathProperties.push(`${prop.varName}`);
+      }
+    });
+    destructureParams.push(`path: { ${pathProperties.join(", ")} }`);
   }
 
   // Query parameters
   if (structure.processed.queryParams.length > 0) {
-    const queryProperties = analysis.queryProperties.map((prop) => prop.name);
+    const queryProperties: string[] = [];
+    analysis.queryProperties.forEach((prop) => {
+      if (prop.needsQuoting) {
+        queryProperties.push(`"${prop.name}": ${prop.varName}`);
+      } else {
+        queryProperties.push(`${prop.varName}`);
+      }
+    });
     const defaultValue = analysis.optionalityRules.isQueryOptional
       ? " = {}"
       : "";
@@ -98,7 +113,7 @@ export function renderParameterHandling(
   } else {
     return params
       .map((p) => {
-        const varName = toCamelCase(p.name);
+        const varName = toValidVariableName(p.name);
         return `if (${varName} !== undefined) url.searchParams.append('${p.name}', String(${varName}));`;
       })
       .join("\n    ");
@@ -114,17 +129,29 @@ export function renderParameterInterface(analysis: ParameterAnalysis): string {
 
   // Path parameters section (never optional if present)
   if (structure.processed.pathParams.length > 0) {
-    const pathProperties = analysis.pathProperties.map(
-      (name) => `${name}: string`,
-    );
+    const pathProperties: string[] = [];
+    analysis.pathProperties.forEach((prop) => {
+      const requiredMarker = prop.isRequired ? "" : "?";
+      if (prop.needsQuoting) {
+        pathProperties.push(`"${prop.name}"${requiredMarker}: string`);
+      } else {
+        pathProperties.push(`${prop.varName}${requiredMarker}: string`);
+      }
+    });
     sections.push(`path: {\n    ${pathProperties.join(";\n    ")};\n  }`);
   }
 
   // Query parameters section
   if (structure.processed.queryParams.length > 0) {
-    const queryProperties = analysis.queryProperties.map(
-      (prop) => `${prop.name}${prop.isRequired ? "" : "?"}: string`,
-    );
+    const queryProperties: string[] = [];
+    analysis.queryProperties.forEach((prop) => {
+      const requiredMarker = prop.isRequired ? "" : "?";
+      if (prop.needsQuoting) {
+        queryProperties.push(`"${prop.name}"${requiredMarker}: string`);
+      } else {
+        queryProperties.push(`${prop.varName}${requiredMarker}: string`);
+      }
+    });
     const optionalMarker = analysis.optionalityRules.isQueryOptional ? "?" : "";
     sections.push(
       `query${optionalMarker}: {\n    ${queryProperties.join(";\n    ")};\n  }`,

--- a/apps/craft/src/client-generator/utils.ts
+++ b/apps/craft/src/client-generator/utils.ts
@@ -115,35 +115,6 @@ export function resolveResponseReference(
 }
 
 /**
- * Converts kebab-case or similar to camelCase.
- * Preserves already camelCased parts.
- */
-export function toCamelCase(str: string): string {
-  // Split on non-alphanumeric characters (-, _, spaces, etc.) and remove empty parts
-  const parts = str.split(/[^a-zA-Z0-9]+/).filter(Boolean);
-  if (parts.length === 0) return "";
-
-  // If only one part (no separators), preserve original casing but ensure first char is lowercase
-  if (parts.length === 1) {
-    const first = parts[0];
-    return first.charAt(0).toLowerCase() + first.slice(1);
-  }
-
-  // Take the first part and lowercase it entirely
-  const first = parts[0];
-  const firstLower = first.toLowerCase();
-
-  // For subsequent parts, capitalize first letter and lowercase the rest
-  return (
-    firstLower +
-    parts
-      .slice(1)
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-      .join("")
-  );
-}
-
-/**
  * Creates a valid JavaScript variable name from any string
  */
 export function toValidVariableName(str: string): string {

--- a/apps/craft/src/client-generator/utils.ts
+++ b/apps/craft/src/client-generator/utils.ts
@@ -19,7 +19,7 @@ export function generatePathInterpolation(
 ): string {
   let finalPath = pathKey;
   for (const param of pathParams) {
-    const varName = toCamelCase(param.name);
+    const varName = toValidVariableName(param.name);
     finalPath = finalPath.replace(`{${param.name}}`, `\${${varName}}`);
   }
   return finalPath;

--- a/apps/craft/tests/client-generator/parameter-models.test.ts
+++ b/apps/craft/tests/client-generator/parameter-models.test.ts
@@ -86,7 +86,12 @@ describe("parameter logic functions", () => {
       const result = determineParameterStructure(
         sampleParameterGroups,
         true,
-        { typeName: "UserCreateRequest", isRequired: true },
+        {
+          typeName: "UserCreateRequest",
+          isRequired: true,
+          contentType: "application/json",
+          typeImports: new Set(),
+        },
         undefined,
         true,
         false,
@@ -107,7 +112,12 @@ describe("parameter logic functions", () => {
       const structure = determineParameterStructure(
         sampleParameterGroups,
         true,
-        { typeName: "UserCreateRequest", isRequired: false },
+        {
+          typeName: "UserCreateRequest",
+          isRequired: false,
+          contentType: "application/json",
+          typeImports: new Set(),
+        },
       );
 
       const rules = determineParameterOptionalityRules(structure);
@@ -123,11 +133,25 @@ describe("parameter logic functions", () => {
       const analysis = analyzeParameters(sampleParameterGroups, true, {
         typeName: "UserCreateRequest",
         isRequired: true,
+        contentType: "application/json",
+        typeImports: new Set(),
       });
 
-      expect(analysis.pathProperties).toEqual(["userId"]);
+      expect(analysis.pathProperties).toEqual([
+        {
+          name: "userId",
+          isRequired: true,
+          varName: "userId",
+          needsQuoting: false,
+        },
+      ]);
       expect(analysis.queryProperties).toEqual([
-        { name: "filter", isRequired: false },
+        {
+          name: "filter",
+          isRequired: false,
+          varName: "filter",
+          needsQuoting: false,
+        },
       ]);
       expect(analysis.headerProperties).toEqual([
         {

--- a/apps/craft/tests/client-generator/parameter-templates.test.ts
+++ b/apps/craft/tests/client-generator/parameter-templates.test.ts
@@ -47,7 +47,20 @@ describe("parameter template functions", () => {
 
     it("should render path parameters correctly", () => {
       const analysis = createBasicAnalysis({
-        pathProperties: ["userId", "projectId"],
+        pathProperties: [
+          {
+            name: "userId",
+            isRequired: true,
+            varName: "userId",
+            needsQuoting: false,
+          },
+          {
+            name: "projectId",
+            isRequired: true,
+            varName: "projectId",
+            needsQuoting: false,
+          },
+        ],
         structure: {
           ...createBasicAnalysis().structure,
           processed: {
@@ -79,8 +92,18 @@ describe("parameter template functions", () => {
     it("should render query parameters with optionality", () => {
       const analysis = createBasicAnalysis({
         queryProperties: [
-          { name: "filter", isRequired: true },
-          { name: "sort", isRequired: false },
+          {
+            name: "filter",
+            isRequired: true,
+            varName: "filter",
+            needsQuoting: false,
+          },
+          {
+            name: "sort",
+            isRequired: false,
+            varName: "sort",
+            needsQuoting: false,
+          },
         ],
         optionalityRules: {
           ...createBasicAnalysis().optionalityRules,
@@ -197,7 +220,12 @@ describe("parameter template functions", () => {
         structure: {
           ...createBasicAnalysis().structure,
           hasBody: true,
-          bodyTypeInfo: { typeName: "UserCreateRequest", isRequired: true },
+          bodyTypeInfo: {
+            typeName: "UserCreateRequest",
+            isRequired: true,
+            contentType: "application/json",
+            typeImports: new Set(),
+          },
         },
         optionalityRules: {
           ...createBasicAnalysis().optionalityRules,
@@ -236,7 +264,20 @@ describe("parameter template functions", () => {
 
     it("should render destructured path parameters", () => {
       const analysis = createBasicAnalysis({
-        pathProperties: ["userId", "projectId"],
+        pathProperties: [
+          {
+            name: "userId",
+            isRequired: true,
+            varName: "userId",
+            needsQuoting: false,
+          },
+          {
+            name: "projectId",
+            isRequired: true,
+            varName: "projectId",
+            needsQuoting: false,
+          },
+        ],
         structure: {
           ...createBasicAnalysis().structure,
           processed: {
@@ -259,7 +300,14 @@ describe("parameter template functions", () => {
 
     it("should render destructured query parameters with defaults", () => {
       const analysis = createBasicAnalysis({
-        queryProperties: [{ name: "filter", isRequired: false }],
+        queryProperties: [
+          {
+            name: "filter",
+            isRequired: false,
+            varName: "filter",
+            needsQuoting: false,
+          },
+        ],
         structure: {
           ...createBasicAnalysis().structure,
           processed: {
@@ -315,7 +363,12 @@ describe("parameter template functions", () => {
         structure: {
           ...createBasicAnalysis().structure,
           hasBody: true,
-          bodyTypeInfo: { typeName: "UserCreateRequest", isRequired: false },
+          bodyTypeInfo: {
+            typeName: "UserCreateRequest",
+            isRequired: false,
+            contentType: "application/json",
+            typeImports: new Set(),
+          },
         },
       });
 

--- a/apps/craft/tests/client-generator/utils.test.ts
+++ b/apps/craft/tests/client-generator/utils.test.ts
@@ -5,55 +5,10 @@ import { describe, expect, it } from "vitest";
 import {
   generatePathInterpolation,
   getResponseContentType,
-  toCamelCase,
   toValidVariableName,
 } from "../../src/client-generator/utils.js";
 
 describe("client-generator utils", () => {
-  describe("toCamelCase", () => {
-    it("should convert kebab-case to camelCase", () => {
-      expect(toCamelCase("hello-world")).toBe("helloWorld");
-      expect(toCamelCase("user-profile-data")).toBe("userProfileData");
-      expect(toCamelCase("api-key")).toBe("apiKey");
-    });
-
-    it("should handle single word", () => {
-      expect(toCamelCase("hello")).toBe("hello");
-    });
-
-    it("should handle empty string", () => {
-      expect(toCamelCase("")).toBe("");
-    });
-
-    it("should handle string without hyphens", () => {
-      expect(toCamelCase("alreadyCamelCase")).toBe("alreadyCamelCase");
-    });
-
-    it("should handle multiple consecutive hyphens", () => {
-      expect(toCamelCase("test--case")).toBe("testCase");
-    });
-
-    it("should handle hyphens at start and end", () => {
-      expect(toCamelCase("-test-case-")).toBe("testCase");
-    });
-
-    it("should handle uppercase letters after hyphens", () => {
-      expect(toCamelCase("test-Case")).toBe("testCase");
-    });
-
-    it("should handle all uppercase input", () => {
-      expect(toCamelCase("TEST-CASE")).toBe("testCase");
-    });
-
-    it("should handle numbers in input", () => {
-      expect(toCamelCase("test-123-case")).toBe("test123Case");
-    });
-
-    it("should handle only separators", () => {
-      expect(toCamelCase("---")).toBe("");
-    });
-  });
-
   describe("toValidVariableName", () => {
     it("should convert special characters to valid variable name", () => {
       expect(toValidVariableName("hello@world.com")).toBe("helloWorldCom");

--- a/apps/craft/tests/integrations/fixtures/test.yaml
+++ b/apps/craft/tests/integrations/fixtures/test.yaml
@@ -301,7 +301,7 @@ paths:
           in: query
           schema:
             type: string
-        - name: headerInlineParam
+        - name: header-InlineParam
           in: header
           schema:
             type: string

--- a/apps/craft/tests/integrations/operations/additional.test.ts
+++ b/apps/craft/tests/integrations/operations/additional.test.ts
@@ -158,7 +158,7 @@ describe("Additional Operations", () => {
       const response = await client.testParametersAtPathLevel({
         query: {
           cursor: "test-cursor-value",
-          requestId: "test-request-123",
+          "request-id": "test-request-123",
         },
       });
 

--- a/apps/craft/tests/integrations/operations/parameters.test.ts
+++ b/apps/craft/tests/integrations/operations/parameters.test.ts
@@ -132,15 +132,15 @@ describe("Parameters Operations", () => {
       const client = createAuthenticatedClient(baseURL, "customToken");
       const params = {
         headers: {
-          headerInlineParam: sampleData.headerParams.headerInlineParam,
+          "header-InlineParam": sampleData.headerParams.headerInlineParam,
           "x-header-param": sampleData.headerParams["x-header-param"],
         },
         path: {
-          pathParam: sampleData.pathParams["path-param"],
+          "path-param": sampleData.pathParams["path-param"],
         },
         query: {
-          fooBar: "test-underscore-param",
-          requestId: sampleData.headerParams["request-id"],
+          foo_bar: "test-underscore-param",
+          "request-id": sampleData.headerParams["request-id"],
         },
       };
 
@@ -157,11 +157,11 @@ describe("Parameters Operations", () => {
       const params = {
         // fooBar is optional, not providing it
         headers: {
-          headerInlineParam: sampleData.headerParams.headerInlineParam,
+          "header-InlineParam": sampleData.headerParams.headerInlineParam,
           "x-header-param": sampleData.headerParams["x-header-param"],
         },
         path: {
-          pathParam: sampleData.pathParams["path-param"],
+          "path-param": sampleData.pathParams["path-param"],
         },
       };
 
@@ -261,7 +261,7 @@ describe("Parameters Operations", () => {
       const params = {
         query: {
           cursor: sampleData.queryParams.cursor,
-          requestId: sampleData.headerParams["request-id"],
+          "request-id": sampleData.headerParams["request-id"],
         },
       };
 


### PR DESCRIPTION
Introduce new properties for path and query parameters, including `needsQuoting` and `varName`, to improve parameter handling and validation. Update related tests and templates to accommodate these changes.