### PR TITLE
fix(client-generator): deduplicate security headers to prevent TS2451

### DIFF
--- a/packages/client-generator/src/templates/security-templates.ts
+++ b/packages/client-generator/src/templates/security-templates.ts
@@ -28,6 +28,17 @@ export function renderSecurityHeaderHandling(
 ): string {
   if (operationSecurityHeaders.length === 0) return "";
 
+  /* Deduplicate by computed variable name to prevent TS2451 from colliding names */
+  const uniqueHeaders = new Map<string, SecurityHeader>();
+  for (const header of operationSecurityHeaders) {
+    const varName = toValidVariableName(header.headerName);
+    const existing = uniqueHeaders.get(varName);
+    if (!existing || (header.isRequired && !existing.isRequired)) {
+      uniqueHeaders.set(varName, header);
+    }
+  }
+  const deduplicatedHeaders = [...uniqueHeaders.values()];
+
   /* Helper to generate security header handling code */
   const generateHeaderCode = (header: SecurityHeader): string => {
     const varName = toValidVariableName(header.headerName);
@@ -46,7 +57,7 @@ export function renderSecurityHeaderHandling(
     }
   };
 
-  return operationSecurityHeaders.map(generateHeaderCode).join("\n    ");
+  return deduplicatedHeaders.map(generateHeaderCode).join("\n    ");
 }
 
 /**

--- a/packages/client-generator/tests/security-templates.test.ts
+++ b/packages/client-generator/tests/security-templates.test.ts
@@ -100,6 +100,93 @@ describe("client-generator security templates", () => {
         "const _sec_XSpecialHeader = params.headers['X-Special@Header'];\n    if (_sec_XSpecialHeader === undefined) throw new Error('Missing required security header: X-Special@Header');\n    finalHeaders['X-Special@Header'] = _sec_XSpecialHeader;",
       );
     });
+
+    it("should deduplicate headers with same headerName, preferring isRequired", () => {
+      const headers: SecurityHeader[] = [
+        {
+          headerName: "X-Auth-Email",
+          isOverride: true,
+          isRequired: true,
+          schemeName: "api_email",
+        },
+        {
+          headerName: "X-Auth-Key",
+          isOverride: true,
+          isRequired: true,
+          schemeName: "api_key",
+        },
+        {
+          headerName: "X-Auth-Email",
+          isOverride: true,
+          isRequired: false,
+          schemeName: "api_email_2",
+        },
+      ];
+
+      const result = renderSecurityHeaderHandling(headers);
+      expect(result).toContain("_sec_XAuthEmail");
+      expect(result).toContain("_sec_XAuthKey");
+
+      const emailOccurrences = result.split("const _sec_XAuthEmail").length - 1;
+      expect(emailOccurrences).toBe(1);
+
+      expect(result).toContain(
+        "if (_sec_XAuthEmail === undefined) throw new Error",
+      );
+    });
+
+    it("should deduplicate headers whose names collide after normalization", () => {
+      const headers: SecurityHeader[] = [
+        {
+          headerName: "X-Auth-Email",
+          isOverride: true,
+          isRequired: true,
+          schemeName: "api_email",
+        },
+        {
+          headerName: "X_Auth_Email",
+          isOverride: true,
+          isRequired: false,
+          schemeName: "api_email_alt",
+        },
+      ];
+
+      const result = renderSecurityHeaderHandling(headers);
+
+      // Both header names normalize to XAuthEmail – only one const should be emitted
+      const emailOccurrences = result.split("const _sec_XAuthEmail").length - 1;
+      expect(emailOccurrences).toBe(1);
+
+      // The required variant should win
+      expect(result).toContain(
+        "if (_sec_XAuthEmail === undefined) throw new Error",
+      );
+    });
+
+    it("should deduplicate headers keeping optional when no required exists", () => {
+      const headers: SecurityHeader[] = [
+        {
+          headerName: "X-Auth-Email",
+          isOverride: true,
+          isRequired: false,
+          schemeName: "api_email",
+        },
+        {
+          headerName: "X-Auth-Email",
+          isOverride: true,
+          isRequired: false,
+          schemeName: "api_email_2",
+        },
+      ];
+
+      const result = renderSecurityHeaderHandling(headers);
+      const emailOccurrences = result.split("const _sec_XAuthEmail").length - 1;
+      expect(emailOccurrences).toBe(1);
+
+      expect(result).toContain(
+        "if (_sec_XAuthEmail !== undefined) finalHeaders",
+      );
+    });
   });
 
   describe("renderAuthHeaderValidation", () => {


### PR DESCRIPTION
## Problem
376 TS2451 errors in 94 generated client files caused by duplicate `const` declarations of security header variables when an operation has multiple security schemes sharing the same headers.

## Root Cause
`renderSecurityHeaderHandling` in `security-templates.ts` received duplicate `SecurityHeader` entries (same `headerName` from different security schemes), generating duplicate `const _sec_*` declarations.

## Fix
Deduplicate `operationSecurityHeaders` by `headerName` before code generation, preferring the entry with `isRequired: true` when duplicates exist.

## Tests
Added 2 new test cases covering:
- Deduplication with mixed required/optional duplicates
- Deduplication when all duplicates are optional