### PR TITLE
Refactor response handling to prioritize status

### DIFF
--- a/.changeset/polite-clowns-feel.md
+++ b/.changeset/polite-clowns-feel.md
@@ -1,0 +1,9 @@
+---
+"@apical-ts/react-query-hooks": minor
+"@apical-ts/client-generator": minor
+"@apical-ts/examples": minor
+"@apical-ts/website": minor
+"@apical-ts/craft": minor
+---
+
+Use response status as primary discriminator improving developer experience.

--- a/apps/craft/tests/integrations/force-validation-type-narrowing.test.ts
+++ b/apps/craft/tests/integrations/force-validation-type-narrowing.test.ts
@@ -46,7 +46,7 @@ describe("forceValidation type narrowing", () => {
       { ...mockConfig, forceValidation: true },
     );
 
-    if (response.isValid && response.status === "200") {
+    if (response.status === "200") {
       // The data should be directly available without calling parse()
       expect(response.data).toBeDefined();
 
@@ -71,7 +71,7 @@ describe("forceValidation type narrowing", () => {
       { ...mockConfig, forceValidation: false },
     );
 
-    if (response.isValid && response.status === "200") {
+    if (response.status === "200") {
       // The parse() method should be available
       const parseResult = response.parse();
       expect(parseResult).toBeDefined();
@@ -88,7 +88,7 @@ describe("forceValidation type narrowing", () => {
       mockConfig, // No forceValidation specified
     );
 
-    if (response.isValid && response.status === "200") {
+    if (response.status === "200") {
       // The parse() method should not be available by default
       // @ts-expect-error
       const parseResult = response.parse();
@@ -113,7 +113,7 @@ describe("forceValidation type narrowing", () => {
     );
 
     // Type guard on status should narrow the response type
-    if (response.isValid && response.status === "200") {
+    if (response.status === "200") {
       // TypeScript knows this is a 200 response with Document schema
       expect(response.status).toBe("200");
       expect(response.data).toBeDefined();

--- a/apps/craft/tests/integrations/simple.test.ts
+++ b/apps/craft/tests/integrations/simple.test.ts
@@ -189,6 +189,7 @@ describe("Working Integration Test Demo", () => {
     if ("kind" in result) {
       expect(result.kind).toBe("unexpected-response");
       expect(result.isValid).toBe(false);
+      expect(result.status).toBeUndefined();
       if ("result" in result) {
         expect(result.result.status).toBe("401");
         expect(result.error).toContain("Unexpected response status: 401");

--- a/apps/website/docs/client-generation/call-operations.md
+++ b/apps/website/docs/client-generation/call-operations.md
@@ -29,7 +29,7 @@ const result = await getPetById({ path: { petId: "123" } }, apiConfig);
 // You must check for status code since
 // different status codes may have different response shapes
 // TypeScript will narrow the type based on the status code
-if (result.isValid && result.status === "200") {
+if (result.status === "200") {
   const { data, contentType } = result.parsed;
   // Different content types may have different schemas
   console.log("Content type:", contentType);
@@ -120,7 +120,7 @@ or error object.
 ```typescript
 type SuccessResponse = {
   isValid: true;
-  status: number; // HTTP status code
+  status: string; // HTTP status code as string literal, e.g. "200"
   data: unknown; // Raw response data
   response: Response; // Original fetch Response object
   parse: () => ParseResult | { parsed: <parsed payload> }; // Parse method for validation
@@ -136,11 +136,14 @@ on the value of `forceValidation` flag. See
 ```typescript
 type ErrorResponse = {
   isValid: false;
+  status: undefined;
   kind: string; // Error type discriminator
   error: unknown; // Error details
-  status?: number; // HTTP status (if available)
-  data?: unknown; // Response data (if available)
-  response?: Response; // Original Response (if available)
+  result?: {
+    status: string; // Real HTTP status when a response exists
+    data: unknown; // Response data
+    response: Response; // Original Response
+  };
 };
 ```
 
@@ -151,17 +154,11 @@ type ErrorResponse = {
 ```typescript
 const result = await getPetById({ path: { petId: "123" } });
 
-if (result.isValid) {
-  // TypeScript knows this is a compliant response
-  // but you still have to check for status
-  console.log("Status:", result.status);
-  if (result.status === "200") {
-    const { data, contentType } = result.parsed;
-    console.log("Content type:", contentType);
-    console.log("Data:", data);
-  }
-} else {
-  // TypeScript knows this is an error response
+if (result.status === "200") {
+  const { data, contentType } = result.parsed;
+  console.log("Content type:", contentType);
+  console.log("Data:", data);
+} else if (!result.isValid) {
   console.error("Error kind:", result.kind);
   console.error("Error details:", result.error);
 }
@@ -178,7 +175,7 @@ if (!result.isValid) {
   const { data, contentType } = result.parsed;
   console.log("Content type:", contentType);
   console.log("Pet found:", data);
-} else if (result.status === 404) {
+} else if (result.status === "404") {
   console.warn("Pet not found");
 } else {
   console.error("Unexpected status:", result.status);
@@ -228,11 +225,12 @@ The generated client automatically handles content type detection:
 ```typescript
 const result = await getPetById({ path: { petId: "123" } });
 
-if (result.isValid) {
+if (result.status === "200") {
   // Response content type may only be known at runtime
-  if (result.contentType == "application/xml" && result.status == 200) {
+  const { contentType, data } = result.parsed;
+  if (contentType === "application/xml") {
     // Handle XML response
-    const xmlData = result.data;
+    const xmlData = data;
   }
 }
 ```
@@ -268,23 +266,20 @@ if (!result.isValid && result.kind === "unexpected-response") {
 ```typescript
 const response = await getPetById({ path: { petId: "123" } });
 
-if (!response.isValid) {
-  // handle errors and early return
-  console.error("Error:", response.error);
-  return response.error;
-}
-
 // Switch on status codes
 switch (response.status) {
-  case 200:
+  case "200":
     const { data, contentType } = response.parsed;
     // Validation succeeded
     console.log("Content type:", contentType);
     console.log("Typed validated data:", data[0].name);
     break;
-  case 404:
+  case "404":
     console.warn("Pet not found");
     break;
+  case undefined:
+    console.error("Error:", response.error);
+    return response.error;
 }
 ```
 
@@ -293,7 +288,7 @@ switch (response.status) {
 ```typescript
 const response = await getPetById({ path: { petId: "123" } });
 
-if (response.isValid) {
+if (response.status === "200") {
   // Assume forceValidation=false
   const parseResult = response.parse();
   if (parseResult.kind === "parse-error") {
@@ -309,8 +304,7 @@ if (response.isValid) {
 
 ## Best Practices
 
-1. **Always check `result.isValid`** before accessing success-specific
-   properties
+1. **Use `result.status`** to discriminate documented responses
 1. **Handle different status codes** explicitly rather than assuming success
    means 200
 

--- a/apps/website/docs/client-generation/custom-response-deserialization.md
+++ b/apps/website/docs/client-generation/custom-response-deserialization.md
@@ -169,7 +169,7 @@ The result of `parse()` is a discriminated object you can pattern match on:
 ```ts
 const result = await getDocument({ path: { docId: "123" } });
 
-if (result.isValid && result.status === "200") {
+if (result.status === "200") {
   const outcome = result.parse();
 
   if (isParsed(outcome)) {

--- a/apps/website/docs/client-generation/error-handling.md
+++ b/apps/website/docs/client-generation/error-handling.md
@@ -2,8 +2,8 @@
 
 Client calls never throw exceptions. Instead, all errors are returned as part of
 the response union, providing a consistent and type-safe error handling
-experience. You can branch on either `result.isValid === false` or the presence
-of the `kind` field; both are valid.
+experience. You can branch on `result.status === undefined` or the presence of
+the `kind` field; both are valid.
 
 ## Error Types
 
@@ -11,7 +11,10 @@ All operations return a union that includes `ApiResponseError`, which is a
 discriminated union covering all possible error scenarios:
 
 ```ts
-type ApiResponseError =
+type ApiResponseError = {
+  readonly isValid: false;
+  readonly status: undefined;
+} & (
   | {
       readonly kind: "unexpected-error";
       readonly error: unknown;
@@ -22,32 +25,41 @@ type ApiResponseError =
     }
   | {
       readonly kind: "unexpected-response";
-      readonly data: unknown;
-      readonly status: string; // status code as string, e.g. '404', '4XX', '5XX'
-      readonly response: Response;
+      readonly result: {
+        readonly data: unknown;
+        readonly status: string;
+        readonly response: Response;
+      };
       readonly error: string;
     }
   | {
       readonly kind: "parse-error";
-      readonly data: unknown;
-      readonly status: string;
-      readonly response: Response;
+      readonly result: {
+        readonly data: unknown;
+        readonly status: string;
+        readonly response: Response;
+      };
       readonly error: z.ZodError;
     }
   | {
       readonly kind: "deserialization-error";
-      readonly data: unknown;
-      readonly status: string;
-      readonly response: Response;
+      readonly result: {
+        readonly data: unknown;
+        readonly status: string;
+        readonly response: Response;
+      };
       readonly error: unknown;
     }
   | {
       readonly kind: "missing-schema";
-      readonly data: unknown;
-      readonly status: string;
-      readonly response: Response;
+      readonly result: {
+        readonly data: unknown;
+        readonly status: string;
+        readonly response: Response;
+      };
       readonly error: string;
-    };
+    }
+);
 ```
 
 ## Error Handling Patterns
@@ -59,7 +71,7 @@ if (!r.isValid) {
   // You don't have to handle all errors like this, but you can.
   switch (r.kind) {
     case "unexpected-response":
-      console.error("Unexpected status:", r.status, r.error);
+      console.error("Unexpected status:", r.result.status, r.error);
       break;
     case "deserialization-error":
       console.error("Deserialization failed:", r.error);
@@ -111,12 +123,12 @@ Different error types provide different context:
 ### unexpected-error
 
 - **When it occurs**: Unexpected failures and connection issues.
-- **Available data**: No `status`, `data`, or `response` fields a
+- **Available data**: top-level `status` is `undefined`; no `result` payload
 - **Use case**: Handle network connectivity issues, timeouts, or other
   infrastructure problems
 
 ```ts
-if (result.kind === "unexpected-error") {
+if (!result.isValid && result.kind === "unexpected-error") {
   console.error("Unexpected error:", result.error);
 }
 ```
@@ -125,11 +137,11 @@ if (result.kind === "unexpected-error") {
 
 - **When it occurs**: Errors during the HTTP fetch request (network timeouts,
   DNS failures, connection refused, etc.)
-- **Available data**: No `status`, `data`, or `response` fields
+- **Available data**: top-level `status` is `undefined`; no `result` payload
 - **Use case**: Handle recoverable network errors that may succeed on retry
 
 ```ts
-if (result.kind === "fetch-error") {
+if (!result.isValid && result.kind === "fetch-error") {
   console.error("Fetch request failed:", result.error);
   // Implement retry logic for recoverable network errors
   // Show "Connection failed, retrying..." message to user
@@ -139,13 +151,14 @@ if (result.kind === "fetch-error") {
 ### unexpected-response
 
 - **When it occurs**: HTTP status codes not defined in OpenAPI spec
-- **Available data**: Includes `status`, `data`, `response`
+- **Available data**: top-level `status` is `undefined`; HTTP details are under
+  `result`
 - **Use case**: Handle undocumented API responses or API changes
 
 ```ts
-if (result.kind === "unexpected-response") {
-  console.error(`Undocumented status ${result.status}:`, result.error);
-  console.log("Response data:", result.data);
+if (!result.isValid && result.kind === "unexpected-response") {
+  console.error(`Undocumented status ${result.result.status}:`, result.error);
+  console.log("Response data:", result.result.data);
   // Log for debugging or handle gracefully
 }
 ```
@@ -154,11 +167,12 @@ if (result.kind === "unexpected-response") {
 
 - **When it occurs**: Zod validation failures when using `parse()` or automatic
   runtime validation
-- **Available data**: Includes parsing details via `z.ZodError`
+- **Available data**: Includes parsing details via `z.ZodError`; HTTP details
+  are under `result`
 - **Use case**: Handle schema validation failures
 
 ```ts
-if (result.kind === "parse-error") {
+if (!result.isValid && result.kind === "parse-error") {
   console.error("Response validation failed:");
   console.error(z.prettifyError(result.error)); // Detailed validation errors
   // Show validation error to user or log for debugging
@@ -168,13 +182,14 @@ if (result.kind === "parse-error") {
 ### deserialization-error
 
 - **When it occurs**: Custom deserializer failures
-- **Available data**: Includes original error from deserializer
+- **Available data**: Includes original error from deserializer; HTTP details
+  are under `result`
 - **Use case**: Handle custom content type parsing failures
 
 ```ts
-if (result.kind === "deserialization-error") {
+if (!result.isValid && result.kind === "deserialization-error") {
   console.error("Custom deserializer failed:", result.error);
-  console.log("Raw data:", result.data);
+  console.log("Raw data:", result.result.data);
   // Fall back to raw data handling
 }
 ```
@@ -182,13 +197,14 @@ if (result.kind === "deserialization-error") {
 ### missing-schema
 
 - **When it occurs**: No schema available for content type
-- **Available data**: Includes attempted deserialization details
+- **Available data**: Includes attempted deserialization details; HTTP details
+  are under `result`
 - **Use case**: Handle content types without defined schemas
 
 ```ts
-if (result.kind === "missing-schema") {
+if (!result.isValid && result.kind === "missing-schema") {
   console.warn("No schema for content type:", result.error);
-  console.log("Raw data:", result.data);
+  console.log("Raw data:", result.result.data);
   // Use raw data without validation
 }
 ```
@@ -222,7 +238,8 @@ async function getPetWithRetry(petId: string, maxRetries = 3) {
 
 ## Best Practices
 
-1. **Never ignore errors** - Always check `isValid` before proceeding
+1. **Never ignore errors** - Handle `status === undefined`, `!isValid` and/or
+   branch on `kind`
 1. **Handle errors appropriately** - Different error types require different
    handling strategies
 1. **Retry fetch errors** - Network errors (`fetch-error`) are often recoverable

--- a/apps/website/docs/client-generation/handling-multiple-content-types.md
+++ b/apps/website/docs/client-generation/handling-multiple-content-types.md
@@ -170,7 +170,7 @@ const result = await updatePet({
   contentType: { response: "application/xml" },
 });
 
-if (result.isValid && result.status === "200") {
+if (result.status === "200") {
   // With forceValidation=true (default)
   // parsed field contains both data and contentType
   const { data, contentType } = result.parsed;

--- a/apps/website/docs/client-generation/response-handling.md
+++ b/apps/website/docs/client-generation/response-handling.md
@@ -2,8 +2,8 @@
 
 Each operation returns a discriminated union: either a compliant API response
 (`isValid: true` with a `status` code as **string**, e.g. `'200'`, `'404'`,
-`'422'`, or a range like `'4XX'`, `'5XX'`) or an error object (`isValid: false`)
-with a `kind` discriminator.
+`'422'`, or a range like `'4XX'`, `'5XX'`) or an error object (`isValid: false`,
+`status: undefined`) with a `kind` discriminator.
 
 Validation is opt-out by default (compliant responses expose a `parsed` field).
 You can disable automatic validation at runtime by providing
@@ -15,18 +15,21 @@ You can disable automatic validation at runtime by providing
 ```ts
 const result = await getPetById({ path: { petId: "123" } });
 
-if (result.isValid === false) {
-  console.error("Operation failed:", result.kind, result.error);
-} else if (result.status === "200") {
-  console.log("Pet (raw):", result.data);
-} else if (result.status === "404") {
-  console.warn("Pet not found");
-} else if (result.status === "4XX") {
-  console.warn("Client error (4XX):", result.data);
-} else if (result.status === "5XX") {
-  console.error("Server error (5XX):", result.data);
-} else {
-  console.error("Unexpected documented status", result.status);
+switch (result.status) {
+  case "200":
+    console.log("Pet (raw):", result.data);
+    break;
+  case "404":
+    console.warn("Pet not found");
+    break;
+  case "4XX":
+    console.warn("Client error (4XX):", result.data);
+    break;
+  case "5XX":
+    console.error("Server error (5XX):", result.data);
+    break;
+  default:
+    console.error("Unexpected response", result.status);
 }
 ```
 
@@ -50,8 +53,11 @@ When an operation succeeds, the response object includes:
 When an operation fails, the response object includes:
 
 - **`isValid: false`**: Indicates the operation failed
+- **`status: undefined`**: Lets you discriminate success vs error using only
+  `status`
 - **`kind`**: The type of error that occurred
 - **`error`**: Detailed error information specific to the error type
+- **`result.status`**: The real HTTP status code when an HTTP response exists
 
 ## Validation Modes
 
@@ -63,7 +69,7 @@ are validated against the OpenAPI schema and the `parsed` field is populated.
 ```ts
 const result = await getPetById({ path: { petId: "123" } });
 
-if (result.isValid && result.status === "200") {
+if (result.status === "200") {
   // Data is automatically validated and includes content type
   const { data, contentType } = result.parsed;
   console.log("Content type:", contentType);
@@ -83,7 +89,7 @@ you can call when needed:
 ```ts
 const result = await getPetById({ path: { petId: "123" } });
 
-if (result.isValid && result.status === "200") {
+if (result.status === "200") {
   const outcome = result.parse();
   if (isParsed(outcome)) {
     console.log("Pet:", outcome.parsed);
@@ -100,13 +106,6 @@ type-safely:
 
 ```ts
 const result = await getPetById({ path: { petId: "123" } });
-
-if (!result.isValid) {
-  console.error("Operation failed:", result.error);
-  return;
-}
-
-// result.data is untyped raw data here
 
 switch (result.status) {
   case "200":
@@ -125,13 +124,13 @@ switch (result.status) {
     console.log("Server error (5XX):", result.data);
     break;
   default:
-    console.log("Unexpected status:", result.status);
+    console.log("Unexpected response:", result.status);
 }
 ```
 
 ## Best Practices
 
-1. **Always check `isValid`** before accessing response data
+1. **Use `status` as the primary discriminator** for documented responses
 2. **Handle all expected status codes** explicitly
 3. **Use automatic validation** for trusted APIs where performance isn't
    critical

--- a/apps/website/docs/client-generation/response-payload-validation.md
+++ b/apps/website/docs/client-generation/response-payload-validation.md
@@ -16,8 +16,8 @@ per operation or globally via `configureOperations`). By default,
 
 - **With `forceValidation: false`:**  
   Successful responses provide a `.parse()` method (instead of `.parsed`). After
-  checking `isValid === true` and the desired `status`, you can call `.parse()`
-  to manually validate the response. Handle any parsing errors yourself.
+  checking the desired `status`, you can call `.parse()` to manually validate
+  the response. Handle any parsing errors yourself.
 
 This design lets you choose between automatic validation (for convenience and
 safety) or manual validation (for performance or custom error handling).
@@ -44,10 +44,7 @@ async function demonstrateClient() {
   const greedyPetsResponse = await findPetsByStatus({
     query: { status: "available" },
   });
-  if (
-    greedyPetsResponse.isValid === true &&
-    greedyPetsResponse.status === "200"
-  ) {
+  if (greedyPetsResponse.status === "200") {
     // automatic validation: .parsed contains { data, contentType }
     const { data, contentType } = greedyPetsResponse.parsed;
     console.log("Content type:", contentType);
@@ -63,7 +60,7 @@ async function demonstrateClient() {
   const petsResponse1 = await greedyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse1.isValid === true && petsResponse1.status === "200") {
+  if (petsResponse1.status === "200") {
     // bound automatic validation: .parsed contains { data, contentType }
     const { data, contentType } = petsResponse1.parsed;
     console.log("Response content type:", contentType);
@@ -78,7 +75,7 @@ async function demonstrateClient() {
     },
     { ...globalConfig, forceValidation: false },
   );
-  if (lazyPetResponse.isValid === true && lazyPetResponse.status === "200") {
+  if (lazyPetResponse.status === "200") {
     lazyPetResponse.parse();
   }
 
@@ -91,7 +88,7 @@ async function demonstrateClient() {
   const petsResponse2 = await lazyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse2.isValid === true && petsResponse2.status === "200") {
+  if (petsResponse2.status === "200") {
     petsResponse2.parse();
   }
 }
@@ -112,7 +109,7 @@ const result = await getDocument({
   contentType: { response: "application/json" },
 });
 
-if (result.isValid && result.status === "200") {
+if (result.status === "200") {
   const { data, contentType } = result.parsed;
 
   // Type-safe discrimination based on content type

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -72,7 +72,7 @@ function HomepageHeader() {
             <div className={styles.codeBlockLabel}>TypeScript</div>
             <CodeBlock
               className={styles.codeBlock}
-              code={`import { findPetsByStatus } from './generated/client/findPetsByStatus.js';\n\nconst r = await findPetsByStatus({\n  query: { status: "available" },\n});\nif (r.isValid === true && r.status === "200") {\n  // Zod v4 parsed payload\n  console.log(r.parsed.data[0].name);\n}`}
+              code={`import { findPetsByStatus } from './generated/client/findPetsByStatus.js';\n\nconst r = await findPetsByStatus({\n  query: { status: "available" },\n});\nif (r.status === "200") {\n  // Zod v4 parsed payload\n  console.log(r.parsed.data[0].name);\n}`}
               language="typescript"
             />
           </div>

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -270,7 +270,7 @@ const response = await findPetsByStatus(
   localConfig,
 );
 
-if (response.isValid && response.status === 200) {
+if (response.status === "200") {
   const data = response.parse();
   if (isParsed(data)) {
     console.log("Pets:", data.parsed);

--- a/examples/express/client-examples/custom-fetch-credentials.ts
+++ b/examples/express/client-examples/custom-fetch-credentials.ts
@@ -24,7 +24,7 @@ async function demonstrateCustomFetch() {
     },
   );
 
-  if (response.isValid && response.status === "200") {
+  if (response.status === "200") {
     console.log("Successfully fetched pets with credentials included");
     console.log(`Found ${response.parsed.data.length} pets`);
   } else if (!response.isValid) {

--- a/examples/express/client-examples/force-validation.ts
+++ b/examples/express/client-examples/force-validation.ts
@@ -12,10 +12,7 @@ async function demonstrateClient() {
   const greedyPetsResponse = await findPetsByStatus({
     query: { status: "available" },
   });
-  if (
-    greedyPetsResponse.isValid === true &&
-    greedyPetsResponse.status === "200"
-  ) {
+  if (greedyPetsResponse.status === "200") {
     // automatic validation: .parsed available
     if (greedyPetsResponse.parsed.data.length > 0) {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -32,7 +29,7 @@ async function demonstrateClient() {
   const petsResponse1 = await greedyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse1.isValid === true && petsResponse1.status === "200") {
+  if (petsResponse1.status === "200") {
     // bound automatic validation: .parsed available
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     petsResponse1.parsed;
@@ -46,7 +43,7 @@ async function demonstrateClient() {
     },
     { ...globalConfig, forceValidation: false },
   );
-  if (lazyPetResponse.isValid === true && lazyPetResponse.status === "200") {
+  if (lazyPetResponse.status === "200") {
     lazyPetResponse.parse();
   }
 
@@ -59,7 +56,7 @@ async function demonstrateClient() {
   const petsResponse2 = await lazyClient.findPetsByStatus({
     query: { status: "available" },
   });
-  if (petsResponse2.isValid === true && petsResponse2.status === "200") {
+  if (petsResponse2.status === "200") {
     petsResponse2.parse();
   }
 }

--- a/examples/express/client-examples/neverthrow.ts
+++ b/examples/express/client-examples/neverthrow.ts
@@ -21,13 +21,16 @@ const getAvailablePets = async () =>
       );
     })
     .mapErr((err) => {
-      if ("status" in err) {
+      if ("result" in err) {
         // here we have a server response but something went wrong
-        console.error(`Failed to get pets with status: ${err.status}`);
-      } else {
+        console.error(`Failed to get pets with status: ${err.result.status}`);
+      } else if ("error" in err) {
         // here we can access some other error occurred before server response
         // (e.g. network errors, timeouts, etc.)
         console.error("Failed to get pets:", err.error);
+      } else {
+        // here we have a documented non-2xx response without an error payload
+        console.error(`Failed to get pets with status: ${err.status}`);
       }
     });
 })();

--- a/examples/react-query-hooks/example/Usage.tsx
+++ b/examples/react-query-hooks/example/Usage.tsx
@@ -13,7 +13,7 @@ export default function Usage() {
       body: { name: "Rex", photoUrls: [] },
     });
     // API always returns 405 for this operation in the example spec
-    if (result.isValid && result.status === "405") {
+    if (result.status === "405") {
       console.log("Validation errors:");
     }
   }

--- a/packages/client-generator/src/templates/config/api-response-types.template.ts
+++ b/packages/client-generator/src/templates/config/api-response-types.template.ts
@@ -141,6 +141,7 @@ type ApiResponseErrorResult = {
  */
 export type ApiResponseError = {
   readonly isValid: false;
+  readonly status: undefined;
 } & (
   | {
       readonly kind: "unexpected-error";

--- a/packages/client-generator/src/templates/function-body-templates.ts
+++ b/packages/client-generator/src/templates/function-body-templates.ts
@@ -133,6 +133,7 @@ ${headersContent}
     } catch (error) {
       return {
         isValid: false,
+        status: undefined,
         kind: "fetch-error",
         error,
       } as const;
@@ -150,6 +151,7 @@ ${defaultResponseHandler}`
     return {
       kind: "unexpected-response",
       isValid: false,
+      status: undefined,
       result: {
         data,
         status: response.status.toString(),
@@ -161,6 +163,7 @@ ${defaultResponseHandler}`
   } catch (error) {
     return {
       isValid: false,
+      status: undefined,
       kind: "unexpected-error",
       error,
     } as const;

--- a/packages/client-generator/src/templates/response-templates.ts
+++ b/packages/client-generator/src/templates/response-templates.ts
@@ -32,6 +32,7 @@ export function renderDefaultResponseHandler(
             const errorResult = {
               ...parseResult,
               isValid: false as const,
+              status: undefined,
               result: { data, status: response.status.toString(), response },
             } satisfies ApiResponseError;
             return errorResult;
@@ -53,6 +54,7 @@ export function renderDefaultResponseHandler(
         return {
           kind: "unexpected-response",
           isValid: false,
+          status: undefined,
           result: {
             data,
             status: response.status.toString(),
@@ -107,6 +109,7 @@ ${!responseInfo.hasSchema ? "      const data = undefined;" : ""}
           const errorResult = {
             ...parseResult,
             isValid: false as const,
+            status: undefined,
             result: { data, status: "${statusCode}", response },
           } satisfies ApiResponseError;
           return errorResult;

--- a/packages/client-generator/tests/config-templates.test.ts
+++ b/packages/client-generator/tests/config-templates.test.ts
@@ -159,6 +159,7 @@ describe("client-generator config-templates", () => {
 
       /* Should also include the new ApiResponseError type */
       expect(result).toContain("export type ApiResponseError");
+      expect(result).toContain("readonly status: undefined;");
       expect(result).toContain('readonly kind: "unexpected-error"');
       expect(result).toContain('readonly kind: "parse-error"');
 

--- a/packages/client-generator/tests/error-handling.test.ts
+++ b/packages/client-generator/tests/error-handling.test.ts
@@ -139,6 +139,7 @@ describe("error handling in client generator", () => {
       expect(responseHandler).toContain('if ("parsed" in parseResult)');
       expect(responseHandler).toContain("if (parseResult.kind");
       expect(responseHandler).toContain("isValid: false");
+      expect(responseHandler).toContain("status: undefined");
       /* Force validation should directly return parsed result or error, not provide a parse method */
     });
   });

--- a/packages/client-generator/tests/fetch-error-handling.test.ts
+++ b/packages/client-generator/tests/fetch-error-handling.test.ts
@@ -56,6 +56,7 @@ describe("Fetch Error Handling", () => {
     /* Verify fetch-error is returned in inner catch */
     expect(result.functionCode).toContain(`return {
         isValid: false,
+        status: undefined,
         kind: "fetch-error",
         error,
       } as const;`);
@@ -63,6 +64,7 @@ describe("Fetch Error Handling", () => {
     /* Verify outer try/catch still exists for unexpected errors */
     expect(result.functionCode).toContain(`return {
       isValid: false,
+      status: undefined,
       kind: "unexpected-error",
       error,
     } as const;`);

--- a/packages/client-generator/tests/function-body-templates.test.ts
+++ b/packages/client-generator/tests/function-body-templates.test.ts
@@ -251,6 +251,7 @@ describe("function-body-templates", () => {
       expect(result).toContain(
         "/* Handle default response or unexpected status codes */",
       );
+      expect(result).toContain("status: undefined");
       expect(result).toContain('kind: "unexpected-response"');
     });
 


### PR DESCRIPTION
Refactor response handling to use status as the primary discriminator, simplifying validation checks across examples and templates. Update documentation and examples to reflect this change.