### PR TITLE
Refactor CLI flags for consistency

### DIFF
--- a/.changeset/bumpy-colts-show.md
+++ b/.changeset/bumpy-colts-show.md
@@ -1,0 +1,5 @@
+---
+"@apical-ts/craft": patch
+---
+
+Refactor command line flags

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,10 +96,10 @@ pnpm test
 pnpm start generate -i <openapi-spec> -o <output-dir>
 
 # Generate schemas and client
-pnpm start generate -i <openapi-spec> -o <output-dir> --generate-client
+pnpm start generate -i <openapi-spec> -o <output-dir> --client
 
 # Example with provided test files
-pnpm start generate -i test.yaml -o ./generated --generate-client
+pnpm start generate -i test.yaml -o ./generated --client
 ```
 
 **Note**: Use single command format (`pnpm start generate`) not double-dash
@@ -204,7 +204,7 @@ pnpm format
 ```bash
 pnpm --filter craft generate
 # or use the CLI directly:
-pnpx @apical-ts/craft generate -i <spec> -o <output> --generate-client
+pnpx @apical-ts/craft generate -i <spec> -o <output> --client
 ```
 
 #### Other Useful Tasks
@@ -313,7 +313,7 @@ pnpx @apical-ts/craft generate -i <spec> -o <output> --generate-client
 ```
 <output-dir>/
 ├── package.json                  # Generated package metadata
-├── operations/                   # Client operations (if --generate-client)
+├── operations/                   # Client operations (if --client)
 │   ├── index.ts                  # Operation exports and configuration
 │   ├── config.ts                 # Global configuration types
 │   └── <operationId>.ts          # Individual operation functions

--- a/apps/craft/package.json
+++ b/apps/craft/package.json
@@ -30,7 +30,7 @@
     "test": "vitest run",
     "test:coverage": "vitest --coverage",
     "start": "node dist/index.js",
-    "generate:tests": "node dist/index.js generate -i tests/integrations/fixtures/test.yaml -o tests/integrations/generated --generate-client --generate-server",
+    "generate:tests": "node dist/index.js generate -i tests/integrations/fixtures/test.yaml -o tests/integrations/generated --client --server",
     "prepublishOnly": "pnpm build:docs && pnpm run build",
     "clean": "rm -rf tests/integrations/generated"
   },

--- a/apps/craft/src/index.ts
+++ b/apps/craft/src/index.ts
@@ -20,8 +20,16 @@ program
     "Path to the OpenAPI specification file.",
   )
   .requiredOption("-o, --output <path>", "Path to the output directory.")
-  .option("--generate-client", "Generate the full HTTP client.", false)
-  .option("--generate-server", "Generate server endpoint wrappers.", false)
+  .option(
+    "--generate-client, --client",
+    "Generate the full HTTP client.",
+    false,
+  )
+  .option(
+    "--generate-server, --server",
+    "Generate server endpoint wrappers.",
+    false,
+  )
   // Disable strict validation setting, this should remain strict for the server
   // and loose for the client
   // .option(

--- a/apps/craft/tests/integrations/README.md
+++ b/apps/craft/tests/integrations/README.md
@@ -77,7 +77,7 @@ tests/integrations/
 
 3. Generate the test client (if not already generated):
    ```bash
-   pnpm start generate -i tests/integrations/fixtures/test.yaml -o tests/integrations/generated --generate-client
+   pnpm start generate -i tests/integrations/fixtures/test.yaml -o tests/integrations/generated --client
    ```
 
 ### Run Working Demo

--- a/apps/craft/tests/integrations/typecheck.test.ts
+++ b/apps/craft/tests/integrations/typecheck.test.ts
@@ -30,8 +30,8 @@ describe("generated client + server typecheck", () => {
         specPath,
         "-o",
         generatedDir,
-        "--generate-client",
-        "--generate-server",
+        "--client",
+        "--server",
       ],
       { encoding: "utf-8" },
     );

--- a/apps/examples/README.md
+++ b/apps/examples/README.md
@@ -42,8 +42,7 @@ pnpm generate:examples
 This task will:
 
 - Clean any existing generated code
-- Run the TypeScript OpenAPI generator with both `--generate-server` and
-  `--generate-client` flags
+- Run the TypeScript OpenAPI generator with both `--server` and `--client` flags
 - Create the `generated/` directory with schemas, server wrappers, and client
   functions
 

--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "typecheck:code": "tsc -p tsconfig.examples.json",
-    "generate": "craft generate -i examples.yaml -o generated --generate-server --generate-client",
+    "generate": "craft generate -i examples.yaml -o generated --server --client",
     "clean": "rm -rf generated"
   },
   "author": "gunzip",

--- a/apps/website/docs/cli-usage.md
+++ b/apps/website/docs/cli-usage.md
@@ -27,8 +27,8 @@ Generate schemas and client code from an OpenAPI specification:
 
 ```bash
 npx @apical-ts/craft generate \
-  --generate-server \
-  --generate-client \
+  --server \
+  --client \
   -i https://petstore.swagger.io/v2/swagger.json \
   -o generated
 ```
@@ -37,8 +37,8 @@ This command will:
 
 1. Download the OpenAPI specification from the provided URL
 2. Generate Zod schemas for all data models
-3. Generate client operation functions (if `--generate-client` is specified)
-4. Generate server handler wrappers (if `--generate-server` is specified)
+3. Generate client operation functions (if `--client` is specified)
+4. Generate server handler wrappers (if `--server` is specified)
 5. Output all generated files to the `generated` directory
 
 ## Runtime Dependencies
@@ -60,8 +60,8 @@ OpenAPI specification file changes:
 npm install chokidar-cli @apical-ts/craft
 npm exec -- chokidar-cli openapi.yaml -c \
   "craft generate \
-  --generate-server \
-  --generate-client \
+  --server \
+  --client \
   -i openapi.yaml \
   -o generated"
 ```
@@ -79,10 +79,13 @@ specification.
 
 ### Generation Options
 
-- `--generate-client`: Generate the operation functions for client-side usage
+- `--client`: Generate the operation functions for client-side usage (default:
+  false)
+- `--server`: Generate the operation wrapper functions for server-side usage
   (default: false)
-- `--generate-server`: Generate the operation wrapper functions for server-side
-  usage (default: false)
+
+> **Note**: The long-form flags `--generate-client` and `--generate-server` are
+> deprecated in favor of the shorter `--client` and `--server` aliases.
 
 ## Output Structure
 
@@ -90,8 +93,8 @@ The generated output follows a consistent structure:
 
 ```
 generated/
-├── client/           # Client operation functions (if --generate-client)
-├── server/           # Server handler wrappers (if --generate-server)
+├── client/           # Client operation functions (if --client)
+├── server/           # Server handler wrappers (if --server)
 └── schemas/          # Zod schemas and TypeScript types
 ```
 

--- a/apps/website/docs/conclusion.md
+++ b/apps/website/docs/conclusion.md
@@ -49,7 +49,7 @@ Ready to experience the difference? Get started with @apical-ts/craft:
 
 ```bash
 npx @apical-ts/craft generate \
-  --generate-client \
+  --client \
   -i https://petstore.swagger.io/v2/swagger.json \
   -o ./generated
 ```

--- a/apps/website/docs/generated-architecture.md
+++ b/apps/website/docs/generated-architecture.md
@@ -26,7 +26,7 @@ and purpose of the generated files and directories.
 ```
 <output-dir>/
 ├── package.json                  # Generated package metadata (if enabled)
-├── client/                       # Type-safe API client operations (if --generate-client)
+├── client/                       # Type-safe API client operations (if --client)
 │   ├── index.ts                  # Exports all operation functions and config
 │   ├── config.ts                 # Global configuration types and helpers
 │   └── <operationId>.ts          # Individual operation function for each endpoint

--- a/apps/website/docs/introduction.md
+++ b/apps/website/docs/introduction.md
@@ -43,8 +43,8 @@ Get started with @apical-ts/craft in just a few commands:
 ```bash
 # Generate schemas and client from an OpenAPI specification
 npx @apical-ts/craft generate \
-  --generate-server \
-  --generate-client \
+  --server \
+  --client \
   -i https://petstore.swagger.io/v2/swagger.json \
   -o generated
 

--- a/apps/website/docs/server-routes-wrappers-generation.md
+++ b/apps/website/docs/server-routes-wrappers-generation.md
@@ -7,11 +7,11 @@ Zod schemas and can return only responses of the expected types.
 
 ## How to Generate a Server Route Wrapper
 
-To generate server-side code, use the CLI with the `--generate-server` flag:
+To generate server-side code, use the CLI with the `--server` flag:
 
 ```bash
 npx @apical-ts/craft generate \
-  --generate-server \
+  --server \
   -i https://petstore.swagger.io/v2/swagger.json \
   -o generated
 ```

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -64,7 +64,7 @@ function HomepageHeader() {
             <div className={styles.codeBlockLabel}>CLI</div>
             <CodeBlock
               className={styles.codeBlock}
-              code={`npx @apical-ts/craft generate \\\n -i https://petstore.swagger.io/v2/swagger.json \\\n -o ./generated \\\n --generate-server \\\n --generate-client\n\ncd generated\n\nnpm install && npm run build`}
+              code={`npx @apical-ts/craft generate \\\n -i https://petstore.swagger.io/v2/swagger.json \\\n -o ./generated \\\n --server \\\n --client\n\ncd generated\n\nnpm install && npm run build`}
               language="bash"
             />
           </div>


### PR DESCRIPTION
Update command line flags from `--generate-client` and `--generate-server` to `--client` and `--server` for improved consistency across the CLI interface. Adjust documentation and examples accordingly.