### PR TITLE
Bump versions and rename method for clarity

### DIFF
--- a/.changeset/fifty-pillows-occur.md
+++ b/.changeset/fifty-pillows-occur.md
@@ -1,6 +1,0 @@
----
-"@apical-ts/core-utils": minor
-"@apical-ts/craft": minor
----
-
-Generate Typescript configuration file

--- a/.changeset/plenty-rooms-pump.md
+++ b/.changeset/plenty-rooms-pump.md
@@ -1,0 +1,6 @@
+---
+"@apical-ts/core-utils": minor
+"@apical-ts/craft": minor
+---
+
+Fix method name

--- a/apps/craft/CHANGELOG.md
+++ b/apps/craft/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @apical-ts/craft
 
+## 0.18.0
+
+### Minor Changes
+
+- 59c77ea: Generate Typescript configuration file
+
 ## 0.17.0
 
 ### Minor Changes

--- a/apps/craft/package.json
+++ b/apps/craft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/craft",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": false,
   "description": "CLI tool for generating fully-typed Zod v4 schemas and type-safe TypeScript REST API clients and server from OpenAPI 2.0, 3.0.x, and 3.1.x specifications.",
   "main": "dist/index.js",

--- a/apps/craft/src/generate.ts
+++ b/apps/craft/src/generate.ts
@@ -6,7 +6,7 @@ import { generateOperations } from "@apical-ts/client-generator";
 import {
   applyGeneratedOperationIds,
   convertToOpenAPI31,
-  createPackageJson,
+  createPackageFiles,
   generateSchemas,
   parseOpenAPI,
   Profiler,
@@ -123,7 +123,7 @@ export async function generate(options: GenerationOptions): Promise<void> {
   );
 
   profiler?.start("package-json");
-  await createPackageJson(output);
+  await createPackageFiles(output);
   profiler?.end("package-json");
 
   profiler?.printSummary?.("Generation timing (ms)");

--- a/packages/client-generator/CHANGELOG.md
+++ b/packages/client-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @apical-ts/client-generator
 
+## 0.12.6
+
+### Patch Changes
+
+- Updated dependencies [59c77ea]
+  - @apical-ts/core-utils@0.17.0
+
 ## 0.12.5
 
 ### Patch Changes

--- a/packages/client-generator/package.json
+++ b/packages/client-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/client-generator",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "private": true,
   "description": "OpenAPI client generator for apical-ts",
   "main": "dist/index.js",

--- a/packages/core-utils/CHANGELOG.md
+++ b/packages/core-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @apical-ts/core-utils
 
+## 0.17.0
+
+### Minor Changes
+
+- 59c77ea: Generate Typescript configuration file
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/core-utils",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Core utilities and generators for apical-ts OpenAPI tooling",
   "main": "dist/index.js",

--- a/packages/core-utils/src/core-generator/package-generator.ts
+++ b/packages/core-utils/src/core-generator/package-generator.ts
@@ -23,7 +23,7 @@ const tsConfigContent = {
 /**
  * Creates the package metadata files for the generated output
  */
-export async function createPackageJson(output: string): Promise<void> {
+export async function createPackageFiles(output: string): Promise<void> {
   const packageJsonContent = {
     dependencies: {
       zod: "^4.0.0",

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -13,7 +13,7 @@ export {
 } from "./core-generator/file-writer.js";
 export { ImportManager } from "./core-generator/import-types.js";
 export { resolveResponseReference } from "./core-generator/openapi-utils.js";
-export { createPackageJson } from "./core-generator/package-generator.js";
+export { createPackageFiles } from "./core-generator/package-generator.js";
 export { parseOpenAPI } from "./core-generator/parser.js";
 export { Profiler } from "./core-generator/profiler.js";
 export { resolveRequestBodies } from "./core-generator/request-body-resolver.js";

--- a/packages/core-utils/tests/package-generator.test.ts
+++ b/packages/core-utils/tests/package-generator.test.ts
@@ -4,14 +4,14 @@ import { tmpdir } from "node:os";
 
 import { describe, expect, it } from "vitest";
 
-import { createPackageJson } from "../src/core-generator/package-generator.js";
+import { createPackageFiles } from "../src/core-generator/package-generator.js";
 
 describe("package generator", () => {
   it("writes package.json and tsconfig.json for generated output", async () => {
     const outputDir = await mkdtemp(join(tmpdir(), "core-utils-package-"));
 
     try {
-      await createPackageJson(outputDir);
+      await createPackageFiles(outputDir);
 
       const packageJson = JSON.parse(
         await readFile(join(outputDir, "package.json"), "utf8"),

--- a/packages/route-generator/CHANGELOG.md
+++ b/packages/route-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @apical-ts/route-generator
 
+## 0.13.1
+
+### Patch Changes
+
+- Updated dependencies [59c77ea]
+  - @apical-ts/core-utils@0.17.0
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/route-generator/package.json
+++ b/packages/route-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/route-generator",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "description": "OpenAPI route generator for apical-ts",
   "main": "dist/index.js",

--- a/packages/server-generator/CHANGELOG.md
+++ b/packages/server-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @apical-ts/server-generator
 
+## 0.13.1
+
+### Patch Changes
+
+- Updated dependencies [59c77ea]
+  - @apical-ts/core-utils@0.17.0
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/server-generator/package.json
+++ b/packages/server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apical-ts/server-generator",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "description": "OpenAPI server generator for apical-ts",
   "main": "dist/index.js",


### PR DESCRIPTION
Update package versions for `@apical-ts/craft` and `@apical-ts/client-generator`. Rename `createPackageJson` to `createPackageFiles` for improved clarity and update references accordingly. Changelog entries reflect these changes.