### PR TITLE
fix(core-utils): generate fallback schemas for non-plain OpenAPI objects

### DIFF
--- a/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
+++ b/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
@@ -293,11 +293,11 @@ function generateComponentSchemas(
     if (!isPlainSchemaObject(schema)) {
       /* eslint-disable-next-line no-console */
       console.warn(
-        `⚠️ ${name}: not a plain schema object, generating z.unknown() fallback`,
+        `⚠️ ${name}: not a plain schema object, generating fallback`,
       );
       const sanitizedName = sanitizeIdentifier(name);
       const promise = context.limit(async () => {
-        const content = generateFallbackSchemaContent(sanitizedName);
+        const content = generateFallbackSchemaContent(sanitizedName, schema);
         const filePath = path.join(context.schemasDir, `${sanitizedName}.ts`);
         await fs.writeFile(filePath, content);
       });
@@ -357,7 +357,13 @@ function generateParameterSchemas(
   return promises;
 }
 
-/* Generates a minimal z.unknown() fallback file for schemas that are not plain OpenAPI objects */
-function generateFallbackSchemaContent(name: string): string {
-  return `import * as z from 'zod';\n\nexport const ${name} = z.unknown();\nexport type ${name} = z.infer<typeof ${name}>;\n`;
+/* Generates a minimal fallback file for schemas that are not plain OpenAPI objects */
+export function generateFallbackSchemaContent(
+  name: string,
+  schema: unknown,
+): string {
+  // OpenAPI 3.1 boolean schemas preserve allow-anything vs allow-nothing.
+  const fallbackSchema = schema === false ? "z.never()" : "z.unknown()";
+
+  return `import * as z from 'zod';\n\nexport const ${name} = ${fallbackSchema};\nexport type ${name} = z.infer<typeof ${name}>;\n`;
 }

--- a/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
+++ b/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
@@ -293,9 +293,15 @@ function generateComponentSchemas(
     if (!isPlainSchemaObject(schema)) {
       /* eslint-disable-next-line no-console */
       console.warn(
-        `⚠️ Skipping ${name}: not a plain OpenAPI schema object. Value:`,
-        schema,
+        `⚠️ ${name}: not a plain schema object, generating z.unknown() fallback`,
       );
+      const sanitizedName = sanitizeIdentifier(name);
+      const promise = context.limit(async () => {
+        const content = generateFallbackSchemaContent(sanitizedName);
+        const filePath = path.join(context.schemasDir, `${sanitizedName}.ts`);
+        await fs.writeFile(filePath, content);
+      });
+      promises.push(promise);
       continue;
     }
 
@@ -349,4 +355,9 @@ function generateParameterSchemas(
   }
 
   return promises;
+}
+
+/* Generates a minimal z.unknown() fallback file for schemas that are not plain OpenAPI objects */
+function generateFallbackSchemaContent(name: string): string {
+  return `import * as z from 'zod';\n\nexport const ${name} = z.unknown();\nexport type ${name} = z.infer<typeof ${name}>;\n`;
 }

--- a/packages/core-utils/tests/core-generator/schema-generation-coordinator.test.ts
+++ b/packages/core-utils/tests/core-generator/schema-generation-coordinator.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { generateFallbackSchemaContent } from "../../src/core-generator/schema-generation-coordinator.js";
+
+describe("core-generator schema-generation-coordinator", () => {
+  describe("generateFallbackSchemaContent", () => {
+    it("should preserve true boolean component schema semantics", () => {
+      const result = generateFallbackSchemaContent("AllowAnything", true);
+
+      expect(result).toContain("export const AllowAnything = z.unknown();");
+      expect(result).not.toContain("z.never()");
+    });
+
+    it("should preserve false boolean component schema semantics", () => {
+      const result = generateFallbackSchemaContent("AllowNothing", false);
+
+      expect(result).toContain("export const AllowNothing = z.never();");
+      expect(result).not.toContain("z.unknown()");
+    });
+  });
+});


### PR DESCRIPTION
## Problem

63 TS2307 errors for 8 schema files that were skipped during generation but still imported by other schemas.

## Fix

Instead of skipping non-plain schemas entirely, generate a minimal fallback file with `z.unknown()`. This ensures the import target exists and the generated code compiles.

## Affected schemas (8)
accessOrganizationsComponentsSchemasIdentifier, iamCreateResourceGroupScopeScopeKey, iamCreateResourceGroupScopeScopeObjectKey, iamScopeKey, iamScopeObjectKey, loadBalancingPreviewId, teamsDevicesIdentifier, vectorizeMutationUuid

## Testing
All 227 existing tests pass. Lint and format clean.