### PR TITLE
Refactor parameter handling to use unified params object

### DIFF
--- a/apps/craft/src/client-generator/code-generation.ts
+++ b/apps/craft/src/client-generator/code-generation.ts
@@ -83,7 +83,7 @@ export function generateFunctionBody({
       bodyContentCode = renderContentTypeSwitch(requestContentTypes || []);
     } else {
       // Single content type operation - generate simple body content
-      bodyContentCode = `  const bodyContent = body ? JSON.stringify(body) : undefined;`;
+      bodyContentCode = `  const bodyContent = params.body ? JSON.stringify(params.body) : undefined;`;
     }
   }
 

--- a/apps/craft/src/client-generator/templates/function-body-templates.ts
+++ b/apps/craft/src/client-generator/templates/function-body-templates.ts
@@ -39,13 +39,13 @@ export function determineFunctionBodyStructure(
   if (shouldGenerateRequestMap) {
     const defaultReq =
       contentTypeMaps.defaultRequestContentType || "application/json";
-    contentTypeLogic += `  const finalRequestContentType = contentType?.request || "${defaultReq}";\n`;
+    contentTypeLogic += `  const finalRequestContentType = params.contentType?.request || "${defaultReq}";\n`;
   }
 
   if (shouldGenerateResponseMap) {
     const defaultRespValue =
       contentTypeMaps.defaultResponseContentType || "application/json";
-    acceptHeaderLogic = `    "Accept": contentType?.response || "${defaultRespValue}",`;
+    acceptHeaderLogic = `    "Accept": params.contentType?.response || "${defaultRespValue}",`;
   }
 
   return {

--- a/apps/craft/src/client-generator/templates/parameter-templates.ts
+++ b/apps/craft/src/client-generator/templates/parameter-templates.ts
@@ -2,99 +2,33 @@ import type { ParameterObject } from "openapi3-ts/oas31";
 
 import type { ParameterAnalysis } from "../models/parameter-models.js";
 
-import { toValidVariableName } from "../utils.js";
-
 /**
- * Renders destructured parameters for function signature
+ * Renders simple parameters for function signature (no destructuring to avoid duplicate identifiers)
  */
 export function renderDestructuredParameters(
   analysis: ParameterAnalysis,
 ): string {
-  const destructureParams: string[] = [];
+  const params: string[] = [];
   const { structure } = analysis;
 
-  // Path parameters
-  if (structure.processed.pathParams.length > 0) {
-    const pathProperties: string[] = [];
-    analysis.pathProperties.forEach((prop) => {
-      if (prop.needsQuoting) {
-        pathProperties.push(`"${prop.name}": ${prop.varName}`);
-      } else {
-        pathProperties.push(`${prop.varName}`);
-      }
-    });
-    destructureParams.push(`path: { ${pathProperties.join(", ")} }`);
-  }
-
-  // Query parameters
-  if (structure.processed.queryParams.length > 0) {
-    const queryProperties: string[] = [];
-    analysis.queryProperties.forEach((prop) => {
-      if (prop.needsQuoting) {
-        queryProperties.push(`"${prop.name}": ${prop.varName}`);
-      } else {
-        queryProperties.push(`${prop.varName}`);
-      }
-    });
-    const defaultValue = analysis.optionalityRules.isQueryOptional
-      ? " = {}"
-      : "";
-    destructureParams.push(
-      `query: { ${queryProperties.join(", ")} }${defaultValue}`,
-    );
-  }
-
-  // Header parameters
+  // Add single params parameter for all parameter types
   if (
+    structure.processed.pathParams.length > 0 ||
+    structure.processed.queryParams.length > 0 ||
     structure.processed.headerParams.length > 0 ||
-    structure.processed.securityHeaders.length > 0
+    structure.processed.securityHeaders.length > 0 ||
+    structure.hasBody ||
+    structure.hasRequestMap ||
+    structure.hasResponseMap
   ) {
-    const headerProperties: string[] = [];
-
-    // Regular header parameters
-    analysis.headerProperties.forEach((prop) => {
-      if (prop.needsQuoting) {
-        headerProperties.push(`"${prop.name}": ${prop.varName}`);
-      } else {
-        /* Use the derived variable name so that later header handling code
-         * refers to the correct (possibly camelCased) identifier. */
-        headerProperties.push(`${prop.varName}`);
-      }
-    });
-
-    // Security headers
-    analysis.securityHeaderProperties.forEach((prop) => {
-      headerProperties.push(`"${prop.headerName}": ${prop.varName}`);
-    });
-
-    const defaultValue = analysis.optionalityRules.isHeadersOptional
-      ? " = {}"
-      : "";
-    destructureParams.push(
-      `headers: { ${headerProperties.join(", ")} }${defaultValue}`,
-    );
+    params.push("params");
   }
 
-  // Body parameter
-  if (structure.hasBody && structure.bodyTypeInfo) {
-    const defaultValue = structure.bodyTypeInfo.isRequired
-      ? ""
-      : " = undefined";
-    destructureParams.push(`body${defaultValue}`);
-  }
-
-  // ContentType parameter
-  if (structure.hasRequestMap || structure.hasResponseMap) {
-    destructureParams.push("contentType = {}");
-  }
-
-  return destructureParams.length > 0
-    ? `{ ${destructureParams.join(", ")} }`
-    : "{}";
+  return params.length > 0 ? params[0] : "{}";
 }
 
 /**
- * Renders parameter handling code for headers
+ * Renders parameter handling code for headers and queries using bracket notation
  */
 export function renderParameterHandling(
   paramType: "header" | "query",
@@ -104,90 +38,44 @@ export function renderParameterHandling(
 
   if (paramType === "header") {
     return params
-      .map((p) => {
-        const varName = toValidVariableName(p.name);
-        // Use the sanitized variable name on the LHS, original header string as key
-        return `if (${varName} !== undefined) finalHeaders['${p.name}'] = String(${varName});`;
-      })
+      .map(
+        (p) =>
+          `if (params.headers?.["${p.name}"] !== undefined) finalHeaders['${p.name}'] = String(params.headers["${p.name}"]);`,
+      )
       .join("\n    ");
   } else {
     return params
-      .map((p) => {
-        const varName = toValidVariableName(p.name);
-        return `if (${varName} !== undefined) url.searchParams.append('${p.name}', String(${varName}));`;
-      })
+      .map(
+        (p) =>
+          `if (params.query?.["${p.name}"] !== undefined) url.searchParams.append('${p.name}', String(params.query["${p.name}"]));`,
+      )
       .join("\n    ");
   }
 }
 
 /**
- * Renders TypeScript interface for parameters
+ * Renders TypeScript interface for parameters (using a params object instead of destructuring)
  */
 export function renderParameterInterface(analysis: ParameterAnalysis): string {
   const sections: string[] = [];
   const { structure } = analysis;
 
-  // Path parameters section (never optional if present)
-  if (structure.processed.pathParams.length > 0) {
-    const pathProperties: string[] = [];
-    analysis.pathProperties.forEach((prop) => {
-      const requiredMarker = prop.isRequired ? "" : "?";
-      if (prop.needsQuoting) {
-        pathProperties.push(`"${prop.name}"${requiredMarker}: string`);
-      } else {
-        pathProperties.push(`${prop.varName}${requiredMarker}: string`);
-      }
-    });
-    sections.push(`path: {\n    ${pathProperties.join(";\n    ")};\n  }`);
-  }
-
-  // Query parameters section
-  if (structure.processed.queryParams.length > 0) {
-    const queryProperties: string[] = [];
-    analysis.queryProperties.forEach((prop) => {
-      const requiredMarker = prop.isRequired ? "" : "?";
-      if (prop.needsQuoting) {
-        queryProperties.push(`"${prop.name}"${requiredMarker}: string`);
-      } else {
-        queryProperties.push(`${prop.varName}${requiredMarker}: string`);
-      }
-    });
-    const optionalMarker = analysis.optionalityRules.isQueryOptional ? "?" : "";
-    sections.push(
-      `query${optionalMarker}: {\n    ${queryProperties.join(";\n    ")};\n  }`,
-    );
-  }
-
-  // Header parameters section
-  if (
+  // Check if we need a params object at all
+  const needsParams =
+    structure.processed.pathParams.length > 0 ||
+    structure.processed.queryParams.length > 0 ||
     structure.processed.headerParams.length > 0 ||
-    structure.processed.securityHeaders.length > 0
-  ) {
-    const headerProperties: string[] = [];
+    structure.processed.securityHeaders.length > 0;
 
-    // Regular header parameters
-    analysis.headerProperties.forEach((prop) => {
-      const requiredMarker = prop.isRequired ? "" : "?";
-      if (prop.needsQuoting) {
-        headerProperties.push(`"${prop.name}"${requiredMarker}: string`);
-      } else {
-        /* Use the sanitized variable name consistently */
-        headerProperties.push(`${prop.varName}${requiredMarker}: string`);
-      }
-    });
+  if (needsParams) {
+    const pathSection = renderPathParametersSection(analysis);
+    if (pathSection) sections.push(pathSection);
 
-    // Security headers
-    analysis.securityHeaderProperties.forEach((prop) => {
-      const requiredMarker = prop.isRequired ? "" : "?";
-      headerProperties.push(`"${prop.headerName}"${requiredMarker}: string`);
-    });
+    const querySection = renderQueryParametersSection(analysis);
+    if (querySection) sections.push(querySection);
 
-    const optionalMarker = analysis.optionalityRules.isHeadersOptional
-      ? "?"
-      : "";
-    sections.push(
-      `headers${optionalMarker}: {\n    ${headerProperties.join(";\n    ")};\n  }`,
-    );
+    const headerSection = renderHeaderParametersSection(analysis);
+    if (headerSection) sections.push(headerSection);
   }
 
   // Body parameter
@@ -219,4 +107,71 @@ export function renderParameterInterface(analysis: ParameterAnalysis): string {
   }
 
   return sections.length > 0 ? `{\n  ${sections.join(";\n  ")};\n}` : "{}";
+}
+
+/* Helper functions for rendering parameter sections */
+
+/**
+ * Renders header parameters section for the params interface
+ */
+function renderHeaderParametersSection(
+  analysis: ParameterAnalysis,
+): null | string {
+  const { structure } = analysis;
+  if (
+    structure.processed.headerParams.length === 0 &&
+    structure.processed.securityHeaders.length === 0
+  ) {
+    return null;
+  }
+
+  const headerProperties: string[] = [];
+
+  // Regular header parameters
+  analysis.headerProperties.forEach((prop) => {
+    const requiredMarker = prop.isRequired ? "" : "?";
+    headerProperties.push(`"${prop.name}"${requiredMarker}: string`);
+  });
+
+  // Security headers
+  analysis.securityHeaderProperties.forEach((prop) => {
+    const requiredMarker = prop.isRequired ? "" : "?";
+    headerProperties.push(`"${prop.headerName}"${requiredMarker}: string`);
+  });
+
+  const optionalMarker = analysis.optionalityRules.isHeadersOptional ? "?" : "";
+  return `headers${optionalMarker}: {\n      ${headerProperties.join(";\n      ")};\n    }`;
+}
+
+/**
+ * Renders path parameters section for the params interface
+ */
+function renderPathParametersSection(
+  analysis: ParameterAnalysis,
+): null | string {
+  if (analysis.structure.processed.pathParams.length === 0) return null;
+
+  const pathProperties: string[] = [];
+  analysis.pathProperties.forEach((prop) => {
+    const requiredMarker = prop.isRequired ? "" : "?";
+    pathProperties.push(`"${prop.name}"${requiredMarker}: string`);
+  });
+  return `path: {\n      ${pathProperties.join(";\n      ")};\n    }`;
+}
+
+/**
+ * Renders query parameters section for the params interface
+ */
+function renderQueryParametersSection(
+  analysis: ParameterAnalysis,
+): null | string {
+  if (analysis.structure.processed.queryParams.length === 0) return null;
+
+  const queryProperties: string[] = [];
+  analysis.queryProperties.forEach((prop) => {
+    const requiredMarker = prop.isRequired ? "" : "?";
+    queryProperties.push(`"${prop.name}"${requiredMarker}: string`);
+  });
+  const optionalMarker = analysis.optionalityRules.isQueryOptional ? "?" : "";
+  return `query${optionalMarker}: {\n      ${queryProperties.join(";\n      ")};\n    }`;
 }

--- a/apps/craft/src/client-generator/templates/request-body-templates.ts
+++ b/apps/craft/src/client-generator/templates/request-body-templates.ts
@@ -11,33 +11,35 @@ import type {
 /* Default content type handling strategies */
 export const DEFAULT_CONTENT_TYPE_HANDLERS: ContentTypeHandlerConfig = {
   "application/json": {
-    bodyProcessing: "body ? JSON.stringify(body) : undefined",
+    bodyProcessing: "params.body ? JSON.stringify(params.body) : undefined",
     contentTypeHeader: '"Content-Type": "application/json"',
     requiresFormData: false,
   },
   "application/octet-stream": {
-    bodyProcessing: "body",
+    bodyProcessing: "params.body",
     contentTypeHeader: '"Content-Type": "application/octet-stream"',
     requiresFormData: false,
   },
   "application/x-www-form-urlencoded": {
     bodyProcessing:
-      "body ? formUrlEncode(body, { arrayFormat: 'repeat' }) : undefined",
+      "params.body ? formUrlEncode(params.body, { arrayFormat: 'repeat' }) : undefined",
     contentTypeHeader: '"Content-Type": "application/x-www-form-urlencoded"',
     requiresFormData: false,
   },
   "application/xml": {
-    bodyProcessing: "typeof body === 'string' ? body : String(body)",
+    bodyProcessing:
+      "typeof params.body === 'string' ? params.body : String(params.body)",
     contentTypeHeader: '"Content-Type": "application/xml"',
     requiresFormData: false,
   },
   "multipart/form-data": {
-    bodyProcessing: "buildFormData(body)",
+    bodyProcessing: "buildFormData(params.body)",
     contentTypeHeader: "",
     requiresFormData: true,
   },
   "text/plain": {
-    bodyProcessing: "typeof body === 'string' ? body : String(body)",
+    bodyProcessing:
+      "typeof params.body === 'string' ? params.body : String(params.body)",
     contentTypeHeader: '"Content-Type": "text/plain"',
     requiresFormData: false,
   },
@@ -87,7 +89,7 @@ export function renderContentTypeSwitch(requestContentTypes: string[]): string {
       } else {
         /* Generic approach for unknown content types */
         return `    case "${contentType}":
-      bodyContent = typeof body === 'string' ? body : JSON.stringify(body);
+      bodyContent = typeof params.body === 'string' ? params.body : JSON.stringify(params.body);
       contentTypeHeader = { "Content-Type": "${contentType}" };
       break;`;
       }
@@ -95,7 +97,7 @@ export function renderContentTypeSwitch(requestContentTypes: string[]): string {
     .join("\n");
 
   const defaultCase = `    default:
-      bodyContent = typeof body === 'string' ? body : JSON.stringify(body);
+      bodyContent = typeof params.body === 'string' ? params.body : JSON.stringify(params.body);
       contentTypeHeader = { "Content-Type": finalRequestContentType };`;
 
   return `  let bodyContent: RequestBody = "";
@@ -130,7 +132,7 @@ export function renderDynamicBodyHandling(
       } else {
         /* Generic approach for unknown content types */
         return `    case "${contentType}":
-      bodyContent = typeof body === 'string' ? body : JSON.stringify(body);
+      bodyContent = typeof params.body === 'string' ? params.body : JSON.stringify(params.body);
       contentTypeHeader = { "Content-Type": "${contentType}" };
       break;`;
       }
@@ -138,7 +140,7 @@ export function renderDynamicBodyHandling(
     .join("\n");
 
   const defaultCase = `    default:
-      bodyContent = typeof body === 'string' ? body : JSON.stringify(body);
+      bodyContent = typeof params.body === 'string' ? params.body : JSON.stringify(params.body);
       contentTypeHeader = { "Content-Type": finalRequestContentType };`;
 
   return `  let bodyContent: RequestBody = "";
@@ -170,7 +172,7 @@ export function renderLegacyRequestBodyHandling(
       /* Fallback for unknown content types */
       const fallbackStrategy: ContentTypeStrategy = {
         bodyProcessing:
-          "typeof body === 'string' ? body : JSON.stringify(body)",
+          "typeof params.body === 'string' ? params.body : JSON.stringify(params.body)",
         contentTypeHeader: `"Content-Type": "${context.requestContentType}"`,
         requiresFormData: false,
       };

--- a/apps/craft/src/client-generator/templates/security-templates.ts
+++ b/apps/craft/src/client-generator/templates/security-templates.ts
@@ -19,7 +19,7 @@ export function renderAuthHeaderValidation(authHeaders: string[]): string {
 }
 
 /**
- * Renders security header handling code from security headers
+ * Renders security header handling code from security headers using bracket notation
  */
 export function renderSecurityHeaderHandling(
   operationSecurityHeaders: SecurityHeader[],
@@ -28,11 +28,10 @@ export function renderSecurityHeaderHandling(
 
   return operationSecurityHeaders
     .map((securityHeader) => {
-      const varName = toValidVariableName(securityHeader.headerName);
       if (securityHeader.isRequired) {
-        return `finalHeaders['${securityHeader.headerName}'] = ${varName};`;
+        return `finalHeaders['${securityHeader.headerName}'] = params.headers["${securityHeader.headerName}"];`;
       } else {
-        return `if (${varName} !== undefined) finalHeaders['${securityHeader.headerName}'] = ${varName};`;
+        return `if (params.headers?.["${securityHeader.headerName}"] !== undefined) finalHeaders['${securityHeader.headerName}'] = params.headers["${securityHeader.headerName}"];`;
       }
     })
     .join("\n    ");

--- a/apps/craft/src/client-generator/utils.ts
+++ b/apps/craft/src/client-generator/utils.ts
@@ -13,7 +13,7 @@ import { isReferenceObject } from "openapi3-ts/oas31";
 import { handleReservedKeyword } from "../shared/reserved-keywords.js";
 
 /**
- * Generates URL path with parameter interpolation
+ * Generates URL path with parameter interpolation using bracket notation
  */
 export function generatePathInterpolation(
   pathKey: string,
@@ -21,8 +21,10 @@ export function generatePathInterpolation(
 ): string {
   let finalPath = pathKey;
   for (const param of pathParams) {
-    const varName = toValidVariableName(param.name);
-    finalPath = finalPath.replace(`{${param.name}}`, `\${${varName}}`);
+    finalPath = finalPath.replace(
+      `{${param.name}}`,
+      `\${params.path["${param.name}"]}`,
+    );
   }
   return finalPath;
 }

--- a/apps/craft/tests/client-generator/function-body-templates.test.ts
+++ b/apps/craft/tests/client-generator/function-body-templates.test.ts
@@ -31,7 +31,7 @@ describe("function-body-templates", () => {
       );
 
       expect(result.contentTypeLogic).toContain(
-        'const finalRequestContentType = contentType?.request || "application/json";',
+        'const finalRequestContentType = params.contentType?.request || "application/json";',
       );
       expect(result.acceptHeaderLogic).toBe("");
     });
@@ -56,7 +56,7 @@ describe("function-body-templates", () => {
       );
 
       expect(result.acceptHeaderLogic).toBe(
-        '    "Accept": contentType?.response || "application/xml",',
+        '    "Accept": params.contentType?.response || "application/xml",',
       );
     });
 
@@ -80,10 +80,10 @@ describe("function-body-templates", () => {
       );
 
       expect(result.contentTypeLogic).toContain(
-        'const finalRequestContentType = contentType?.request || "application/json";',
+        'const finalRequestContentType = params.contentType?.request || "application/json";',
       );
       expect(result.acceptHeaderLogic).toBe(
-        '    "Accept": contentType?.response || "application/xml",',
+        '    "Accept": params.contentType?.response || "application/xml",',
       );
     });
 
@@ -107,10 +107,10 @@ describe("function-body-templates", () => {
       );
 
       expect(result.contentTypeLogic).toContain(
-        'const finalRequestContentType = contentType?.request || "application/json";',
+        'const finalRequestContentType = params.contentType?.request || "application/json";',
       );
       expect(result.acceptHeaderLogic).toBe(
-        '    "Accept": contentType?.response || "application/json",',
+        '    "Accept": params.contentType?.response || "application/json",',
       );
     });
   });

--- a/apps/craft/tests/client-generator/multi-content-type.test.ts
+++ b/apps/craft/tests/client-generator/multi-content-type.test.ts
@@ -134,12 +134,12 @@ describe("Multi-content-type operation function generation", () => {
 
     // Check dynamic content type handling looks for contentType in first parameter
     expect(result.functionCode).toContain(
-      'const finalRequestContentType = contentType?.request || "application/json";',
+      'const finalRequestContentType = params.contentType?.request || "application/json";',
     );
     expect(result.functionCode).toContain("switch (finalRequestContentType)");
     // Accept header now emitted for response negotiation
     expect(result.functionCode).toContain(
-      '"Accept": contentType?.response || "application/json",',
+      '"Accept": params.contentType?.response || "application/json",',
     );
 
     // Check type imports

--- a/apps/craft/tests/client-generator/operation-metadata.test.ts
+++ b/apps/craft/tests/client-generator/operation-metadata.test.ts
@@ -158,11 +158,10 @@ describe("extractOperationMetadata", () => {
     expect(metadata.bodyInfo.requestContentTypes).toEqual([]);
     expect(metadata.bodyInfo.bodyTypeInfo).toBeUndefined();
 
-    /* Parameter structures should include path and query parameters */
-    expect(metadata.parameterStructures.destructuredParams).toContain("path");
-    expect(metadata.parameterStructures.destructuredParams).toContain("query");
+    /* Parameter structures should use simple params approach */
+    expect(metadata.parameterStructures.destructuredParams).toBe("params");
     expect(metadata.parameterStructures.paramsInterface).toContain(
-      "id: string",
+      '"id": string',
     );
   });
 
@@ -217,12 +216,8 @@ describe("extractOperationMetadata", () => {
     expect(metadata.parameterGroups.headerParams).toHaveLength(1);
     expect(metadata.parameterGroups.headerParams[0].name).toBe("version");
 
-    /* Parameter structures should include both path-level and operation parameters */
-    expect(metadata.parameterStructures.destructuredParams).toContain("path");
-    expect(metadata.parameterStructures.destructuredParams).toContain(
-      "headers",
-    );
-    expect(metadata.parameterStructures.destructuredParams).toContain("body");
+    /* Parameter structures should use simple params approach */
+    expect(metadata.parameterStructures.destructuredParams).toBe("params");
   });
 
   it("should handle operation with security schemes", () => {

--- a/apps/craft/tests/client-generator/parameter-templates.test.ts
+++ b/apps/craft/tests/client-generator/parameter-templates.test.ts
@@ -85,8 +85,8 @@ describe("parameter template functions", () => {
 
       const result = renderParameterInterface(analysis);
       expect(result).toContain("path: {");
-      expect(result).toContain("userId: string");
-      expect(result).toContain("projectId: string");
+      expect(result).toContain('"userId": string');
+      expect(result).toContain('"projectId": string');
     });
 
     it("should render query parameters with optionality", () => {
@@ -134,8 +134,8 @@ describe("parameter template functions", () => {
 
       const result = renderParameterInterface(analysis);
       expect(result).toContain("query: {");
-      expect(result).toContain("filter: string");
-      expect(result).toContain("sort?: string");
+      expect(result).toContain('"filter": string');
+      expect(result).toContain('"sort"?: string');
     });
 
     it("should render header parameters with quoting", () => {
@@ -184,7 +184,7 @@ describe("parameter template functions", () => {
       const result = renderParameterInterface(analysis);
       expect(result).toContain("headers: {");
       expect(result).toContain('"Content-Type": string');
-      expect(result).toContain("simpleheader?: string");
+      expect(result).toContain('"simpleheader"?: string');
     });
 
     it("should render security headers", () => {
@@ -295,7 +295,7 @@ describe("parameter template functions", () => {
       });
 
       const result = renderDestructuredParameters(analysis);
-      expect(result).toContain("path: { userId, projectId }");
+      expect(result).toBe("params");
     });
 
     it("should render destructured query parameters with defaults", () => {
@@ -325,7 +325,7 @@ describe("parameter template functions", () => {
       });
 
       const result = renderDestructuredParameters(analysis);
-      expect(result).toContain("query: { filter } = {}");
+      expect(result).toBe("params");
     });
 
     it("should render destructured header parameters with quoting", () => {
@@ -355,7 +355,7 @@ describe("parameter template functions", () => {
       });
 
       const result = renderDestructuredParameters(analysis);
-      expect(result).toContain('"Content-Type": ContentType');
+      expect(result).toBe("params");
     });
 
     it("should render body parameter with default", () => {
@@ -373,7 +373,7 @@ describe("parameter template functions", () => {
       });
 
       const result = renderDestructuredParameters(analysis);
-      expect(result).toContain("body = undefined");
+      expect(result).toBe("params");
     });
   });
 
@@ -396,10 +396,10 @@ describe("parameter template functions", () => {
 
       const result = renderParameterHandling("header", params);
       expect(result).toContain(
-        "if (XAPIKey !== undefined) finalHeaders['X-API-Key'] = String(XAPIKey);",
+        'if (params.headers?.["X-API-Key"] !== undefined) finalHeaders[\'X-API-Key\'] = String(params.headers["X-API-Key"]);',
       );
       expect(result).toContain(
-        "if (ContentType !== undefined) finalHeaders['Content-Type'] = String(ContentType);",
+        'if (params.headers?.["Content-Type"] !== undefined) finalHeaders[\'Content-Type\'] = String(params.headers["Content-Type"]);',
       );
     });
 
@@ -421,10 +421,10 @@ describe("parameter template functions", () => {
 
       const result = renderParameterHandling("query", params);
       expect(result).toContain(
-        "if (filter !== undefined) url.searchParams.append('filter', String(filter));",
+        'if (params.query?.["filter"] !== undefined) url.searchParams.append(\'filter\', String(params.query["filter"]));',
       );
       expect(result).toContain(
-        "if (sortBy !== undefined) url.searchParams.append('sort-by', String(sortBy));",
+        'if (params.query?.["sort-by"] !== undefined) url.searchParams.append(\'sort-by\', String(params.query["sort-by"]));',
       );
     });
 

--- a/apps/craft/tests/client-generator/request-body-analysis.test.ts
+++ b/apps/craft/tests/client-generator/request-body-analysis.test.ts
@@ -66,7 +66,7 @@ describe("Request Body Analysis Functions", () => {
       const strategy = determineContentTypeStrategy("application/json");
 
       expect(strategy.bodyProcessing).toBe(
-        "body ? JSON.stringify(body) : undefined",
+        "params.body ? JSON.stringify(params.body) : undefined",
       );
       expect(strategy.contentTypeHeader).toBe(
         '"Content-Type": "application/json"',
@@ -157,7 +157,7 @@ describe("Request Body Analysis Functions", () => {
       expect(result.isRequired).toBe(true);
       expect(result.contentType).toBe("application/json");
       expect(result.strategy.bodyProcessing).toBe(
-        "body ? JSON.stringify(body) : undefined",
+        "params.body ? JSON.stringify(params.body) : undefined",
       );
       expect(result.typeInfo).toBeDefined();
       expect(result.typeInfo?.typeName).toBe("TestSchema");

--- a/apps/craft/tests/client-generator/request-body-templates.test.ts
+++ b/apps/craft/tests/client-generator/request-body-templates.test.ts
@@ -28,7 +28,9 @@ describe("Request Body Template Functions", () => {
 
       const result = renderBodyHandling(strategy);
 
-      expect(result).toBe("    body: body ? JSON.stringify(body) : undefined,");
+      expect(result).toBe(
+        "    body: params.body ? JSON.stringify(params.body) : undefined,",
+      );
     });
 
     it("should render body handling with custom indentation", () => {
@@ -36,7 +38,9 @@ describe("Request Body Template Functions", () => {
 
       const result = renderBodyHandling(strategy, "  ");
 
-      expect(result).toBe("  body: body ? JSON.stringify(body) : undefined,");
+      expect(result).toBe(
+        "  body: params.body ? JSON.stringify(params.body) : undefined,",
+      );
     });
 
     it("should handle multipart/form-data correctly", () => {
@@ -243,7 +247,7 @@ describe("Request Body Template Functions", () => {
       expect(result).toContain('case "text/plain":');
       expect(result).toContain("default:");
       expect(result).toContain(
-        "bodyContent = typeof body === 'string' ? body : JSON.stringify(body);",
+        "bodyContent = typeof params.body === 'string' ? params.body : JSON.stringify(params.body);",
       );
       expect(result).toContain(
         'contentTypeHeader = { "Content-Type": finalRequestContentType };',
@@ -256,7 +260,7 @@ describe("Request Body Template Functions", () => {
 
       expect(result).toContain('case "application/custom":');
       expect(result).toContain(
-        "bodyContent = typeof body === 'string' ? body : JSON.stringify(body);",
+        "bodyContent = typeof params.body === 'string' ? params.body : JSON.stringify(params.body);",
       );
       expect(result).toContain(
         'contentTypeHeader = { "Content-Type": "application/custom" };',
@@ -279,7 +283,7 @@ describe("Request Body Template Functions", () => {
 
       expect(result).toContain('    case "application/json":');
       expect(result).toContain(
-        "bodyContent = body ? JSON.stringify(body) : undefined;",
+        "bodyContent = params.body ? JSON.stringify(params.body) : undefined;",
       );
       expect(result).toContain(
         'contentTypeHeader = { "Content-Type": "application/json" };',

--- a/apps/craft/tests/client-generator/security-templates.test.ts
+++ b/apps/craft/tests/client-generator/security-templates.test.ts
@@ -19,7 +19,9 @@ describe("client-generator security templates", () => {
       ];
 
       const result = renderSecurityHeaderHandling(headers);
-      expect(result).toBe("finalHeaders['X-API-Key'] = XAPIKey;");
+      expect(result).toBe(
+        "finalHeaders['X-API-Key'] = params.headers[\"X-API-Key\"];",
+      );
     });
 
     it("should render optional header assignment", () => {
@@ -33,7 +35,7 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "if (XAPIKey !== undefined) finalHeaders['X-API-Key'] = XAPIKey;",
+        'if (params.headers?.["X-API-Key"] !== undefined) finalHeaders[\'X-API-Key\'] = params.headers["X-API-Key"];',
       );
     });
 
@@ -53,8 +55,8 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "finalHeaders['X-API-Key'] = XAPIKey;\n" +
-          "    if (Authorization !== undefined) finalHeaders['Authorization'] = Authorization;",
+        "finalHeaders['X-API-Key'] = params.headers[\"X-API-Key\"];\n" +
+          '    if (params.headers?.["Authorization"] !== undefined) finalHeaders[\'Authorization\'] = params.headers["Authorization"];',
       );
     });
 
@@ -69,7 +71,7 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "finalHeaders['X-Custom-Auth-Token'] = XCustomAuthToken;",
+        "finalHeaders['X-Custom-Auth-Token'] = params.headers[\"X-Custom-Auth-Token\"];",
       );
     });
 
@@ -88,7 +90,9 @@ describe("client-generator security templates", () => {
       ];
 
       const result = renderSecurityHeaderHandling(headers);
-      expect(result).toBe("finalHeaders['X-Special@Header'] = XSpecialHeader;");
+      expect(result).toBe(
+        "finalHeaders['X-Special@Header'] = params.headers[\"X-Special@Header\"];",
+      );
     });
   });
 

--- a/apps/craft/tests/client-generator/security.test.ts
+++ b/apps/craft/tests/client-generator/security.test.ts
@@ -352,7 +352,9 @@ describe("client-generator security", () => {
       ];
 
       const result = renderSecurityHeaderHandling(headers);
-      expect(result).toBe("finalHeaders['X-API-Key'] = XAPIKey;");
+      expect(result).toBe(
+        "finalHeaders['X-API-Key'] = params.headers[\"X-API-Key\"];",
+      );
     });
 
     it("should generate optional header assignment", () => {
@@ -366,7 +368,7 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "if (XAPIKey !== undefined) finalHeaders['X-API-Key'] = XAPIKey;",
+        'if (params.headers?.["X-API-Key"] !== undefined) finalHeaders[\'X-API-Key\'] = params.headers["X-API-Key"];',
       );
     });
 
@@ -386,8 +388,8 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "finalHeaders['X-API-Key'] = XAPIKey;\n" +
-          "    if (Authorization !== undefined) finalHeaders['Authorization'] = Authorization;",
+        "finalHeaders['X-API-Key'] = params.headers[\"X-API-Key\"];\n" +
+          '    if (params.headers?.["Authorization"] !== undefined) finalHeaders[\'Authorization\'] = params.headers["Authorization"];',
       );
     });
 
@@ -402,7 +404,7 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "finalHeaders['X-Custom-Auth-Token'] = XCustomAuthToken;",
+        "finalHeaders['X-Custom-Auth-Token'] = params.headers[\"X-Custom-Auth-Token\"];",
       );
     });
 
@@ -421,7 +423,9 @@ describe("client-generator security", () => {
       ];
 
       const result = renderSecurityHeaderHandling(headers);
-      expect(result).toBe("finalHeaders['X-Special@Header'] = XSpecialHeader;");
+      expect(result).toBe(
+        "finalHeaders['X-Special@Header'] = params.headers[\"X-Special@Header\"];",
+      );
     });
   });
 });

--- a/apps/craft/tests/client-generator/utils.test.ts
+++ b/apps/craft/tests/client-generator/utils.test.ts
@@ -61,7 +61,7 @@ describe("client-generator utils", () => {
       ];
 
       const result = generatePathInterpolation("/users/{userId}", pathParams);
-      expect(result).toBe("/users/${userId}");
+      expect(result).toBe('/users/${params.path["userId"]}');
     });
 
     it("should interpolate multiple path parameters", () => {
@@ -74,7 +74,9 @@ describe("client-generator utils", () => {
         "/users/{userId}/posts/{postId}",
         pathParams,
       );
-      expect(result).toBe("/users/${userId}/posts/${postId}");
+      expect(result).toBe(
+        '/users/${params.path["userId"]}/posts/${params.path["postId"]}',
+      );
     });
 
     it("should convert kebab-case parameter names to camelCase", () => {
@@ -87,7 +89,9 @@ describe("client-generator utils", () => {
         "/users/{user-id}/posts/{post-id}",
         pathParams,
       );
-      expect(result).toBe("/users/${userId}/posts/${postId}");
+      expect(result).toBe(
+        '/users/${params.path["user-id"]}/posts/${params.path["post-id"]}',
+      );
     });
 
     it("should handle paths with no parameters", () => {
@@ -119,7 +123,9 @@ describe("client-generator utils", () => {
         "/users/{user_id}/data/{complex-param-name}",
         pathParams,
       );
-      expect(result).toBe("/users/${userId}/data/${complexParamName}"); // Only complex-param-name gets converted
+      expect(result).toBe(
+        '/users/${params.path["user_id"]}/data/${params.path["complex-param-name"]}',
+      ); // Now uses exact param names
     });
   });
 

--- a/apps/craft/tests/integrations/express-server-wrapper.test.ts
+++ b/apps/craft/tests/integrations/express-server-wrapper.test.ts
@@ -183,19 +183,19 @@ describe("Express server wrappers integration", () => {
     const res = await request(base)
       .get("/test-coercion/456/false")
       .set("count-header", "99")
-      .query({ "num-query": "123.5", "flag-query": "true" });
+      .query({ "num-query": "123.5", class: "true" });
     expect(res.status).toBe(200);
     /* Path coercion */
-    expect(res.body.path["int-param"]).toBe(456);
-    expect(typeof res.body.path["int-param"]).toBe("number");
+    expect(res.body.path["class"]).toBe(456);
+    expect(typeof res.body.path["class"]).toBe("number");
     /* stringbool(): should parse 'false' to boolean false */
     expect(res.body.path["bool-param"]).toBe(false);
     expect(typeof res.body.path["bool-param"]).toBe("boolean");
     /* Query coercion */
     expect(res.body.query["num-query"]).toBeCloseTo(123.5);
     expect(typeof res.body.query["num-query"]).toBe("number");
-    expect(res.body.query["flag-query"]).toBe(true);
-    expect(typeof res.body.query["flag-query"]).toBe("boolean");
+    expect(res.body.query["class"]).toBe(true);
+    expect(typeof res.body.query["class"]).toBe("boolean");
     /* Header coercion */
     expect(res.body.headers["count-header"]).toBe(99);
     expect(typeof res.body.headers["count-header"]).toBe("number");

--- a/apps/craft/tests/integrations/fixtures/test.yaml
+++ b/apps/craft/tests/integrations/fixtures/test.yaml
@@ -332,11 +332,11 @@ paths:
           description: "Ok"
         "500":
           description: "Fatal error"
-  /test-coercion/{int-param}/{bool-param}:
+  /test-coercion/{class}/{bool-param}:
     get:
       operationId: testCoercion
       parameters:
-        - name: int-param
+        - name: class
           in: path
           required: true
           schema:
@@ -351,7 +351,7 @@ paths:
           required: true
           schema:
             type: number
-        - name: flag-query
+        - name: class
           in: query
           required: true
           schema:


### PR DESCRIPTION
Update the codebase to utilize a unified `params` object for parameter handling across templates and functions, enhancing consistency and maintainability. Adjust tests accordingly to reflect these changes.