### PR TITLE
Add support for string format overrides in schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,37 @@ Need to **validate server requests and return typed responses**? 🛡️ We've g
 you covered with built-in support for request and response validation using Zod
 schemas.
 
+## CLI
+
+```bash
+pnpm start generate -i ./openapi.yaml -o ./generated --client --server
+```
+
+### Overriding OpenAPI string formats
+
+Use `--format` to replace a `type: string` + `format` mapping with your own Zod
+schema:
+
+```bash
+pnpm start generate \
+  -i ./openapi.yaml \
+  -o ./generated \
+  --client \
+  --server \
+  --format tax-code=./src/zod/TaxCode.ts \
+  --format uuid=@acme/domain-schemas#Uuid
+```
+
+- `--format` is repeatable
+- `<format>` must match the OpenAPI `format` value exactly
+- `<module-or-path>` accepts both package/module specifiers and explicit project
+  paths (`./` or `../`)
+- `#<export>` is optional; when omitted, `craft` infers the export name from the
+  last path or module segment
+
+When a mapping matches, the generator imports your Zod schema into generated
+`schemas` files and reuses it through generated routes, client, and server
+types. The matched string field stops using the built-in OpenAPI string
+constraints and delegates validation to your custom schema.
+
 See https://gunzip.github.io/apical-ts/ for more information.

--- a/apps/craft/README.md
+++ b/apps/craft/README.md
@@ -11,4 +11,37 @@ Need to **validate server requests and return typed responses**? 🛡️ We've g
 you covered with built-in support for request and response validation using Zod
 schemas.
 
+## CLI
+
+```bash
+pnpm start generate -i ./openapi.yaml -o ./generated --client --server
+```
+
+### Overriding OpenAPI string formats
+
+Use `--format` to replace a `type: string` + `format` mapping with your own Zod
+schema:
+
+```bash
+pnpm start generate \
+  -i ./openapi.yaml \
+  -o ./generated \
+  --client \
+  --server \
+  --format tax-code=./src/zod/TaxCode.ts \
+  --format uuid=@acme/domain-schemas#Uuid
+```
+
+- `--format` is repeatable
+- `<format>` must match the OpenAPI `format` value exactly
+- `<module-or-path>` accepts both package/module specifiers and explicit project
+  paths (`./` or `../`)
+- `#<export>` is optional; when omitted, `craft` infers the export name from the
+  last path or module segment
+
+When a mapping matches, the generator imports your Zod schema into generated
+`schemas` files and reuses it through generated routes, client, and server
+types. The matched string field stops using the built-in OpenAPI string
+constraints and delegates validation to your custom schema.
+
 See https://gunzip.github.io/apical-ts/ for more information.

--- a/apps/craft/src/format-overrides.ts
+++ b/apps/craft/src/format-overrides.ts
@@ -1,0 +1,139 @@
+import type { StringFormatOverride } from "@apical-ts/core-utils";
+
+import { sanitizeIdentifier } from "@apical-ts/core-utils";
+import path from "node:path";
+
+const VALID_IDENTIFIER = /^[$A-Z_a-z][$\w]*$/;
+
+export function parseFormatOverrideArguments(
+  mappings: readonly string[] = [],
+  cwd = process.cwd(),
+): StringFormatOverride[] {
+  const overrides = mappings.map((mapping) =>
+    parseFormatOverrideArgument(mapping, cwd),
+  );
+  const seenFormats = new Set<string>();
+
+  for (const override of overrides) {
+    if (seenFormats.has(override.format)) {
+      throw new Error(
+        `Duplicate --format override for "${override.format}". Each format can only be mapped once.`,
+      );
+    }
+    seenFormats.add(override.format);
+  }
+
+  return overrides;
+}
+
+export function parseFormatOverrideArgument(
+  mapping: string,
+  cwd = process.cwd(),
+): StringFormatOverride {
+  const separatorIndex = mapping.indexOf("=");
+  if (separatorIndex <= 0 || separatorIndex === mapping.length - 1) {
+    throw new Error(
+      `Invalid --format value "${mapping}". Expected <format>=<module-or-path>#<export>.`,
+    );
+  }
+
+  const format = mapping.slice(0, separatorIndex).trim();
+  const importTarget = mapping.slice(separatorIndex + 1).trim();
+  if (!format) {
+    throw new Error(
+      `Invalid --format value "${mapping}". The OpenAPI format name cannot be empty.`,
+    );
+  }
+  if (!importTarget) {
+    throw new Error(
+      `Invalid --format value "${mapping}". The import target cannot be empty.`,
+    );
+  }
+
+  const { importName = inferImportName(importTarget), source } =
+    parseImportTarget(importTarget, cwd);
+
+  return {
+    format,
+    import: source,
+    importName,
+  };
+}
+
+function inferImportName(importTarget: string): string {
+  const sourceWithoutExport = stripExplicitExport(importTarget);
+  const baseName = path.basename(sourceWithoutExport);
+  const extension = path.extname(baseName);
+  const inferredBaseName = extension
+    ? baseName.slice(0, -extension.length)
+    : baseName;
+
+  if (!inferredBaseName) {
+    throw new Error(
+      `Unable to infer an export name from "${importTarget}". Use --format <format>=<module-or-path>#<export>.`,
+    );
+  }
+
+  const identifier = sanitizeIdentifier(inferredBaseName);
+  return identifier.charAt(0).toUpperCase() + identifier.slice(1);
+}
+
+function isFilePathSource(source: string): boolean {
+  return (
+    source.startsWith("./") ||
+    source.startsWith("../") ||
+    path.isAbsolute(source)
+  );
+}
+
+function parseImportTarget(
+  importTarget: string,
+  cwd: string,
+): {
+  importName?: string;
+  source:
+    | { kind: "module"; specifier: string }
+    | { kind: "path"; path: string };
+} {
+  const exportSeparatorIndex = importTarget.lastIndexOf("#");
+  const hasExplicitExport =
+    exportSeparatorIndex > -1 && exportSeparatorIndex < importTarget.length - 1;
+  const rawSource = (
+    hasExplicitExport
+      ? importTarget.slice(0, exportSeparatorIndex)
+      : importTarget
+  ).trim();
+  const explicitImportName = hasExplicitExport
+    ? importTarget.slice(exportSeparatorIndex + 1).trim()
+    : undefined;
+
+  if (!rawSource) {
+    throw new Error(
+      `Invalid --format value "${importTarget}". The import target cannot be empty.`,
+    );
+  }
+
+  if (explicitImportName && !VALID_IDENTIFIER.test(explicitImportName)) {
+    throw new Error(
+      `Invalid export name "${explicitImportName}" in --format value "${importTarget}".`,
+    );
+  }
+
+  return {
+    importName: explicitImportName,
+    source: isFilePathSource(rawSource)
+      ? { kind: "path", path: path.resolve(cwd, rawSource) }
+      : { kind: "module", specifier: rawSource },
+  };
+}
+
+function stripExplicitExport(importTarget: string): string {
+  const exportSeparatorIndex = importTarget.lastIndexOf("#");
+  if (
+    exportSeparatorIndex <= -1 ||
+    exportSeparatorIndex === importTarget.length - 1
+  ) {
+    return importTarget;
+  }
+  return importTarget.slice(0, exportSeparatorIndex);
+}

--- a/apps/craft/src/format-overrides.ts
+++ b/apps/craft/src/format-overrides.ts
@@ -3,8 +3,14 @@ import type { StringFormatOverride } from "@apical-ts/core-utils";
 import { sanitizeIdentifier } from "@apical-ts/core-utils";
 import path from "node:path";
 
+/* Named imports in generated files must be valid TypeScript identifiers. */
 const VALID_IDENTIFIER = /^[$A-Z_a-z][$\w]*$/;
 
+/*
+ * Parses the repeatable `--format` CLI values into normalized overrides.
+ * This batches per-entry parsing and enforces uniqueness early so generation
+ * can treat the mapping as a simple one-to-one lookup by OpenAPI format.
+ */
 export function parseFormatOverrideArguments(
   mappings: readonly string[] = [],
   cwd = process.cwd(),
@@ -26,10 +32,17 @@ export function parseFormatOverrideArguments(
   return overrides;
 }
 
+/*
+ * Parses a single `--format` value of the form
+ * `<format>=<module-or-path>#<export>`.
+ * It validates the user-facing contract up front so downstream generators only
+ * receive a normalized `{ format, import, importName }` shape.
+ */
 export function parseFormatOverrideArgument(
   mapping: string,
   cwd = process.cwd(),
 ): StringFormatOverride {
+  // Split only on the first `=` so the right-hand side stays intact.
   const separatorIndex = mapping.indexOf("=");
   if (separatorIndex <= 0 || separatorIndex === mapping.length - 1) {
     throw new Error(
@@ -60,6 +73,11 @@ export function parseFormatOverrideArgument(
   };
 }
 
+/*
+ * Infers the named export to import when the user omits `#ExportName`.
+ * We derive it from the last path/module segment, sanitize it into a valid
+ * identifier, and promote it to PascalCase to match common schema naming.
+ */
 function inferImportName(importTarget: string): string {
   const sourceWithoutExport = stripExplicitExport(importTarget);
   const baseName = path.basename(sourceWithoutExport);
@@ -78,6 +96,11 @@ function inferImportName(importTarget: string): string {
   return identifier.charAt(0).toUpperCase() + identifier.slice(1);
 }
 
+/*
+ * Distinguishes filesystem paths from module specifiers.
+ * We intentionally require explicit relative or absolute path syntax so bare
+ * values such as `src/foo/TaxCode.ts` still behave like module specifiers.
+ */
 function isFilePathSource(source: string): boolean {
   return (
     source.startsWith("./") ||
@@ -86,6 +109,11 @@ function isFilePathSource(source: string): boolean {
   );
 }
 
+/*
+ * Splits the import target into source + optional export name and normalizes
+ * the source into either a module specifier or an absolute filesystem path.
+ * This keeps all import-shape decisions in one place before generation starts.
+ */
 function parseImportTarget(
   importTarget: string,
   cwd: string,
@@ -95,6 +123,7 @@ function parseImportTarget(
     | { kind: "module"; specifier: string }
     | { kind: "path"; path: string };
 } {
+  // Use the last `#` so only the trailing segment is treated as the export name.
   const exportSeparatorIndex = importTarget.lastIndexOf("#");
   const hasExplicitExport =
     exportSeparatorIndex > -1 && exportSeparatorIndex < importTarget.length - 1;
@@ -121,12 +150,17 @@ function parseImportTarget(
 
   return {
     importName: explicitImportName,
+    // Resolve project paths eagerly so later stages never depend on the caller cwd.
     source: isFilePathSource(rawSource)
       ? { kind: "path", path: path.resolve(cwd, rawSource) }
       : { kind: "module", specifier: rawSource },
   };
 }
 
+/*
+ * Removes an explicit `#ExportName` suffix before name inference.
+ * Inference should only look at the source portion of the mapping.
+ */
 function stripExplicitExport(importTarget: string): string {
   const exportSeparatorIndex = importTarget.lastIndexOf("#");
   if (

--- a/apps/craft/src/format-overrides.ts
+++ b/apps/craft/src/format-overrides.ts
@@ -34,7 +34,7 @@ export function parseFormatOverrideArguments(
 
 /*
  * Parses a single `--format` value of the form
- * `<format>=<module-or-path>#<export>`.
+ * `<format>=<module-or-path>[#<export>]`.
  * It validates the user-facing contract up front so downstream generators only
  * receive a normalized `{ format, import, importName }` shape.
  */
@@ -46,7 +46,7 @@ export function parseFormatOverrideArgument(
   const separatorIndex = mapping.indexOf("=");
   if (separatorIndex <= 0 || separatorIndex === mapping.length - 1) {
     throw new Error(
-      `Invalid --format value "${mapping}". Expected <format>=<module-or-path>#<export>.`,
+      `Invalid --format value "${mapping}". Expected <format>=<module-or-path>[#<export>].`,
     );
   }
 
@@ -88,12 +88,18 @@ function inferImportName(importTarget: string): string {
 
   if (!inferredBaseName) {
     throw new Error(
-      `Unable to infer an export name from "${importTarget}". Use --format <format>=<module-or-path>#<export>.`,
+      `Unable to infer an export name from "${importTarget}". Use --format <format>=<module-or-path> or include #<export> when it cannot be inferred.`,
     );
   }
 
-  const identifier = sanitizeIdentifier(inferredBaseName);
-  return identifier.charAt(0).toUpperCase() + identifier.slice(1);
+  try {
+    const identifier = sanitizeIdentifier(inferredBaseName);
+    return identifier.charAt(0).toUpperCase() + identifier.slice(1);
+  } catch {
+    throw new Error(
+      `Unable to infer an export name from "${importTarget}". Use --format <format>=<module-or-path> or include #<export> when it cannot be inferred.`,
+    );
+  }
 }
 
 /*
@@ -125,16 +131,22 @@ function parseImportTarget(
 } {
   // Use the last `#` so only the trailing segment is treated as the export name.
   const exportSeparatorIndex = importTarget.lastIndexOf("#");
-  const hasExplicitExport =
-    exportSeparatorIndex > -1 && exportSeparatorIndex < importTarget.length - 1;
+  const hasExportSeparator = exportSeparatorIndex > -1;
+  const explicitImportName = hasExportSeparator
+    ? importTarget.slice(exportSeparatorIndex + 1).trim()
+    : undefined;
+
+  if (hasExportSeparator && !explicitImportName) {
+    throw new Error(
+      `Invalid --format value "${importTarget}". The import target contains "#" but no export name follows it.`,
+    );
+  }
+
   const rawSource = (
-    hasExplicitExport
+    hasExportSeparator
       ? importTarget.slice(0, exportSeparatorIndex)
       : importTarget
   ).trim();
-  const explicitImportName = hasExplicitExport
-    ? importTarget.slice(exportSeparatorIndex + 1).trim()
-    : undefined;
 
   if (!rawSource) {
     throw new Error(

--- a/apps/craft/src/generate.ts
+++ b/apps/craft/src/generate.ts
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
-import type { ExtraPropsMode } from "@apical-ts/core-utils";
+import type {
+  ExtraPropsMode,
+  StringFormatOverride,
+} from "@apical-ts/core-utils";
 import type { OpenAPIObject } from "openapi3-ts/oas31";
 
 import { generateOperations } from "@apical-ts/client-generator";
@@ -49,6 +52,7 @@ export interface GenerationOptions {
    * @default "strip"
    */
   extraProps?: ExtraPropsMode;
+  formatOverrides?: StringFormatOverride[];
   generateClient: boolean;
   generateRoutes?: boolean;
   generateServer?: boolean;
@@ -85,6 +89,7 @@ export async function generate(options: GenerationOptions): Promise<void> {
   const {
     concurrency = DEFAULT_CONCURRENCY,
     extraProps = "strip",
+    formatOverrides = [],
     generateClient: genClient,
     generateRoutes: genRoutes = false,
     generateServer: genServer = false,
@@ -109,6 +114,7 @@ export async function generate(options: GenerationOptions): Promise<void> {
     genServer,
     extraProps,
     profiler,
+    formatOverrides,
   );
   profiler?.end("schemas:all");
 
@@ -123,7 +129,7 @@ export async function generate(options: GenerationOptions): Promise<void> {
   );
 
   profiler?.start("package-json");
-  await createPackageFiles(output);
+  await createPackageFiles(output, formatOverrides);
   profiler?.end("package-json");
 
   profiler?.printSummary?.("Generation timing (ms)");

--- a/apps/craft/src/index.ts
+++ b/apps/craft/src/index.ts
@@ -5,6 +5,7 @@ import type { ExtraPropsMode } from "@apical-ts/core-utils";
 
 import { Command } from "commander";
 
+import { parseFormatOverrideArguments } from "./format-overrides.js";
 import { generate } from "./generate.js";
 
 const program = new Command();
@@ -35,6 +36,12 @@ program
   .option("--generate-routes, --routes", "Generate route metadata.", false)
   .option("--profile", "Print timing breakdown for generation phases.", false)
   .option(
+    "--format <mapping>",
+    "Override an OpenAPI string format with <format>=<module-or-path>#<export>. Repeatable.",
+    collectOption,
+    [],
+  )
+  .option(
     "--extra-props <mode>",
     "Control how additional properties are handled in object schemas. Options: strip (default), loose, strict",
     "strip",
@@ -44,6 +51,11 @@ program
       const started = process.hrtime.bigint();
       const generationOptions = {
         extraProps: String(options.extraProps) as ExtraPropsMode,
+        formatOverrides: parseFormatOverrideArguments(
+          Array.isArray(options.format)
+            ? options.format.map((value) => String(value))
+            : [],
+        ),
         generateClient: Boolean(options.client),
         generateRoutes: Boolean(options.routes),
         generateServer: Boolean(options.server),
@@ -65,3 +77,8 @@ program
   });
 
 program.parse(process.argv);
+
+function collectOption(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
+}

--- a/apps/craft/src/index.ts
+++ b/apps/craft/src/index.ts
@@ -37,7 +37,7 @@ program
   .option("--profile", "Print timing breakdown for generation phases.", false)
   .option(
     "--format <mapping>",
-    "Override an OpenAPI string format with <format>=<module-or-path>#<export>. Repeatable.",
+    "Override an OpenAPI string format with <format>=<module-or-path>[#<export>]. Repeatable.",
     collectOption,
     [],
   )

--- a/apps/craft/tests/format-overrides.test.ts
+++ b/apps/craft/tests/format-overrides.test.ts
@@ -1,0 +1,68 @@
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  parseFormatOverrideArgument,
+  parseFormatOverrideArguments,
+} from "../src/format-overrides.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const craftRoot = resolve(__dirname, "..");
+
+describe("format overrides parser", () => {
+  it("parses package specifiers with an explicit export name", () => {
+    expect(
+      parseFormatOverrideArgument("tax-code=@acme/domain#TaxCode", craftRoot),
+    ).toEqual({
+      format: "tax-code",
+      import: {
+        kind: "module",
+        specifier: "@acme/domain",
+      },
+      importName: "TaxCode",
+    });
+  });
+
+  it("infers the export name from a project path", () => {
+    expect(
+      parseFormatOverrideArgument(
+        "tax-code=./tests/integrations/fixtures/format-overrides/TaxCode.ts",
+        craftRoot,
+      ),
+    ).toEqual({
+      format: "tax-code",
+      import: {
+        kind: "path",
+        path: join(
+          craftRoot,
+          "tests/integrations/fixtures/format-overrides/TaxCode.ts",
+        ),
+      },
+      importName: "TaxCode",
+    });
+  });
+
+  it("rejects duplicate mappings for the same format", () => {
+    expect(() =>
+      parseFormatOverrideArguments(
+        [
+          "tax-code=./tests/integrations/fixtures/format-overrides/TaxCode.ts",
+          "tax-code=@acme/domain#TaxCode",
+        ],
+        craftRoot,
+      ),
+    ).toThrow(/Duplicate --format override/);
+  });
+
+  it("rejects malformed export names", () => {
+    expect(() =>
+      parseFormatOverrideArgument(
+        "tax-code=@acme/domain#not-valid!",
+        craftRoot,
+      ),
+    ).toThrow(/Invalid export name/);
+  });
+});

--- a/apps/craft/tests/format-overrides.test.ts
+++ b/apps/craft/tests/format-overrides.test.ts
@@ -57,6 +57,12 @@ describe("format overrides parser", () => {
     ).toThrow(/Duplicate --format override/);
   });
 
+  it("uses the optional export syntax in malformed mapping errors", () => {
+    expect(() => parseFormatOverrideArgument("tax-code", craftRoot)).toThrow(
+      'Invalid --format value "tax-code". Expected <format>=<module-or-path>[#<export>].',
+    );
+  });
+
   it("rejects malformed export names", () => {
     expect(() =>
       parseFormatOverrideArgument(
@@ -64,5 +70,19 @@ describe("format overrides parser", () => {
         craftRoot,
       ),
     ).toThrow(/Invalid export name/);
+  });
+
+  it("rejects trailing export separators without an export name", () => {
+    expect(() =>
+      parseFormatOverrideArgument("tax-code=@acme/domain#", craftRoot),
+    ).toThrow(/contains "#" but no export name follows it/);
+  });
+
+  it("uses optional export guidance when the export name cannot be inferred", () => {
+    expect(() =>
+      parseFormatOverrideArgument("tax-code=@@@", craftRoot),
+    ).toThrow(
+      'Unable to infer an export name from "@@@". Use --format <format>=<module-or-path> or include #<export> when it cannot be inferred.',
+    );
   });
 });

--- a/apps/craft/tests/integrations/fixtures/format-overrides.yaml
+++ b/apps/craft/tests/integrations/fixtures/format-overrides.yaml
@@ -1,0 +1,48 @@
+openapi: 3.1.0
+info:
+  title: Format Override Test API
+  version: 1.0.0
+paths:
+  /profiles:
+    post:
+      operationId: createProfile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Profile"
+      responses:
+        "201":
+          description: Created profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Profile"
+  /profiles/{taxCode}:
+    get:
+      operationId: getProfileByTaxCode
+      parameters:
+        - in: path
+          name: taxCode
+          required: true
+          schema:
+            type: string
+            format: tax-code
+      responses:
+        "200":
+          description: Profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Profile"
+components:
+  schemas:
+    Profile:
+      type: object
+      properties:
+        fiscalCode:
+          type: string
+          format: tax-code
+      required:
+        - fiscalCode

--- a/apps/craft/tests/integrations/fixtures/format-overrides/TaxCode.js
+++ b/apps/craft/tests/integrations/fixtures/format-overrides/TaxCode.js
@@ -1,0 +1,2 @@
+import * as z from "zod";
+export const TaxCode = z.union([z.literal("TAX-001"), z.literal("TAX-002")]);

--- a/apps/craft/tests/integrations/fixtures/format-overrides/TaxCode.ts
+++ b/apps/craft/tests/integrations/fixtures/format-overrides/TaxCode.ts
@@ -1,0 +1,4 @@
+import * as z from "zod";
+
+export const TaxCode = z.union([z.literal("TAX-001"), z.literal("TAX-002")]);
+export type TaxCode = z.infer<typeof TaxCode>;

--- a/apps/craft/tests/integrations/format-overrides.test.ts
+++ b/apps/craft/tests/integrations/format-overrides.test.ts
@@ -1,0 +1,156 @@
+import { promises as fs } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseFormatOverrideArguments } from "../../src/format-overrides.js";
+import { generate } from "../../src/generate.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const craftRoot = resolve(__dirname, "../..");
+const inputSpec = join(__dirname, "fixtures/format-overrides.yaml");
+const outputDir = join(__dirname, "../../tmp/format-overrides");
+const taxCodeSourcePath = join(
+  __dirname,
+  "fixtures/format-overrides/TaxCode.ts",
+);
+const formatOverrideAlias = "__apicalStringFormatTaxCode";
+
+describe("format overrides integration", () => {
+  beforeEach(async () => {
+    await fs.rm(outputDir, { force: true, recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(outputDir, { force: true, recursive: true });
+  });
+
+  it("imports the custom schema into generated schemas and parameter files", async () => {
+    await generateWithFormatOverride();
+
+    const profilePath = join(outputDir, "schemas/Profile.ts");
+    const parametersPath = join(
+      outputDir,
+      "schemas/getProfileByTaxCodeParameters.ts",
+    );
+    const profileContent = await fs.readFile(profilePath, "utf-8");
+    const parametersContent = await fs.readFile(parametersPath, "utf-8");
+    const expectedImport = `import { TaxCode as ${formatOverrideAlias} } from ${JSON.stringify(
+      getExpectedImportSpecifier(profilePath),
+    )};`;
+
+    expect(profileContent).toContain(expectedImport);
+    expect(profileContent).toContain(`"fiscalCode": ${formatOverrideAlias}`);
+    expect(parametersContent).toContain(expectedImport);
+    expect(parametersContent).toContain(`"taxCode": ${formatOverrideAlias}`);
+  });
+
+  it("propagates the overridden type through client, routes, and server", async () => {
+    await generateWithFormatOverride();
+    await fs.writeFile(join(outputDir, "consumer.ts"), createConsumerSource());
+
+    const result = spawnSync(
+      "pnpm",
+      [
+        "exec",
+        "tsgo",
+        "-p",
+        join(outputDir, "tsconfig.json"),
+        "--pretty",
+        "false",
+      ],
+      {
+        cwd: craftRoot,
+        encoding: "utf-8",
+      },
+    );
+
+    if (result.status !== 0) {
+      console.error(result.stdout);
+      console.error(result.stderr);
+    }
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).not.toMatch(/error TS\d{4}:/);
+  });
+});
+
+function createConsumerSource(): string {
+  return `import * as z from "zod";
+import { createProfile } from "./client/createProfile.js";
+import { createProfileRequestMap } from "./routes/createProfile.js";
+import { serverRoute as getProfileByTaxCodeServerRoute } from "./routes/getProfileByTaxCode.js";
+import type { Profile } from "./schemas/Profile.js";
+import type { getProfileByTaxCodeHandler } from "./server/getProfileByTaxCode.js";
+
+const validProfile: Profile = { fiscalCode: "TAX-001" };
+// @ts-expect-error invalid tax code should be rejected by the overridden schema type
+const invalidProfile: Profile = { fiscalCode: "INVALID" };
+
+type CreateProfileRequest = z.infer<typeof createProfileRequestMap["application/json"]>;
+const validRequest: CreateProfileRequest = validProfile;
+// @ts-expect-error invalid tax code should be rejected in route request maps
+const invalidRequest: CreateProfileRequest = { fiscalCode: "INVALID" };
+
+const config = {
+  baseURL: "http://example.com",
+  fetch: async () =>
+    new Response(JSON.stringify({ fiscalCode: "TAX-001" }), {
+      headers: { "content-type": "application/json" },
+      status: 201,
+    }),
+  forceValidation: false,
+  headers: {},
+};
+
+void createProfile({ body: validProfile }, config);
+// @ts-expect-error invalid tax code should be rejected by generated client params
+void createProfile({ body: { fiscalCode: "INVALID" } }, config);
+
+type ServerParsedParams = Extract<
+  Parameters<getProfileByTaxCodeHandler>[0],
+  { isValid: true }
+>["value"];
+
+const validPath: ServerParsedParams["path"] = { taxCode: "TAX-001" };
+// @ts-expect-error invalid tax code should be rejected by generated server params
+const invalidPath: ServerParsedParams["path"] = { taxCode: "INVALID" };
+
+type RoutePath = z.infer<typeof getProfileByTaxCodeServerRoute.params.shape.path>;
+const validRoutePath: RoutePath = validPath;
+// @ts-expect-error invalid tax code should be rejected by generated route params
+const invalidRoutePath: RoutePath = { taxCode: "INVALID" };
+
+void validRequest;
+void validRoutePath;
+void invalidPath;
+void invalidProfile;
+void invalidRequest;
+void invalidRoutePath;
+`;
+}
+
+async function generateWithFormatOverride(): Promise<void> {
+  await generate({
+    formatOverrides: parseFormatOverrideArguments(
+      ["tax-code=./tests/integrations/fixtures/format-overrides/TaxCode.ts"],
+      craftRoot,
+    ),
+    generateClient: true,
+    generateRoutes: true,
+    generateServer: true,
+    input: inputSpec,
+    output: outputDir,
+  });
+}
+
+function getExpectedImportSpecifier(filePath: string): string {
+  const relativePath = relative(dirname(filePath), taxCodeSourcePath)
+    .replaceAll("\\", "/")
+    .replace(/\.ts$/, ".js");
+
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}

--- a/apps/website/docs/cli-usage.md
+++ b/apps/website/docs/cli-usage.md
@@ -86,6 +86,10 @@ specification.
 - `--routes`: Generate route metadata only (default: false). Useful when you
   want to generate your own type-safe client or server implementation while
   leveraging the generated schemas and route definitions.
+- `--format <mapping>`: Override an OpenAPI `type: string` + `format` mapping
+  with a custom imported Zod schema. Syntax:
+  `<format>=<module-or-path>[#<export>]`. Repeatable. See
+  [String Format Overrides](./schema-generation/string-format-overrides.md).
 - `--extra-props <mode>`: Control how Zod schemas handle additional properties.
   Options: `strip` (default), `loose`, `strict`. See
   [Schema Validation Modes](./schema-validation-modes.md) for details.
@@ -93,6 +97,31 @@ specification.
 > **Note**: The long-form flags `--generate-client`, `--generate-server`, and
 > `--generate-routes` are deprecated in favor of the shorter `--client`,
 > `--server`, and `--routes` aliases.
+
+## Overriding OpenAPI String Formats
+
+Use `--format` when a string format in your OpenAPI specification should map to
+your own Zod schema instead of the built-in handling.
+
+```bash
+npx @apical-ts/craft generate \
+  --client \
+  --server \
+  -i openapi.yaml \
+  -o generated \
+  --format tax-code=./src/zod/TaxCode.ts \
+  --format uuid=@acme/domain-schemas#Uuid
+```
+
+This makes the generated schemas import your custom validators and propagates
+their types through generated routes, client operations, and server wrappers.
+
+- `--format` is repeatable
+- `#<export>` is optional
+- project paths must be explicit (`./` or `../`)
+
+For a complete walkthrough, see
+[String Format Overrides](./schema-generation/string-format-overrides.md).
 
 ## Output Structure
 

--- a/apps/website/docs/schema-generation/string-format-overrides.md
+++ b/apps/website/docs/schema-generation/string-format-overrides.md
@@ -1,0 +1,163 @@
+---
+id: string-format-overrides
+title: String Format Overrides
+description:
+  Replace OpenAPI string format handling with imported custom Zod schemas by
+  using the --format CLI option.
+keywords:
+  [
+    string format overrides,
+    OpenAPI format,
+    custom Zod schemas,
+    schema generation,
+    CLI,
+  ]
+---
+
+# String Format Overrides
+
+`@apical-ts/craft` can replace the built-in handling of an OpenAPI
+`type: string` + `format` combination with your own Zod schema.
+
+This is useful when a format in your API represents a domain-specific value
+such as a tax code, customer ID, slug, or branded UUID that should be validated
+by a custom schema instead of the default string-format mapping.
+
+## CLI Syntax
+
+Use the repeatable `--format` option:
+
+```bash
+npx @apical-ts/craft generate \
+  --client \
+  --server \
+  -i openapi.yaml \
+  -o generated \
+  --format <format>=<module-or-path>[#<export>]
+```
+
+Examples:
+
+```bash
+npx @apical-ts/craft generate \
+  --client \
+  --server \
+  -i openapi.yaml \
+  -o generated \
+  --format tax-code=./src/zod/TaxCode.ts \
+  --format uuid=@acme/domain-schemas#Uuid
+```
+
+- `<format>` must match the OpenAPI `format` value exactly
+- `<module-or-path>` accepts package specifiers and explicit project paths
+- `#<export>` is optional; when omitted, `craft` infers the export name from
+  the last module or path segment
+- `--format` can be provided multiple times
+
+## Example
+
+OpenAPI schema:
+
+```yaml
+components:
+  schemas:
+    Profile:
+      type: object
+      properties:
+        fiscalCode:
+          type: string
+          format: tax-code
+      required:
+        - fiscalCode
+
+paths:
+  /profiles/{taxCode}:
+    get:
+      operationId: getProfileByTaxCode
+      parameters:
+        - in: path
+          name: taxCode
+          required: true
+          schema:
+            type: string
+            format: tax-code
+```
+
+Custom Zod schema:
+
+```ts
+import * as z from "zod";
+
+export const TaxCode = z.union([z.literal("TAX-001"), z.literal("TAX-002")]);
+export type TaxCode = z.infer<typeof TaxCode>;
+```
+
+Generation command:
+
+```bash
+npx @apical-ts/craft generate \
+  --client \
+  --routes \
+  --server \
+  -i openapi.yaml \
+  -o generated \
+  --format tax-code=./src/zod/TaxCode.ts
+```
+
+## What Gets Generated
+
+When a field or parameter matches the configured format:
+
+1. The generated schema file imports your custom Zod schema.
+2. The matching property or parameter reuses that schema instead of the
+   built-in string-format logic.
+3. The resulting type flows through generated schemas, routes, client
+   operations, and server wrappers.
+
+For the example above, both `Profile.fiscalCode` and the `taxCode` path
+parameter will use `TaxCode` end-to-end.
+
+## Import Sources
+
+You can import overrides from:
+
+- **A package or module specifier**
+
+  ```bash
+  --format uuid=@acme/domain-schemas#Uuid
+  ```
+
+- **A project path**
+
+  ```bash
+  --format tax-code=./src/zod/TaxCode.ts
+  ```
+
+If you omit `#<export>`, `craft` infers the export name automatically:
+
+- `./src/zod/TaxCode.ts` → `TaxCode`
+- `@acme/domain-schemas/Uuid` → `Uuid`
+
+## Validation Rules
+
+The CLI validates overrides before generation starts:
+
+- duplicate mappings for the same format are rejected
+- empty format names are rejected
+- invalid export names are rejected
+- an import target ending with `#` is rejected
+- ambiguous mappings that would generate the same internal reference are
+  rejected
+
+## Behavior Notes
+
+- The override applies only to matching OpenAPI `type: string` formats
+- Once a mapping matches, the generated code delegates validation to your custom
+  schema
+- Built-in string-format constraints are not combined with the custom schema for
+  that field
+
+## Related Pages
+
+- [CLI Usage](../cli-usage.md)
+- [Supported Features](../supported-features.md)

--- a/apps/website/docs/schema-generation/string-format-overrides.md
+++ b/apps/website/docs/schema-generation/string-format-overrides.md
@@ -19,9 +19,9 @@ keywords:
 `@apical-ts/craft` can replace the built-in handling of an OpenAPI
 `type: string` + `format` combination with your own Zod schema.
 
-This is useful when a format in your API represents a domain-specific value
-such as a tax code, customer ID, slug, or branded UUID that should be validated
-by a custom schema instead of the default string-format mapping.
+This is useful when a format in your API represents a domain-specific value such
+as a tax code, customer ID, slug, or branded UUID that should be validated by a
+custom schema instead of the default string-format mapping.
 
 ## CLI Syntax
 
@@ -50,8 +50,8 @@ npx @apical-ts/craft generate \
 
 - `<format>` must match the OpenAPI `format` value exactly
 - `<module-or-path>` accepts package specifiers and explicit project paths
-- `#<export>` is optional; when omitted, `craft` infers the export name from
-  the last module or path segment
+- `#<export>` is optional; when omitted, `craft` infers the export name from the
+  last module or path segment
 - `--format` can be provided multiple times
 
 ## Example
@@ -109,8 +109,8 @@ npx @apical-ts/craft generate \
 When a field or parameter matches the configured format:
 
 1. The generated schema file imports your custom Zod schema.
-2. The matching property or parameter reuses that schema instead of the
-   built-in string-format logic.
+2. The matching property or parameter reuses that schema instead of the built-in
+   string-format logic.
 3. The resulting type flows through generated schemas, routes, client
    operations, and server wrappers.
 

--- a/apps/website/docs/supported-features.md
+++ b/apps/website/docs/supported-features.md
@@ -33,6 +33,9 @@ experience.
   automatically or call `response.parse()` as needed
 - ⚙️ **Configurable validation modes**: Control how schemas handle additional
   properties with `--extra-props` flag (strip, loose, or strict validation)
+- 🧬 **Custom string format overrides**: Replace specific OpenAPI string
+  formats with imported Zod schemas via `--format`, with type propagation across
+  generated schemas, routes, client, and server code
 - 📦 **Small footprint**: Generates each operation and schema/type in its own
   file for maximum tree-shaking and modularity
 - 🚀 **Fast code generation**: Optimized for quick generation times, even with
@@ -90,6 +93,8 @@ experience.
 - Comprehensive error types with context
 - Validation error details with field-level information
 - Configurable additional properties handling (strip/loose/strict modes)
+- Custom domain validation for OpenAPI string formats through imported Zod
+  schemas
 - Respect for explicit OpenAPI `additionalProperties` settings
 - **ReadOnly and WriteOnly property handling**: Automatic variant generation for
   schemas with `readOnly` and `writeOnly` properties, ensuring type-safe request

--- a/apps/website/docs/supported-features.md
+++ b/apps/website/docs/supported-features.md
@@ -33,8 +33,8 @@ experience.
   automatically or call `response.parse()` as needed
 - ⚙️ **Configurable validation modes**: Control how schemas handle additional
   properties with `--extra-props` flag (strip, loose, or strict validation)
-- 🧬 **Custom string format overrides**: Replace specific OpenAPI string
-  formats with imported Zod schemas via `--format`, with type propagation across
+- 🧬 **Custom string format overrides**: Replace specific OpenAPI string formats
+  with imported Zod schemas via `--format`, with type propagation across
   generated schemas, routes, client, and server code
 - 📦 **Small footprint**: Generates each operation and schema/type in its own
   file for maximum tree-shaking and modularity

--- a/apps/website/sidebars.ts
+++ b/apps/website/sidebars.ts
@@ -41,7 +41,10 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       type: "category",
       label: "Schema Generation",
-      items: ["schema-generation/readonly-writeonly-properties"],
+      items: [
+        "schema-generation/string-format-overrides",
+        "schema-generation/readonly-writeonly-properties",
+      ],
     },
     "server-routes-wrappers-generation",
     "supported-input-formats",

--- a/packages/core-utils/src/core-generator/package-generator.ts
+++ b/packages/core-utils/src/core-generator/package-generator.ts
@@ -1,29 +1,32 @@
 import { promises as fs } from "fs";
 import path from "path";
 
-const tsConfigContent = {
-  compilerOptions: {
-    allowSyntheticDefaultImports: true,
-    esModuleInterop: true,
-    forceConsistentCasingInFileNames: true,
-    lib: ["es2025"],
-    module: "NodeNext",
-    moduleResolution: "NodeNext",
-    noEmitOnError: false,
-    outDir: "dist",
-    resolveJsonModule: true,
-    rootDir: ".",
-    skipLibCheck: true,
-    strict: true,
-    target: "es2025",
-    types: ["node"],
-  },
+import type { StringFormatOverride } from "../schema-generator/format-overrides.js";
+
+const baseCompilerOptions: Record<string, unknown> = {
+  allowSyntheticDefaultImports: true,
+  esModuleInterop: true,
+  forceConsistentCasingInFileNames: true,
+  lib: ["es2024"],
+  module: "NodeNext",
+  moduleResolution: "NodeNext",
+  noEmitOnError: false,
+  outDir: "dist",
+  resolveJsonModule: true,
+  skipLibCheck: true,
+  strict: true,
+  target: "es2024",
+  types: ["node"],
 };
 
-/**
- * Creates the package metadata files for the generated output
- */
-export async function createPackageFiles(output: string): Promise<void> {
+export async function createPackageFiles(
+  output: string,
+  formatOverrides: readonly StringFormatOverride[] = [],
+): Promise<void> {
+  const compilerOptions = { ...baseCompilerOptions };
+  if (!formatOverrides.some((override) => override.import.kind === "path")) {
+    compilerOptions.rootDir = ".";
+  }
   const packageJsonContent = {
     dependencies: {
       zod: "^4.0.0",
@@ -46,7 +49,7 @@ export async function createPackageFiles(output: string): Promise<void> {
     ),
     fs.writeFile(
       path.join(output, "tsconfig.json"),
-      JSON.stringify(tsConfigContent, null, 2),
+      JSON.stringify({ compilerOptions }, null, 2),
     ),
   ]);
 }

--- a/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
+++ b/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
@@ -5,8 +5,10 @@ import pLimit from "p-limit";
 import path from "path";
 
 import type { Profiler } from "./profiler.js";
+import type { StringFormatOverride } from "../schema-generator/format-overrides.js";
 
 import {
+  createStringFormatOverrideRegistry,
   analyzeSchemaForRecursion,
   createRecursiveContext,
   findRecursiveSchemas,
@@ -41,6 +43,7 @@ interface ComponentSchemaOptions {
 
 interface SchemaGenerationContext {
   extraProps: ExtraPropsMode;
+  formatOverrides: ReturnType<typeof createStringFormatOverrideRegistry>;
   generateServer: boolean;
   limit: ReturnType<typeof pLimit>;
   openApiDoc: OpenAPIObject;
@@ -63,6 +66,7 @@ export async function generateSchemas(
   generateServer: boolean,
   extraProps: ExtraPropsMode,
   profiler?: Profiler,
+  formatOverrides: readonly StringFormatOverride[] = [],
 ): Promise<void> {
   const schemasDir = path.join(output, "schemas");
   await fs.mkdir(schemasDir, { recursive: true });
@@ -70,6 +74,7 @@ export async function generateSchemas(
   const limit = pLimit(concurrency);
   const context: SchemaGenerationContext = {
     extraProps,
+    formatOverrides: createStringFormatOverrideRegistry(formatOverrides),
     generateServer,
     limit,
     openApiDoc,
@@ -85,13 +90,25 @@ export async function generateSchemas(
       ...createSchemaGenerationPromises(
         extractRequestSchemas(openApiDoc),
         context,
-        generateRequestSchemaFile,
+        (name, schema) =>
+          generateRequestSchemaFile(name, schema, {
+            extraProps: context.extraProps,
+            formatOverrides: context.formatOverrides,
+            resolvedSchemas: context.resolvedSchemas,
+            schemaDirectory: context.schemasDir,
+          }),
       ),
       // Generate response schemas from operations
       ...createSchemaGenerationPromises(
         extractResponseSchemas(openApiDoc),
         context,
-        generateResponseSchemaFile,
+        (name, schema) =>
+          generateResponseSchemaFile(name, schema, {
+            extraProps: context.extraProps,
+            formatOverrides: context.formatOverrides,
+            resolvedSchemas: context.resolvedSchemas,
+            schemaDirectory: context.schemasDir,
+          }),
       ),
       // Generate parameter schemas from operations
       ...generateParameterSchemas(openApiDoc, context),
@@ -113,7 +130,13 @@ export async function generateSchemas(
       createSchemaGenerationPromises(
         extractRequestSchemas(openApiDoc),
         context,
-        generateRequestSchemaFile,
+        (name, schema) =>
+          generateRequestSchemaFile(name, schema, {
+            extraProps: context.extraProps,
+            formatOverrides: context.formatOverrides,
+            resolvedSchemas: context.resolvedSchemas,
+            schemaDirectory: context.schemasDir,
+          }),
       ),
     );
     profiler.end("schemas:requests");
@@ -123,7 +146,13 @@ export async function generateSchemas(
       createSchemaGenerationPromises(
         extractResponseSchemas(openApiDoc),
         context,
-        generateResponseSchemaFile,
+        (name, schema) =>
+          generateResponseSchemaFile(name, schema, {
+            extraProps: context.extraProps,
+            formatOverrides: context.formatOverrides,
+            resolvedSchemas: context.resolvedSchemas,
+            schemaDirectory: context.schemasDir,
+          }),
       ),
     );
     profiler.end("schemas:responses");
@@ -167,17 +196,21 @@ function createComponentSchemaPromise(
         ? generateRecursiveSchemaFile({
             description,
             extraProps: context.extraProps,
+            formatOverrides: context.formatOverrides,
             name: schemaName,
             originalSchemaName: originalSchemaName || schemaName,
             recursiveContext,
             resolvedSchemas: context.resolvedSchemas,
+            schemaDirectory: context.schemasDir,
             schema,
           })
         : generateSchemaFile(schemaName, schema, description, {
             extraProps: context.extraProps,
+            formatOverrides: context.formatOverrides,
             originalSchemaName,
             recursiveContext,
             resolvedSchemas: context.resolvedSchemas,
+            schemaDirectory: context.schemasDir,
           });
 
     const schemaFile = await generationPromise;
@@ -307,6 +340,7 @@ function generateParameterSchemas(
         {
           /* Client defaults - no coercion or special handling */
           coercePrimitives: false,
+          formatOverrides: context.formatOverrides,
           lowercaseHeaderKeys: false,
         },
       ),

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -41,6 +41,7 @@ export {
   generateSchemaVariants,
   type SchemaVariantsResult,
 } from "./schema-generator/file-generators.js";
+export type { StringFormatOverride } from "./schema-generator/format-overrides.js";
 export {
   determineObjectMethod,
   generateObjectCode,

--- a/packages/core-utils/src/schema-generator/file-generators.ts
+++ b/packages/core-utils/src/schema-generator/file-generators.ts
@@ -1,12 +1,18 @@
 import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
 
 import { isReferenceObject } from "openapi3-ts/oas31";
+import path from "node:path";
 
 import type { ExtraPropsMode, SchemaContext } from "../shared/types.js";
+import type { StringFormatOverrideRegistry } from "./format-overrides.js";
 import type { RecursiveContext } from "./recursive-handlers.js";
 import type { ResolvedSchemas } from "./types.js";
 
 import { analyzeReadWriteProperties } from "../shared/types.js";
+import {
+  findStringFormatOverrideByReferenceName,
+  renderStringFormatOverrideImports,
+} from "./format-overrides.js";
 import { generateObjectCode } from "./object-properties.js";
 import {
   createRecursiveContext,
@@ -21,10 +27,12 @@ import { sanitizeIdentifier } from "./utils.js";
 interface RecursiveSchemaFileOptions {
   description?: string;
   extraProps?: ExtraPropsMode;
+  formatOverrides?: StringFormatOverrideRegistry;
   name: string;
   originalSchemaName: string;
   recursiveContext: RecursiveContext;
   resolvedSchemas?: ResolvedSchemas;
+  schemaDirectory?: string;
   schema: SchemaObject;
 }
 
@@ -43,9 +51,11 @@ interface SchemaFileResult {
  */
 interface SchemaGenerationOptions {
   extraProps?: ExtraPropsMode;
+  formatOverrides?: StringFormatOverrideRegistry;
   originalSchemaName?: string;
   recursiveContext?: RecursiveContext;
   resolvedSchemas?: ResolvedSchemas;
+  schemaDirectory?: string;
   schemaContext?: SchemaContext;
 }
 
@@ -66,10 +76,12 @@ export async function generateRecursiveSchemaFile(
   const {
     description,
     extraProps,
+    formatOverrides,
     name,
     originalSchemaName,
     recursiveContext,
     resolvedSchemas,
+    schemaDirectory = ".",
     schema,
   } = options;
 
@@ -114,6 +126,7 @@ export async function generateRecursiveSchemaFile(
       const propResult = zodSchemaToCode(propSchema, {
         currentSchemaName: name,
         extraProps,
+        formatOverrides,
         imports: new Set(),
         recursiveContext,
         resolvedSchemas,
@@ -153,6 +166,7 @@ export async function generateRecursiveSchemaFile(
       const propResult = zodSchemaToCode(propSchema, {
         currentSchemaName: name,
         extraProps,
+        formatOverrides,
         imports: new Set(),
         recursiveContext,
         resolvedSchemas,
@@ -172,8 +186,6 @@ export async function generateRecursiveSchemaFile(
     }
   }
 
-  const importsSection = generateImportsSection(imports, name);
-
   /*
    * Use additionalProperties to determine object type and generate code using common function
    */
@@ -185,6 +197,7 @@ export async function generateRecursiveSchemaFile(
       currentSchemaName: name,
       extraProps,
       formatShape: true,
+      formatOverrides,
       imports,
       recursiveContext,
       resolvedSchemas,
@@ -198,6 +211,12 @@ export async function generateRecursiveSchemaFile(
   });
 
   const schemaCode = objectCodeResult.code;
+  const importsSection = generateImportsSection(
+    imports,
+    name,
+    path.join(schemaDirectory, `${name}.ts`),
+    formatOverrides,
+  );
 
   const content = assembleFileContent(
     name,
@@ -248,14 +267,20 @@ export async function generateSchemaFile(
   description?: string,
   options: SchemaGenerationOptions = {},
 ): Promise<SchemaFileResult> {
-  const { extraProps, recursiveContext, resolvedSchemas, schemaContext } =
-    options;
+  const {
+    extraProps,
+    recursiveContext,
+    resolvedSchemas,
+    schemaContext,
+    schemaDirectory,
+  } = options;
 
   const context = recursiveContext || createRecursiveContext();
 
   const schemaResult = zodSchemaToCode(schema, {
     currentSchemaName: name,
     extraProps,
+    formatOverrides: options.formatOverrides,
     isTopLevel: true,
     recursiveContext: context,
     resolvedSchemas,
@@ -263,7 +288,12 @@ export async function generateSchemaFile(
   });
 
   const commentSection = generateCommentSection(description);
-  const importsSection = generateImportsSection(schemaResult.imports, name);
+  const importsSection = generateImportsSection(
+    schemaResult.imports,
+    name,
+    path.join(schemaDirectory || ".", `${name}.ts`),
+    options.formatOverrides,
+  );
 
   const content = assembleFileContent(
     name,
@@ -279,8 +309,10 @@ export async function generateSchemaFile(
     const variants = generateSchemaVariants(schema);
     variantFiles = await generateVariantSchemaFiles(name, schema, variants, {
       extraProps,
+      formatOverrides: options.formatOverrides,
       recursiveContext,
       resolvedSchemas,
+      schemaDirectory,
     });
   }
 
@@ -386,10 +418,25 @@ function generateGetterCode(
 function generateImportsSection(
   imports: Set<string>,
   currentSchemaName: string,
+  filePath: string,
+  formatOverrides?: StringFormatOverrideRegistry,
 ): string {
-  const importStatements = Array.from(imports)
-    .filter((importName) => importName !== currentSchemaName) // Don't import self
+  const localImportStatements = Array.from(imports)
+    .filter(
+      (importName) =>
+        importName !== currentSchemaName &&
+        !findStringFormatOverrideByReferenceName(importName, formatOverrides),
+    )
+    .sort()
     .map((importName) => `import { ${importName} } from "./${importName}.js";`)
+    .join("\n");
+  const externalImportStatements = renderStringFormatOverrideImports(
+    imports,
+    formatOverrides,
+    filePath,
+  ).join("\n");
+  const importStatements = [externalImportStatements, localImportStatements]
+    .filter(Boolean)
     .join("\n");
   return importStatements ? `${importStatements}\n` : "";
 }

--- a/packages/core-utils/src/schema-generator/format-overrides.ts
+++ b/packages/core-utils/src/schema-generator/format-overrides.ts
@@ -1,0 +1,139 @@
+import path from "node:path";
+
+import { sanitizeIdentifier } from "./utils.js";
+
+export type StringFormatOverrideImport =
+  | { kind: "module"; specifier: string }
+  | { kind: "path"; path: string };
+
+export interface StringFormatOverride {
+  format: string;
+  import: StringFormatOverrideImport;
+  importName: string;
+}
+
+export type StringFormatOverrideRegistry = ReadonlyMap<
+  string,
+  StringFormatOverride
+>;
+
+export function createStringFormatOverrideRegistry(
+  overrides: readonly StringFormatOverride[] = [],
+): StringFormatOverrideRegistry {
+  const registry = new Map<string, StringFormatOverride>();
+
+  for (const override of overrides) {
+    registry.set(override.format, override);
+  }
+
+  return registry;
+}
+
+export function findStringFormatOverride(
+  format: string | undefined,
+  registry?: StringFormatOverrideRegistry,
+): StringFormatOverride | undefined {
+  if (!format || !registry) {
+    return undefined;
+  }
+
+  return registry.get(format);
+}
+
+export function findStringFormatOverrideByReferenceName(
+  referenceName: string,
+  registry?: StringFormatOverrideRegistry,
+): StringFormatOverride | undefined {
+  if (!registry) {
+    return undefined;
+  }
+
+  for (const override of registry.values()) {
+    if (
+      getStringFormatOverrideReferenceName(override.format) === referenceName
+    ) {
+      return override;
+    }
+  }
+
+  return undefined;
+}
+
+export function renderStringFormatOverrideImports(
+  imports: Iterable<string>,
+  registry: StringFormatOverrideRegistry | undefined,
+  filePath: string,
+): string[] {
+  if (!registry) {
+    return [];
+  }
+
+  const groupedImports = new Map<string, Set<string>>();
+  const seenReferenceNames = new Set<string>();
+
+  for (const importName of imports) {
+    if (seenReferenceNames.has(importName)) {
+      continue;
+    }
+    seenReferenceNames.add(importName);
+
+    const override = findStringFormatOverrideByReferenceName(
+      importName,
+      registry,
+    );
+    if (!override) {
+      continue;
+    }
+
+    const importSpecifier = getImportSpecifier(override.import, filePath);
+    const renderedBinding = `${override.importName} as ${importName}`;
+    const bindings = groupedImports.get(importSpecifier) ?? new Set<string>();
+    bindings.add(renderedBinding);
+    groupedImports.set(importSpecifier, bindings);
+  }
+
+  return Array.from(groupedImports.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([importSpecifier, bindings]) => {
+      const sortedBindings = Array.from(bindings).sort();
+      return `import { ${sortedBindings.join(", ")} } from ${JSON.stringify(importSpecifier)};`;
+    });
+}
+
+export function getStringFormatOverrideReferenceName(format: string): string {
+  const identifier = sanitizeIdentifier(format);
+  return `__apicalStringFormat${identifier.charAt(0).toUpperCase()}${identifier.slice(1)}`;
+}
+
+function getImportSpecifier(
+  source: StringFormatOverrideImport,
+  filePath: string,
+): string {
+  if (source.kind === "module") {
+    return source.specifier;
+  }
+
+  const relativePath = path.relative(path.dirname(filePath), source.path);
+  const normalizedPath = relativePath.replaceAll(path.sep, "/");
+  const importPath = normalizedPath.startsWith(".")
+    ? normalizedPath
+    : `./${normalizedPath}`;
+
+  return rewriteTypeScriptExtension(importPath);
+}
+
+function rewriteTypeScriptExtension(importPath: string): string {
+  if (importPath.endsWith(".d.ts")) {
+    return `${importPath.slice(0, -5)}.js`;
+  }
+  if (importPath.endsWith(".mts")) {
+    return `${importPath.slice(0, -4)}.mjs`;
+  }
+  if (importPath.endsWith(".cts")) {
+    return `${importPath.slice(0, -4)}.cjs`;
+  }
+  if (importPath.endsWith(".ts") || importPath.endsWith(".tsx")) {
+    return `${importPath.slice(0, importPath.lastIndexOf("."))}.js`;
+  }
+  return importPath;
+}

--- a/packages/core-utils/src/schema-generator/format-overrides.ts
+++ b/packages/core-utils/src/schema-generator/format-overrides.ts
@@ -26,12 +26,74 @@ export function createStringFormatOverrideRegistry(
   overrides: readonly StringFormatOverride[] = [],
 ): StringFormatOverrideRegistry {
   const registry = new Map<string, StringFormatOverride>();
+  const referenceNames = new Set<string>();
 
   for (const override of overrides) {
+    const referenceName = validateStringFormatOverride(
+      override,
+      registry,
+      referenceNames,
+    );
+
     registry.set(override.format, override);
+    referenceNames.add(referenceName);
   }
 
   return registry;
+}
+
+function validateStringFormatOverride(
+  override: StringFormatOverride,
+  registry: ReadonlyMap<string, StringFormatOverride>,
+  referenceNames: ReadonlySet<string>,
+): string {
+  assertNonEmptyFormat(override.format);
+  assertValidImportName(override.importName, override.format);
+
+  if (registry.has(override.format)) {
+    throw new Error(
+      `Duplicate string format override for format "${override.format}".`,
+    );
+  }
+
+  const referenceName = getStringFormatOverrideReferenceName(override.format);
+  if (referenceNames.has(referenceName)) {
+    throw new Error(
+      `Duplicate string format override reference name "${referenceName}" derived from format "${override.format}".`,
+    );
+  }
+
+  return referenceName;
+}
+
+function assertNonEmptyFormat(format: string): void {
+  if (format.trim().length === 0) {
+    throw new Error(
+      "String format override format must be a non-empty string.",
+    );
+  }
+}
+
+function assertValidImportName(importName: string, format: string): void {
+  const trimmedImportName = importName.trim();
+  if (trimmedImportName.length === 0) {
+    throw new Error(
+      `String format override "${format}" must specify a non-empty importName.`,
+    );
+  }
+
+  try {
+    if (
+      trimmedImportName !== importName ||
+      sanitizeIdentifier(trimmedImportName) !== trimmedImportName
+    ) {
+      throw new Error("Invalid import name.");
+    }
+  } catch {
+    throw new Error(
+      `String format override "${format}" has an invalid importName "${importName}".`,
+    );
+  }
 }
 
 /*

--- a/packages/core-utils/src/schema-generator/format-overrides.ts
+++ b/packages/core-utils/src/schema-generator/format-overrides.ts
@@ -17,6 +17,11 @@ export type StringFormatOverrideRegistry = ReadonlyMap<
   StringFormatOverride
 >;
 
+/*
+ * Builds the lookup map used during schema conversion.
+ * A registry keeps format resolution O(1) once CLI input has already been
+ * validated and normalized upstream.
+ */
 export function createStringFormatOverrideRegistry(
   overrides: readonly StringFormatOverride[] = [],
 ): StringFormatOverrideRegistry {
@@ -29,6 +34,10 @@ export function createStringFormatOverrideRegistry(
   return registry;
 }
 
+/*
+ * Resolves the override for a raw OpenAPI `format` token.
+ * This is the main lookup used by primitive string conversion.
+ */
 export function findStringFormatOverride(
   format: string | undefined,
   registry?: StringFormatOverrideRegistry,
@@ -40,6 +49,12 @@ export function findStringFormatOverride(
   return registry.get(format);
 }
 
+/*
+ * Resolves an override starting from the generated alias name rather than the
+ * original OpenAPI format token.
+ * File writers use this in the opposite direction when they need to turn a
+ * dependency like `__apicalStringFormatTaxCode` back into a real import.
+ */
 export function findStringFormatOverrideByReferenceName(
   referenceName: string,
   registry?: StringFormatOverrideRegistry,
@@ -59,6 +74,12 @@ export function findStringFormatOverrideByReferenceName(
   return undefined;
 }
 
+/*
+ * Renders import statements for the reserved aliases used by format overrides.
+ * The caller passes the full dependency set for a generated file; this helper
+ * filters out only override aliases, groups them by source, and emits stable
+ * sorted imports.
+ */
 export function renderStringFormatOverrideImports(
   imports: Iterable<string>,
   registry: StringFormatOverrideRegistry | undefined,
@@ -72,6 +93,7 @@ export function renderStringFormatOverrideImports(
   const seenReferenceNames = new Set<string>();
 
   for (const importName of imports) {
+    // Multiple schema fragments can require the same alias; emit it once.
     if (seenReferenceNames.has(importName)) {
       continue;
     }
@@ -86,6 +108,7 @@ export function renderStringFormatOverrideImports(
     }
 
     const importSpecifier = getImportSpecifier(override.import, filePath);
+    // Keep the generated alias stable even if the user export name is generic.
     const renderedBinding = `${override.importName} as ${importName}`;
     const bindings = groupedImports.get(importSpecifier) ?? new Set<string>();
     bindings.add(renderedBinding);
@@ -100,11 +123,21 @@ export function renderStringFormatOverrideImports(
     });
 }
 
+/*
+ * Generates the reserved local alias used inside generated code for a format
+ * override. The alias is deterministic and sanitized so it never depends on
+ * user-export naming conventions.
+ */
 export function getStringFormatOverrideReferenceName(format: string): string {
   const identifier = sanitizeIdentifier(format);
   return `__apicalStringFormat${identifier.charAt(0).toUpperCase()}${identifier.slice(1)}`;
 }
 
+/*
+ * Converts an override source into the import specifier that should appear in
+ * generated files. Module specifiers are preserved, while filesystem paths are
+ * rewritten relative to the generated file location.
+ */
 function getImportSpecifier(
   source: StringFormatOverrideImport,
   filePath: string,
@@ -115,6 +148,7 @@ function getImportSpecifier(
 
   const relativePath = path.relative(path.dirname(filePath), source.path);
   const normalizedPath = relativePath.replaceAll(path.sep, "/");
+  // Ensure path-based imports stay valid ESM relative specifiers.
   const importPath = normalizedPath.startsWith(".")
     ? normalizedPath
     : `./${normalizedPath}`;
@@ -122,6 +156,11 @@ function getImportSpecifier(
   return rewriteTypeScriptExtension(importPath);
 }
 
+/*
+ * Rewrites TypeScript source extensions to the runtime module extension that
+ * generated ESM code must import. This keeps path-based overrides compatible
+ * with the emitted `.js`/`.mjs`/`.cjs` files.
+ */
 function rewriteTypeScriptExtension(importPath: string): string {
   if (importPath.endsWith(".d.ts")) {
     return `${importPath.slice(0, -5)}.js`;

--- a/packages/core-utils/src/schema-generator/index.ts
+++ b/packages/core-utils/src/schema-generator/index.ts
@@ -4,6 +4,10 @@ export {
   generateResponseSchemaFile,
   generateSchemaFile,
 } from "./file-generators.js";
+export {
+  createStringFormatOverrideRegistry,
+  type StringFormatOverride,
+} from "./format-overrides.js";
 export { writeParameterSchemaFile } from "./parameter-file-generator.js";
 export {
   analyzeSchemaForRecursion,

--- a/packages/core-utils/src/schema-generator/object-properties.ts
+++ b/packages/core-utils/src/schema-generator/object-properties.ts
@@ -1,6 +1,7 @@
 import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
 
 import type { ExtraPropsMode } from "../shared/types.js";
+import type { StringFormatOverrideRegistry } from "./format-overrides.js";
 import type { RecursiveContext } from "./recursive-handlers.js";
 import type { ResolvedSchemas } from "./types.js";
 
@@ -19,6 +20,7 @@ export interface ObjectPropertyOptions {
   currentSchemaName?: string;
   extraProps?: ExtraPropsMode;
   formatShape?: boolean;
+  formatOverrides?: StringFormatOverrideRegistry;
   imports?: Set<string>;
   recursiveContext?: RecursiveContext;
   resolvedSchemas?: ResolvedSchemas;
@@ -53,7 +55,10 @@ export function generateObjectCode(
   zodSchemaToCode: (
     schema: ReferenceObject | SchemaObject,
     options?: ObjectPropertyOptions,
-  ) => { code: string; imports: Set<string> },
+  ) => {
+    code: string;
+    imports: Set<string>;
+  },
   options: ObjectPropertyOptions = {},
 ): ObjectCodeResult {
   const imports = options.imports || new Set<string>();
@@ -99,6 +104,7 @@ export function generateObjectCode(
     const additionalResult = zodSchemaToCode(additionalProperties, {
       currentSchemaName: options.currentSchemaName,
       imports,
+      formatOverrides: options.formatOverrides,
       recursiveContext: options.recursiveContext,
       resolvedSchemas: options.resolvedSchemas,
     });

--- a/packages/core-utils/src/schema-generator/object-types.ts
+++ b/packages/core-utils/src/schema-generator/object-types.ts
@@ -38,6 +38,7 @@ export function handleObjectType(
       const propResult = zodSchemaToCode(propSchema, {
         currentSchemaName,
         imports: result.imports,
+        formatOverrides: options.formatOverrides,
         recursiveContext,
         resolvedSchemas,
         schemaContext,
@@ -68,6 +69,7 @@ export function handleObjectType(
     {
       currentSchemaName,
       extraProps,
+      formatOverrides: options.formatOverrides,
       imports: result.imports,
       recursiveContext,
       resolvedSchemas,

--- a/packages/core-utils/src/schema-generator/parameter-file-generator.ts
+++ b/packages/core-utils/src/schema-generator/parameter-file-generator.ts
@@ -2,7 +2,12 @@ import { promises as fs } from "fs";
 import path from "path";
 
 import type { OperationParameterMetadata } from "../core-generator/parameter-extractor.js";
+import type { StringFormatOverrideRegistry } from "./format-overrides.js";
 
+import {
+  findStringFormatOverrideByReferenceName,
+  renderStringFormatOverrideImports,
+} from "./format-overrides.js";
 import { generateParameterSchemas } from "../shared/parameter-schemas.js";
 import { sanitizeIdentifier } from "./utils.js";
 
@@ -12,7 +17,6 @@ import { sanitizeIdentifier } from "./utils.js";
 interface ParameterSchemaFileResult {
   content: string;
   fileName: string;
-  typeImports: Set<string>;
 }
 
 /**
@@ -20,11 +24,13 @@ interface ParameterSchemaFileResult {
  * Creates separate files for each operation's query, path, and headers schemas.
  */
 async function generateParameterSchemaFile(
+  schemasDir: string,
   operationId: string,
   parameterMetadata: OperationParameterMetadata,
   options: {
     /* Use client defaults for parameter schema generation */
     coercePrimitives?: boolean;
+    formatOverrides?: StringFormatOverrideRegistry;
     lowercaseHeaderKeys?: boolean;
   } = {},
 ): Promise<ParameterSchemaFileResult> {
@@ -49,6 +55,7 @@ async function generateParameterSchemaFile(
     parameterMetadata.parameterGroups,
     {
       coercePrimitives: true,
+      formatOverrides: options.formatOverrides,
       lowercaseHeaderKeys: true,
       securityHeaders,
     },
@@ -72,12 +79,29 @@ async function generateParameterSchemaFile(
 
   /* Add other type imports */
   if (result.typeImports.size > 0) {
-    const typeImportsList = Array.from(result.typeImports).sort();
+    const typeImportsList = Array.from(result.typeImports)
+      .filter(
+        (typeImport) =>
+          typeImport !== "z" &&
+          !findStringFormatOverrideByReferenceName(
+            typeImport,
+            options.formatOverrides,
+          ),
+      )
+      .sort();
     for (const typeImport of typeImportsList) {
-      if (typeImport !== "z") {
-        imports.push(`import { ${typeImport} } from "./${typeImport}.js";`);
-      }
+      imports.push(`import { ${typeImport} } from "./${typeImport}.js";`);
     }
+  }
+
+  const filePath = path.join(schemasDir, fileName);
+  const externalImportLines = renderStringFormatOverrideImports(
+    new Set([...result.typeImports, ...serverResult.typeImports]),
+    options.formatOverrides,
+    filePath,
+  );
+  if (externalImportLines.length > 0) {
+    imports.push(...externalImportLines);
   }
 
   /* Calculate optionality for parameters */
@@ -205,7 +229,6 @@ async function generateParameterSchemaFile(
   return {
     content,
     fileName,
-    typeImports: result.typeImports,
   };
 }
 
@@ -218,10 +241,12 @@ export async function writeParameterSchemaFile(
   parameterMetadata: OperationParameterMetadata,
   options: {
     coercePrimitives?: boolean;
+    formatOverrides?: StringFormatOverrideRegistry;
     lowercaseHeaderKeys?: boolean;
   } = {},
 ): Promise<void> {
   const result = await generateParameterSchemaFile(
+    schemasDir,
     operationId,
     parameterMetadata,
     options,

--- a/packages/core-utils/src/schema-generator/primitive-types.ts
+++ b/packages/core-utils/src/schema-generator/primitive-types.ts
@@ -5,6 +5,11 @@ import type { ExtraPropsMode } from "../shared/types.js";
 import type { RecursiveContext } from "./recursive-handlers.js";
 import type { SchemaContext } from "../shared/types.js";
 import type { ResolvedSchemas } from "./types.js";
+
+import {
+  findStringFormatOverride,
+  getStringFormatOverrideReferenceName,
+} from "./format-overrides.js";
 import { handleExtensibleEnum, handleRegularEnum } from "./enum-handlers.js";
 import { addDefaultValue } from "./utils.js";
 
@@ -21,6 +26,7 @@ export function handleArrayType(
   options: {
     currentSchemaName?: string;
     extraProps?: ExtraPropsMode;
+    formatOverrides?: ZodSchemaCodeOptions["formatOverrides"];
     recursiveContext?: RecursiveContext;
     resolvedSchemas?: ResolvedSchemas;
     schemaContext?: SchemaContext;
@@ -29,6 +35,7 @@ export function handleArrayType(
   const {
     currentSchemaName,
     extraProps,
+    formatOverrides,
     recursiveContext,
     resolvedSchemas,
     schemaContext,
@@ -43,6 +50,7 @@ export function handleArrayType(
   const itemsResult = zodSchemaToCode(schema.items, {
     currentSchemaName,
     extraProps,
+    formatOverrides,
     imports: result.imports,
     recursiveContext,
     resolvedSchemas,
@@ -139,12 +147,26 @@ export function handleNumberType(
 export function handleStringType(
   schema: SchemaObject,
   result: ZodSchemaResult,
+  formatOverrides?: ZodSchemaCodeOptions["formatOverrides"],
 ): ZodSchemaResult {
   // Handle x-extensible-enum first, as it takes precedence over regular enum
   const extensibleEnumResult = handleExtensibleEnum(schema);
   if (extensibleEnumResult) {
     result.code = extensibleEnumResult.code;
     result.extensibleEnumValues = extensibleEnumResult.enumValues;
+    return result;
+  }
+
+  if (schema.enum && schema.enum.length >= 1) {
+    result.code = handleRegularEnum(schema.enum, schema.default);
+    return result;
+  }
+
+  const override = findStringFormatOverride(schema.format, formatOverrides);
+  if (override) {
+    const referenceName = getStringFormatOverrideReferenceName(override.format);
+    result.imports.add(referenceName);
+    result.code = addDefaultValue(referenceName, schema.default);
     return result;
   }
 
@@ -175,13 +197,8 @@ export function handleStringType(
   // while in Node.js, fetch returns a Blob instance.
   if (schema.format === "binary") code = "z.instanceof(Blob)";
 
-  // Handle enums for strings (both single and multi-value)
-  if (schema.enum && schema.enum.length >= 1) {
-    code = handleRegularEnum(schema.enum, schema.default);
-  } else {
-    // Add default value if present and no enum
-    code = addDefaultValue(code, schema.default);
-  }
+  // Add default value if present and no enum
+  code = addDefaultValue(code, schema.default);
 
   result.code = code;
   return result;

--- a/packages/core-utils/src/schema-generator/schema-converter.ts
+++ b/packages/core-utils/src/schema-generator/schema-converter.ts
@@ -41,6 +41,7 @@ export function zodSchemaToCode(
   const {
     currentSchemaName,
     extraProps,
+    formatOverrides,
     imports,
     recursiveContext,
     resolvedSchemas,
@@ -77,6 +78,7 @@ export function zodSchemaToCode(
         currentSchemaName,
         resolvedSchemas,
         extraProps,
+        formatOverrides,
       ),
     );
   }
@@ -103,6 +105,7 @@ export function zodSchemaToCode(
         currentSchemaName,
         resolvedSchemas,
         extraProps,
+        formatOverrides,
       ),
     );
   }
@@ -115,6 +118,7 @@ export function zodSchemaToCode(
     currentSchemaName,
     resolvedSchemas,
     extraProps,
+    formatOverrides,
   );
   if (composition) return applyDesc(composition);
 
@@ -128,6 +132,7 @@ export function zodSchemaToCode(
     resolvedSchemas,
     extraProps,
     schemaContext,
+    formatOverrides,
   );
   if (primitiveHandled) return applyDesc(primitiveHandled);
 
@@ -138,7 +143,10 @@ export function zodSchemaToCode(
 
 /* Internal helper: creates an empty ZodSchemaResult reusing provided imports set when present */
 function createResult(imports?: Set<string>): ZodSchemaResult {
-  return { code: "", imports: imports || new Set<string>() };
+  return {
+    code: "",
+    imports: imports || new Set<string>(),
+  };
 }
 
 /* Internal helper: handles OpenAPI 3.1 multi-type (array) declarations like ["string","null"] */
@@ -150,6 +158,7 @@ function handleMultiTypeArray(
   currentSchemaName?: string,
   resolvedSchemas?: ResolvedSchemas,
   extraProps?: ExtraPropsMode,
+  formatOverrides?: ZodSchemaCodeOptions["formatOverrides"],
 ): ZodSchemaResult {
   const { isNullable: hasNull, nonNullTypes } = analyzeTypeArray(effectiveType);
   if (nonNullTypes.length === 1 && hasNull) {
@@ -163,6 +172,7 @@ function handleMultiTypeArray(
     const subResult = zodSchemaToCode(clone as SchemaObject, {
       currentSchemaName,
       extraProps,
+      formatOverrides,
       imports: result.imports,
       recursiveContext,
       resolvedSchemas,
@@ -181,6 +191,7 @@ function handleMultiTypeArray(
     zodSchemaToCode({ ...schema, type: t } as SchemaObject, {
       currentSchemaName,
       extraProps,
+      formatOverrides,
       imports: result.imports,
       recursiveContext,
       resolvedSchemas,
@@ -201,6 +212,7 @@ function handleNullableSchema(
   currentSchemaName?: string,
   resolvedSchemas?: ResolvedSchemas,
   extraProps?: ExtraPropsMode,
+  formatOverrides?: ZodSchemaCodeOptions["formatOverrides"],
 ): ZodSchemaResult {
   // Same rationale as handleMultiTypeArray(): nullable defaults such as `null`
   // must be applied to the outer nullable schema, not to the inner non-null one.
@@ -208,6 +220,7 @@ function handleNullableSchema(
   const subResult = zodSchemaToCode(clone, {
     currentSchemaName,
     extraProps,
+    formatOverrides,
     imports: result.imports,
     recursiveContext,
     resolvedSchemas,
@@ -231,8 +244,11 @@ function handlePrimitive(
   resolvedSchemas?: ResolvedSchemas,
   extraProps?: ExtraPropsMode,
   schemaContext?: SchemaContext,
+  formatOverrides?: ZodSchemaCodeOptions["formatOverrides"],
 ): undefined | ZodSchemaResult {
-  if (effectiveType === "string") return handleStringType(schema, result);
+  if (effectiveType === "string") {
+    return handleStringType(schema, result, formatOverrides);
+  }
   if (effectiveType === "number" || effectiveType === "integer") {
     return handleNumberType(schema, result);
   }
@@ -241,6 +257,7 @@ function handlePrimitive(
     return handleArrayType(schema, result, zodSchemaToCode, {
       currentSchemaName,
       extraProps,
+      formatOverrides,
       recursiveContext,
       resolvedSchemas,
       schemaContext,
@@ -250,6 +267,7 @@ function handlePrimitive(
     return handleObjectType(schema, result, zodSchemaToCode, {
       currentSchemaName,
       extraProps,
+      formatOverrides,
       recursiveContext,
       resolvedSchemas,
       schemaContext,
@@ -266,11 +284,13 @@ function tryHandleCompositions(
   currentSchemaName?: string,
   resolvedSchemas?: ResolvedSchemas,
   extraProps?: ExtraPropsMode,
+  formatOverrides?: ZodSchemaCodeOptions["formatOverrides"],
 ): undefined | ZodSchemaResult {
   if (schema.allOf) {
     return handleAllOfSchema(schema.allOf, result, zodSchemaToCode, {
       currentSchemaName,
       extraProps,
+      formatOverrides,
       recursiveContext,
       resolvedSchemas,
     });
@@ -285,6 +305,7 @@ function tryHandleCompositions(
       {
         currentSchemaName,
         extraProps,
+        formatOverrides,
         recursiveContext,
         resolvedSchemas,
       },
@@ -300,6 +321,7 @@ function tryHandleCompositions(
       {
         currentSchemaName,
         extraProps,
+        formatOverrides,
         recursiveContext,
         resolvedSchemas,
       },

--- a/packages/core-utils/src/schema-generator/types.ts
+++ b/packages/core-utils/src/schema-generator/types.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIObject } from "openapi3-ts/oas31";
 
 import type { ExtraPropsMode, SchemaContext } from "../shared/types.js";
+import type { StringFormatOverrideRegistry } from "./format-overrides.js";
 import type { RecursiveContext } from "./recursive-handlers.js";
 
 /**
@@ -16,6 +17,10 @@ export type ResolvedSchemas = NonNullable<
  * These options control how OpenAPI schemas are converted to Zod validation schemas.
  */
 export interface ZodSchemaCodeOptions {
+  /**
+   * Override registry for OpenAPI string formats
+   */
+  formatOverrides?: StringFormatOverrideRegistry;
   /**
    * Name of the schema being converted (used for recursive detection and naming)
    */
@@ -71,7 +76,9 @@ export interface ZodSchemaResult {
    */
   extensibleEnumValues?: unknown[];
   /**
-   * Set of schema names that need to be imported for this code to work
+   * Set of dependency identifiers that need to be imported for this code to work.
+   * This includes generated schema names and reserved aliases for string-format
+   * overrides.
    */
   imports: Set<string>;
 }

--- a/packages/core-utils/src/schema-generator/union-types.ts
+++ b/packages/core-utils/src/schema-generator/union-types.ts
@@ -8,6 +8,7 @@ import type {
   ResolvedSchemas,
 } from "./types.js";
 import type { ExtraPropsMode } from "../shared/types.js";
+import type { StringFormatOverrideRegistry } from "./format-overrides.js";
 import type { RecursiveContext } from "./recursive-handlers.js";
 import { mergeImports, sanitizeIdentifier } from "./utils.js";
 
@@ -37,13 +38,19 @@ export function handleAllOfSchema(
   options: {
     currentSchemaName?: string;
     extraProps?: ExtraPropsMode;
+    formatOverrides?: StringFormatOverrideRegistry;
     recursiveContext?: RecursiveContext;
     resolvedSchemas?: ResolvedSchemas;
     strictValidation?: boolean;
   } = {},
 ): ZodSchemaResult {
-  const { currentSchemaName, extraProps, recursiveContext, resolvedSchemas } =
-    options;
+  const {
+    currentSchemaName,
+    extraProps,
+    formatOverrides,
+    recursiveContext,
+    resolvedSchemas,
+  } = options;
 
   /*
    * Avoid object spread when allOf contains a self-reference.
@@ -120,6 +127,7 @@ export function handleAllOfSchema(
         const subResult = zodSchemaToCode(modifiedSchema, {
           currentSchemaName,
           extraProps,
+          formatOverrides,
           imports: new Set(),
           recursiveContext,
           resolvedSchemas,
@@ -144,6 +152,7 @@ export function handleAllOfSchema(
     zodSchemaToCode(s, {
       currentSchemaName,
       extraProps,
+      formatOverrides,
       imports: result.imports,
       recursiveContext,
       resolvedSchemas,
@@ -185,12 +194,18 @@ export function handleUnionSchema(
   options: {
     currentSchemaName?: string;
     extraProps?: ExtraPropsMode;
+    formatOverrides?: StringFormatOverrideRegistry;
     recursiveContext?: RecursiveContext;
     resolvedSchemas?: ResolvedSchemas;
   } = {},
 ): ZodSchemaResult {
-  const { currentSchemaName, extraProps, recursiveContext, resolvedSchemas } =
-    options;
+  const {
+    currentSchemaName,
+    extraProps,
+    formatOverrides,
+    recursiveContext,
+    resolvedSchemas,
+  } = options;
   // Check if discriminator is present for discriminated unions
   if (discriminator && discriminator.propertyName) {
     const discriminatorProperty = discriminator.propertyName;
@@ -198,6 +213,7 @@ export function handleUnionSchema(
       zodSchemaToCode(s, {
         currentSchemaName,
         extraProps,
+        formatOverrides,
         imports: result.imports,
         recursiveContext,
         resolvedSchemas,
@@ -227,6 +243,7 @@ export function handleUnionSchema(
     zodSchemaToCode(s, {
       currentSchemaName,
       extraProps,
+      formatOverrides,
       imports: result.imports,
       recursiveContext,
       resolvedSchemas,

--- a/packages/core-utils/src/shared/parameter-schemas.ts
+++ b/packages/core-utils/src/shared/parameter-schemas.ts
@@ -9,6 +9,7 @@ import type {
 import { isReferenceObject } from "openapi3-ts/oas31";
 
 import type { ParameterGroups } from "./models/parameter-models.js";
+import type { StringFormatOverrideRegistry } from "../schema-generator/format-overrides.js";
 
 import { zodSchemaToCode } from "../schema-generator/index.js";
 import {
@@ -23,6 +24,7 @@ import {
 export interface ParameterSchemaOptions {
   /* Apply coercion transformations for primitive types */
   coercePrimitives?: boolean;
+  formatOverrides?: StringFormatOverrideRegistry;
   lowercaseHeaderKeys?: boolean;
   /* Security headers to include in the headers schema */
   securityHeaders?: {
@@ -51,7 +53,7 @@ export interface ParameterSchemaResult {
     pathSchema: string;
     querySchema: string;
   };
-  /* Type imports needed */
+  /* Dependency identifiers needed by generated parameter schemas */
   typeImports: Set<string>;
   /* Type names for external reference */
   typeNames: {
@@ -71,6 +73,7 @@ export function generateParameterSchemas(
 ): ParameterSchemaResult {
   const {
     coercePrimitives = false,
+    formatOverrides,
     lowercaseHeaderKeys = false,
     securityHeaders = [],
   } = options;
@@ -100,6 +103,7 @@ export function generateParameterSchemas(
     let zodCode: string;
     if (schema) {
       const result = zodSchemaToCode(schema, {
+        formatOverrides,
         imports: typeImports,
       });
       zodCode = result.code;

--- a/packages/core-utils/tests/package-generator.test.ts
+++ b/packages/core-utils/tests/package-generator.test.ts
@@ -2,6 +2,8 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+import type { StringFormatOverride } from "../src/schema-generator/format-overrides.js";
+
 import { describe, expect, it } from "vitest";
 
 import { createPackageFiles } from "../src/core-generator/package-generator.js";
@@ -41,7 +43,7 @@ describe("package generator", () => {
           allowSyntheticDefaultImports: true,
           esModuleInterop: true,
           forceConsistentCasingInFileNames: true,
-          lib: ["es2025"],
+          lib: ["es2024"],
           module: "NodeNext",
           moduleResolution: "NodeNext",
           noEmitOnError: false,
@@ -50,7 +52,49 @@ describe("package generator", () => {
           rootDir: ".",
           skipLibCheck: true,
           strict: true,
-          target: "es2025",
+          target: "es2024",
+          types: ["node"],
+        },
+      });
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits rootDir when path-based format overrides are present", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "core-utils-package-"));
+    const formatOverrides: StringFormatOverride[] = [
+      {
+        format: "tax-code",
+        import: {
+          kind: "path",
+          path: "/tmp/TaxCode.ts",
+        },
+        importName: "TaxCode",
+      },
+    ];
+
+    try {
+      await createPackageFiles(outputDir, formatOverrides);
+
+      const tsConfig = JSON.parse(
+        await readFile(join(outputDir, "tsconfig.json"), "utf8"),
+      );
+
+      expect(tsConfig).toEqual({
+        compilerOptions: {
+          allowSyntheticDefaultImports: true,
+          esModuleInterop: true,
+          forceConsistentCasingInFileNames: true,
+          lib: ["es2024"],
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          noEmitOnError: false,
+          outDir: "dist",
+          resolveJsonModule: true,
+          skipLibCheck: true,
+          strict: true,
+          target: "es2024",
           types: ["node"],
         },
       });

--- a/packages/core-utils/tests/schema-generator/file-generators.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators.test.ts
@@ -29,10 +29,12 @@ describe("schema-generator file-generators", () => {
         type: "object",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.object({ name: z.string() })",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ name: z.string() })",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateSchemaFile("User", schema);
 
@@ -47,10 +49,12 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.string()",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.string()",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateSchemaFile(
         "User",
@@ -66,10 +70,12 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.string()",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.string()",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateSchemaFile(
         "User",
@@ -87,10 +93,12 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.string()",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.string()",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateSchemaFile(
         "User",
@@ -109,10 +117,12 @@ describe("schema-generator file-generators", () => {
         type: "object",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.object({ user: User })",
-        imports: new Set(["User"]),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ user: User })",
+          imports: new Set(["User"]),
+        }),
+      );
 
       const result = await generateSchemaFile("Profile", schema);
 
@@ -127,10 +137,12 @@ describe("schema-generator file-generators", () => {
         type: "object",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.object({ self: User })",
-        imports: new Set(["Profile", "User"]),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ self: User })",
+          imports: new Set(["Profile", "User"]),
+        }),
+      );
 
       const result = await generateSchemaFile("User", schema);
 
@@ -144,11 +156,13 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.union([z.literal('value1'), z.literal('value2'), z.string()])",
-        extensibleEnumValues: ["value1", "value2"],
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.union([z.literal('value1'), z.literal('value2'), z.string()])",
+          extensibleEnumValues: ["value1", "value2"],
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateSchemaFile("Status", schema);
 
@@ -163,11 +177,13 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.union([z.literal('complex-value'), z.literal('another_value'), z.literal('123'), z.string()])",
-        extensibleEnumValues: ["complex-value", "another_value", "123"],
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.union([z.literal('complex-value'), z.literal('another_value'), z.literal('123'), z.string()])",
+          extensibleEnumValues: ["complex-value", "another_value", "123"],
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateSchemaFile("Type", schema);
 
@@ -185,10 +201,12 @@ describe("schema-generator file-generators", () => {
         type: "object",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.object({ user: User, role: Role })",
-        imports: new Set(["Role", "User"]),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ user: User, role: Role })",
+          imports: new Set(["Role", "User"]),
+        }),
+      );
 
       const result = await generateSchemaFile("Profile", schema);
 
@@ -206,10 +224,12 @@ describe("schema-generator file-generators", () => {
         type: "object",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.object({ email: z.string() })",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ email: z.string() })",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateRequestSchemaFile(
         "createUserRequest",
@@ -227,10 +247,12 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.string()",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.string()",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateRequestSchemaFile("testRequest", schema);
 
@@ -247,10 +269,12 @@ describe("schema-generator file-generators", () => {
         type: "object",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.object({ id: z.string() })",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ id: z.string() })",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateResponseSchemaFile(
         "CreateUser200Response",
@@ -266,10 +290,12 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.string()",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.string()",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateResponseSchemaFile("User", schema);
 
@@ -281,10 +307,12 @@ describe("schema-generator file-generators", () => {
         type: "string",
       };
 
-      vi.mocked(zodSchemaToCode).mockReturnValue({
-        code: "z.string()",
-        imports: new Set(),
-      });
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.string()",
+          imports: new Set(),
+        }),
+      );
 
       const result = await generateResponseSchemaFile(
         "GetUser404Response",
@@ -351,3 +379,23 @@ describe("schema-generator file-generators", () => {
     });
   });
 });
+
+function mockSchemaResult(
+  overrides: Partial<{
+    code: string;
+    extensibleEnumValues: string[];
+    imports: Set<string>;
+  }>,
+) {
+  return {
+    ...createMockSchemaResult(),
+    ...overrides,
+  };
+}
+
+function createMockSchemaResult() {
+  return {
+    code: "z.unknown()",
+    imports: new Set<string>(),
+  };
+}

--- a/packages/core-utils/tests/schema-generator/format-overrides.test.ts
+++ b/packages/core-utils/tests/schema-generator/format-overrides.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { createStringFormatOverrideRegistry } from "../../src/schema-generator/format-overrides.js";
+
+describe("string format override registry", () => {
+  it("creates a registry for valid overrides", () => {
+    const registry = createStringFormatOverrideRegistry([
+      {
+        format: "tax-code",
+        import: {
+          kind: "module",
+          specifier: "@acme/domain",
+        },
+        importName: "TaxCode",
+      },
+    ]);
+
+    expect(registry.get("tax-code")).toEqual({
+      format: "tax-code",
+      import: {
+        kind: "module",
+        specifier: "@acme/domain",
+      },
+      importName: "TaxCode",
+    });
+  });
+
+  it("rejects duplicate formats", () => {
+    expect(() =>
+      createStringFormatOverrideRegistry([
+        {
+          format: "tax-code",
+          import: {
+            kind: "module",
+            specifier: "@acme/domain",
+          },
+          importName: "TaxCode",
+        },
+        {
+          format: "tax-code",
+          import: {
+            kind: "module",
+            specifier: "@acme/domain",
+          },
+          importName: "AnotherTaxCode",
+        },
+      ]),
+    ).toThrow('Duplicate string format override for format "tax-code".');
+  });
+
+  it("rejects duplicate reference names derived from different formats", () => {
+    expect(() =>
+      createStringFormatOverrideRegistry([
+        {
+          format: "tax-code",
+          import: {
+            kind: "module",
+            specifier: "@acme/domain",
+          },
+          importName: "TaxCode",
+        },
+        {
+          format: "tax_code",
+          import: {
+            kind: "module",
+            specifier: "@acme/domain",
+          },
+          importName: "TaxCodeSchema",
+        },
+      ]),
+    ).toThrow(
+      'Duplicate string format override reference name "__apicalStringFormatTaxCode" derived from format "tax_code".',
+    );
+  });
+
+  it("rejects blank formats", () => {
+    expect(() =>
+      createStringFormatOverrideRegistry([
+        {
+          format: "   ",
+          import: {
+            kind: "module",
+            specifier: "@acme/domain",
+          },
+          importName: "TaxCode",
+        },
+      ]),
+    ).toThrow("String format override format must be a non-empty string.");
+  });
+
+  it("rejects invalid import names", () => {
+    expect(() =>
+      createStringFormatOverrideRegistry([
+        {
+          format: "tax-code",
+          import: {
+            kind: "module",
+            specifier: "@acme/domain",
+          },
+          importName: "not-valid!",
+        },
+      ]),
+    ).toThrow(
+      'String format override "tax-code" has an invalid importName "not-valid!".',
+    );
+  });
+});

--- a/packages/core-utils/tests/schema-generator/object-types-context.test.ts
+++ b/packages/core-utils/tests/schema-generator/object-types-context.test.ts
@@ -17,7 +17,10 @@ describe("object-types with schemaContext", () => {
         },
       };
 
-      const result: ZodSchemaResult = { code: "", imports: new Set<string>() };
+      const result: ZodSchemaResult = {
+        code: "",
+        imports: new Set<string>(),
+      };
       handleObjectType(schema, result, zodSchemaToCode, {
         schemaContext: "base",
       });
@@ -37,7 +40,10 @@ describe("object-types with schemaContext", () => {
         },
       };
 
-      const result: ZodSchemaResult = { code: "", imports: new Set<string>() };
+      const result: ZodSchemaResult = {
+        code: "",
+        imports: new Set<string>(),
+      };
       handleObjectType(schema, result, zodSchemaToCode, {
         schemaContext: "request",
       });
@@ -57,7 +63,10 @@ describe("object-types with schemaContext", () => {
         },
       };
 
-      const result: ZodSchemaResult = { code: "", imports: new Set<string>() };
+      const result: ZodSchemaResult = {
+        code: "",
+        imports: new Set<string>(),
+      };
       handleObjectType(schema, result, zodSchemaToCode, {
         schemaContext: "response",
       });
@@ -76,7 +85,10 @@ describe("object-types with schemaContext", () => {
         },
       };
 
-      const result: ZodSchemaResult = { code: "", imports: new Set<string>() };
+      const result: ZodSchemaResult = {
+        code: "",
+        imports: new Set<string>(),
+      };
       handleObjectType(schema, result, zodSchemaToCode);
 
       expect(result.code).toContain('"id"');
@@ -93,7 +105,10 @@ describe("object-types with schemaContext", () => {
         required: ["id", "name"],
       };
 
-      const result: ZodSchemaResult = { code: "", imports: new Set<string>() };
+      const result: ZodSchemaResult = {
+        code: "",
+        imports: new Set<string>(),
+      };
       handleObjectType(schema, result, zodSchemaToCode, {
         schemaContext: "request",
       });
@@ -112,7 +127,10 @@ describe("object-types with schemaContext", () => {
         },
       };
 
-      const result: ZodSchemaResult = { code: "", imports: new Set<string>() };
+      const result: ZodSchemaResult = {
+        code: "",
+        imports: new Set<string>(),
+      };
       handleObjectType(schema, result, zodSchemaToCode, {
         schemaContext: "request",
       });


### PR DESCRIPTION
Introduce the ability to customize string format mappings in schema generation through a new `formatOverrides` option. Enhance schema handling functions to support these overrides, including validation and integration tests to ensure correct functionality. Update documentation to reflect the new feature and provide usage examples.