### PR TITLE
Add support for schema descriptions in Zod code generation

### DIFF
--- a/packages/core-utils/src/schema-generator/schema-converter.ts
+++ b/packages/core-utils/src/schema-generator/schema-converter.ts
@@ -29,12 +29,15 @@ import {
 import { handleReferenceWithContext } from "./reference-handlers.js";
 import { handleAllOfSchema, handleUnionSchema } from "./union-types.js";
 import {
+  addDescription,
   analyzeTypeArray,
+  cloneWithoutDescription,
   cloneWithoutNullable,
   inferEffectiveType,
   isNullable,
   mergeImports,
 } from "./utils.js";
+import { SchemaObjectType } from "openapi3-ts/oas30";
 
 /**
  * Converts an OpenAPI schema object to Zod validation code
@@ -61,6 +64,35 @@ export function zodSchemaToCode(
     });
   }
 
+  /* Process the schema and get the base result */
+  const baseResult = processSchemaObject(
+    schema,
+    result,
+    currentSchemaName,
+    extraProps,
+    recursiveContext,
+    resolvedSchemas,
+    schemaContext,
+  );
+
+  /* Add description if present in the schema */
+  baseResult.code = addDescription(baseResult.code, schema.description);
+
+  return baseResult;
+}
+
+/**
+ * Process a SchemaObject and return the Zod code result (without description)
+ */
+function processSchemaObject(
+  schema: SchemaObject,
+  result: ZodSchemaResult,
+  currentSchemaName?: string,
+  extraProps?: ExtraPropsMode,
+  recursiveContext?: RecursiveContext,
+  resolvedSchemas?: ResolvedSchemas,
+  schemaContext?: SchemaContext,
+): ZodSchemaResult {
   const effectiveType = inferEffectiveType(schema);
 
   /* Multi-type (array) declarations */
@@ -146,7 +178,11 @@ function handleMultiTypeArray(
 ): ZodSchemaResult {
   const { isNullable: hasNull, nonNullTypes } = analyzeTypeArray(effectiveType);
   if (nonNullTypes.length === 1 && hasNull) {
-    const clone = { ...schema, type: nonNullTypes[0] };
+    // Strip description - it will be added at the outer level
+    const clone = cloneWithoutDescription({
+      ...schema,
+      type: nonNullTypes[0] as SchemaObjectType,
+    });
     const subResult = zodSchemaToCode(clone as SchemaObject, {
       currentSchemaName,
       extraProps,
@@ -158,14 +194,21 @@ function handleMultiTypeArray(
     mergeImports(result.imports, subResult.imports);
     return result;
   }
+  // Strip description from all type variants - it will be added at the outer level
   const subResults = effectiveType.map((t: string) =>
-    zodSchemaToCode({ ...schema, type: t } as SchemaObject, {
-      currentSchemaName,
-      extraProps,
-      imports: result.imports,
-      recursiveContext,
-      resolvedSchemas,
-    }),
+    zodSchemaToCode(
+      cloneWithoutDescription({
+        ...schema,
+        type: t as SchemaObjectType,
+      }) as SchemaObject,
+      {
+        currentSchemaName,
+        extraProps,
+        imports: result.imports,
+        recursiveContext,
+        resolvedSchemas,
+      },
+    ),
   );
   const schemas = subResults.map((r) => r.code);
   subResults.forEach((r) => mergeImports(result.imports, r.imports));
@@ -182,7 +225,8 @@ function handleNullableSchema(
   resolvedSchemas?: ResolvedSchemas,
   extraProps?: ExtraPropsMode,
 ): ZodSchemaResult {
-  const clone = cloneWithoutNullable(schema);
+  // Strip both nullable and description - description will be added at the outer level
+  const clone = cloneWithoutDescription(cloneWithoutNullable(schema));
   const subResult = zodSchemaToCode(clone, {
     currentSchemaName,
     extraProps,

--- a/packages/core-utils/src/schema-generator/utils.ts
+++ b/packages/core-utils/src/schema-generator/utils.ts
@@ -32,6 +32,21 @@ export function addDefaultValue(code: string, defaultValue: unknown): string {
 }
 
 /**
+ * Add description to zod code if present in schema
+ */
+export function addDescription(
+  code: string,
+  description: string | undefined,
+): string {
+  if (!description) {
+    return code;
+  }
+
+  // Use JSON.stringify to properly escape the description for JavaScript string
+  return `${code}.describe(${JSON.stringify(description)})`;
+}
+
+/**
  * Check if a type array represents a nullable type (e.g., ["string", "null"])
  */
 export function analyzeTypeArray(types: string[]): {
@@ -55,6 +70,16 @@ export function cloneWithoutNullable(schema: SchemaObject): SchemaObject {
   if ("nullable" in clone) {
     delete clone.nullable;
   }
+  return clone;
+}
+
+/**
+ * Create a clone of schema without the description property.
+ * Used when recursively processing the same schema to avoid duplicate .describe() calls.
+ */
+export function cloneWithoutDescription(schema: SchemaObject): SchemaObject {
+  const clone = { ...schema };
+  delete clone.description;
   return clone;
 }
 

--- a/packages/core-utils/src/shared/parameter-schemas.ts
+++ b/packages/core-utils/src/shared/parameter-schemas.ts
@@ -11,7 +11,7 @@ import { isReferenceObject } from "openapi3-ts/oas31";
 import type { ParameterGroups } from "./models/parameter-models.js";
 
 import { zodSchemaToCode } from "../schema-generator/index.js";
-import { sanitizeIdentifier } from "../schema-generator/utils.js";
+import { addDescription, sanitizeIdentifier } from "../schema-generator/utils.js";
 
 /**
  * Options for parameter schema generation, controlling transformations
@@ -85,7 +85,8 @@ export function generateParameterSchemas(
      For servers, applies parameter-specific transformations:
        - Preserve original OpenAPI key verbatim (quoted)
        - Lowercase header parameter keys (Express normalizes)
-       - Coerce primitive number/integer/boolean to accept strings */
+       - Coerce primitive number/integer/boolean to accept strings
+       - Add parameter description via .describe() */
   const buildProp = (originalName: string, param: ParameterObject): string => {
     const schema = param.schema as ReferenceObject | SchemaObject | undefined;
     const isRequired = param.required === true;
@@ -114,6 +115,9 @@ export function generateParameterSchemas(
     } else {
       zodCode = "z.string()";
     }
+
+    /* Add parameter description if present (separate from schema description) */
+    zodCode = addDescription(zodCode, param.description);
 
     if (!isRequired) {
       zodCode = `${zodCode}.optional()`;

--- a/packages/core-utils/tests/zod-schema-to-code.test.ts
+++ b/packages/core-utils/tests/zod-schema-to-code.test.ts
@@ -749,4 +749,212 @@ describe("zodSchemaToCode", () => {
       );
     });
   });
+
+  describe("description handling", () => {
+    it("should add .describe() for string schema with description", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        description: "A user's full name",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.string().describe("A user\'s full name")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse("John Doe").success).toBe(true);
+      expect(zodSchema.description).toBe("A user's full name");
+    });
+
+    it("should add .describe() for number schema with description", () => {
+      const schema: SchemaObject = {
+        type: "number",
+        description: "The user's age in years",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.number().describe("The user\'s age in years")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse(25).success).toBe(true);
+      expect(zodSchema.description).toBe("The user's age in years");
+    });
+
+    it("should add .describe() for boolean schema with description", () => {
+      const schema: SchemaObject = {
+        type: "boolean",
+        description: "Whether the user is active",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.boolean().describe("Whether the user is active")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse(true).success).toBe(true);
+      expect(zodSchema.description).toBe("Whether the user is active");
+    });
+
+    it("should add .describe() for array schema with description", () => {
+      const schema: SchemaObject = {
+        type: "array",
+        items: { type: "string" },
+        description: "List of tags",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.array(z.string()).describe("List of tags")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse(["tag1", "tag2"]).success).toBe(true);
+      expect(zodSchema.description).toBe("List of tags");
+    });
+
+    it("should add .describe() for object schema with description", () => {
+      const schema: SchemaObject = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+        description: "A user profile",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.object({"name": z.string().optional()}).describe("A user profile")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse({ name: "John" }).success).toBe(true);
+      expect(zodSchema.description).toBe("A user profile");
+    });
+
+    it("should add .describe() for nullable schema with description", () => {
+      const schema: SchemaObject = {
+        type: ["string", "null"],
+        description: "Optional nickname",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('(z.string()).nullable().describe("Optional nickname")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse("Nick").success).toBe(true);
+      expect(zodSchema.safeParse(null).success).toBe(true);
+      expect(zodSchema.description).toBe("Optional nickname");
+    });
+
+    it("should add .describe() for OpenAPI 3.0 nullable schema with description", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        nullable: true,
+        description: "Optional nickname",
+      } as SchemaObject;
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('(z.string()).nullable().describe("Optional nickname")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse("Nick").success).toBe(true);
+      expect(zodSchema.safeParse(null).success).toBe(true);
+      expect(zodSchema.description).toBe("Optional nickname");
+    });
+
+    it("should add .describe() for enum schema with description", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        enum: ["active", "inactive", "pending"],
+        description: "User account status",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.enum(["active", "inactive", "pending"]).describe("User account status")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse("active").success).toBe(true);
+      expect(zodSchema.description).toBe("User account status");
+    });
+
+    it("should add .describe() for const schema with description", () => {
+      const schema: SchemaObject = {
+        const: "fixed-value",
+        description: "A constant value",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.literal("fixed-value").describe("A constant value")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.safeParse("fixed-value").success).toBe(true);
+      expect(zodSchema.description).toBe("A constant value");
+    });
+
+    it("should properly escape special characters in description", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        description: 'Description with "quotes" and\nnewlines',
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.string().describe("Description with \\"quotes\\" and\\nnewlines")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.description).toBe('Description with "quotes" and\nnewlines');
+    });
+
+    it("should add .describe() after default value", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        default: "default-value",
+        description: "A string with default",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.string().default("default-value").describe("A string with default")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.parse(undefined)).toBe("default-value");
+      expect(zodSchema.description).toBe("A string with default");
+    });
+
+    it("should add .describe() after constraints", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        minLength: 5,
+        maxLength: 100,
+        description: "A constrained string",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.string().min(5).max(100).describe("A constrained string")');
+      const zodSchema = evalZod(result.code);
+      expect(zodSchema.description).toBe("A constrained string");
+    });
+
+    it("should not add .describe() when description is undefined", () => {
+      const schema: SchemaObject = {
+        type: "string",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe("z.string()");
+      expect(result.code).not.toContain("describe");
+    });
+
+    it("should not add .describe() when description is empty string", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        description: "",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe("z.string()");
+      expect(result.code).not.toContain("describe");
+    });
+
+    it("should add .describe() for nested object properties with descriptions", () => {
+      const schema: SchemaObject = {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "The person's name",
+          },
+          age: {
+            type: "number",
+            description: "Age in years",
+          },
+        },
+        description: "A person object",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toContain('.describe("The person\'s name")');
+      expect(result.code).toContain('.describe("Age in years")');
+      expect(result.code).toContain('.describe("A person object")');
+    });
+
+    it("should add .describe() for array items with description", () => {
+      const schema: SchemaObject = {
+        type: "array",
+        items: {
+          type: "string",
+          description: "A tag name",
+        },
+        description: "List of tags",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('z.array(z.string().describe("A tag name")).describe("List of tags")');
+    });
+  });
 });


### PR DESCRIPTION
Add support for schema descriptions in Zod code generation

- Introduced `addDescription` utility to append descriptions to Zod schemas.
- Updated `zodSchemaToCode` to process schema descriptions and include them in the generated code.
- Enhanced handling of multi-type and nullable schemas to strip descriptions for outer-level addition.
- Added comprehensive tests to verify description handling across various schema types.