### PR TITLE
Add TypeScript configuration and tests for package generator

### DIFF
--- a/.changeset/fifty-pillows-occur.md
+++ b/.changeset/fifty-pillows-occur.md
@@ -1,0 +1,6 @@
+---
+"@apical-ts/core-utils": minor
+"@apical-ts/craft": minor
+---
+
+Generate Typescript configuration file

--- a/packages/core-utils/src/core-generator/package-generator.ts
+++ b/packages/core-utils/src/core-generator/package-generator.ts
@@ -1,8 +1,27 @@
 import { promises as fs } from "fs";
 import path from "path";
 
+const tsConfigContent = {
+  compilerOptions: {
+    allowSyntheticDefaultImports: true,
+    esModuleInterop: true,
+    forceConsistentCasingInFileNames: true,
+    lib: ["es2025"],
+    module: "NodeNext",
+    moduleResolution: "NodeNext",
+    noEmitOnError: false,
+    outDir: "dist",
+    resolveJsonModule: true,
+    rootDir: ".",
+    skipLibCheck: true,
+    strict: true,
+    target: "es2025",
+    types: ["node"],
+  },
+};
+
 /**
- * Creates the package.json file for the generated output
+ * Creates the package metadata files for the generated output
  */
 export async function createPackageJson(output: string): Promise<void> {
   const packageJsonContent = {
@@ -11,19 +30,23 @@ export async function createPackageJson(output: string): Promise<void> {
     },
     devDependencies: {
       "@types/node": "^24.3.1",
-      typescript: "^5.4.5",
+      "@typescript/native-preview": "^7.0.0-dev",
     },
     name: "generated-client",
     scripts: {
-      build:
-        "tsc --outDir ./dist --rootDir . --moduleResolution NodeNext --module NodeNext --target ES2022 --lib es2022 --strict --esModuleInterop --skipLibCheck --allowSyntheticDefaultImports --resolveJsonModule --forceConsistentCasingInFileNames --noEmitOnError false schemas/*.ts client/*.ts server/*.ts routes/*.ts",
+      build: "tsgo",
     },
     type: "module",
     version: "0.1.0",
   };
-  const packageJsonPath = path.join(output, "package.json");
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify(packageJsonContent, null, 2),
-  );
+  await Promise.all([
+    fs.writeFile(
+      path.join(output, "package.json"),
+      JSON.stringify(packageJsonContent, null, 2),
+    ),
+    fs.writeFile(
+      path.join(output, "tsconfig.json"),
+      JSON.stringify(tsConfigContent, null, 2),
+    ),
+  ]);
 }

--- a/packages/core-utils/tests/package-generator.test.ts
+++ b/packages/core-utils/tests/package-generator.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import { createPackageJson } from "../src/core-generator/package-generator.js";
+
+describe("package generator", () => {
+  it("writes package.json and tsconfig.json for generated output", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "core-utils-package-"));
+
+    try {
+      await createPackageJson(outputDir);
+
+      const packageJson = JSON.parse(
+        await readFile(join(outputDir, "package.json"), "utf8"),
+      );
+      const tsConfig = JSON.parse(
+        await readFile(join(outputDir, "tsconfig.json"), "utf8"),
+      );
+
+      expect(packageJson).toMatchObject({
+        dependencies: {
+          zod: "^4.0.0",
+        },
+        devDependencies: {
+          "@types/node": "^24.3.1",
+          "@typescript/native-preview": "^7.0.0-dev",
+        },
+        name: "generated-client",
+        scripts: {
+          build: "tsgo",
+        },
+        type: "module",
+        version: "0.1.0",
+      });
+
+      expect(tsConfig).toEqual({
+        compilerOptions: {
+          allowSyntheticDefaultImports: true,
+          esModuleInterop: true,
+          forceConsistentCasingInFileNames: true,
+          lib: ["es2022"],
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          noEmitOnError: false,
+          outDir: "dist",
+          resolveJsonModule: true,
+          rootDir: ".",
+          skipLibCheck: true,
+          strict: true,
+          target: "ES2022",
+          types: ["node"],
+        },
+      });
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core-utils/tests/package-generator.test.ts
+++ b/packages/core-utils/tests/package-generator.test.ts
@@ -41,7 +41,7 @@ describe("package generator", () => {
           allowSyntheticDefaultImports: true,
           esModuleInterop: true,
           forceConsistentCasingInFileNames: true,
-          lib: ["es2022"],
+          lib: ["es2025"],
           module: "NodeNext",
           moduleResolution: "NodeNext",
           noEmitOnError: false,
@@ -50,7 +50,7 @@ describe("package generator", () => {
           rootDir: ".",
           skipLibCheck: true,
           strict: true,
-          target: "ES2022",
+          target: "es2025",
           types: ["node"],
         },
       });


### PR DESCRIPTION
Introduce a TypeScript configuration file targeting ES2025 and implement tests to ensure the package generator creates both `package.json` and `tsconfig.json` correctly.