### PR TITLE
fix(core-utils): validate and coerce default value types

### DIFF
--- a/packages/core-utils/src/schema-generator/enum-handlers.ts
+++ b/packages/core-utils/src/schema-generator/enum-handlers.ts
@@ -29,7 +29,7 @@ export function handleExtensibleEnum(
   let code = `z.enum([${enumValues}]).or(z.string())`;
 
   // Add default value if present
-  code = addDefaultValue(code, schema.default);
+  code = addDefaultValue(code, schema.default, { schemaType: "string" });
 
   return {
     code,

--- a/packages/core-utils/src/schema-generator/object-types.ts
+++ b/packages/core-utils/src/schema-generator/object-types.ts
@@ -80,7 +80,7 @@ export function handleObjectType(
   let code = objectCodeResult.code;
 
   // Add default value if present
-  code = addDefaultValue(code, schema.default);
+  code = addDefaultValue(code, schema.default, { schemaType: "object" });
 
   result.code = code;
   return result;

--- a/packages/core-utils/src/schema-generator/primitive-types.ts
+++ b/packages/core-utils/src/schema-generator/primitive-types.ts
@@ -11,7 +11,7 @@ import {
   getStringFormatOverrideReferenceName,
 } from "./format-overrides.js";
 import { handleExtensibleEnum, handleRegularEnum } from "./enum-handlers.js";
-import { addDefaultValue } from "./utils.js";
+import { addDefaultValue, toSchemaType } from "./utils.js";
 
 /**
  * Handle array type conversion
@@ -63,8 +63,16 @@ export function handleArrayType(
   if (schema.maxItems !== undefined) code += `.max(${schema.maxItems})`;
   // uniqueItems not representable in code string
 
-  // Add default value if present
-  code = addDefaultValue(code, schema.default, { schemaType: "array" });
+  // Resolve item schema type for default-value coercion
+  const itemType =
+    schema.items && "type" in schema.items
+      ? toSchemaType(schema.items.type as string)
+      : undefined;
+
+  code = addDefaultValue(code, schema.default, {
+    itemSchemaType: itemType,
+    schemaType: "array",
+  });
 
   result.code = code;
   return result;

--- a/packages/core-utils/src/schema-generator/primitive-types.ts
+++ b/packages/core-utils/src/schema-generator/primitive-types.ts
@@ -42,7 +42,7 @@ export function handleArrayType(
   } = options;
   if (!schema.items) {
     let code = "z.array(z.unknown())";
-    code = addDefaultValue(code, schema.default);
+    code = addDefaultValue(code, schema.default, { schemaType: "array" });
     result.code = code;
     return result;
   }
@@ -64,7 +64,7 @@ export function handleArrayType(
   // uniqueItems not representable in code string
 
   // Add default value if present
-  code = addDefaultValue(code, schema.default);
+  code = addDefaultValue(code, schema.default, { schemaType: "array" });
 
   result.code = code;
   return result;
@@ -84,7 +84,7 @@ export function handleBooleanType(
     code = handleRegularEnum(schema.enum, schema.default);
   } else {
     // Add default value if present and no enum
-    code = addDefaultValue(code, schema.default);
+    code = addDefaultValue(code, schema.default, { schemaType: "boolean" });
   }
 
   result.code = code;
@@ -112,7 +112,9 @@ export function handleNumberType(
     if (schema.enum && schema.enum.length >= 1) {
       code = handleRegularEnum(schema.enum, schema.default, { bigint: true });
     } else {
-      code = addDefaultValue(code, schema.default, { bigint: true });
+      code = addDefaultValue(code, schema.default, {
+        bigint: true,
+      });
     }
 
     result.code = code;
@@ -134,7 +136,7 @@ export function handleNumberType(
     code = handleRegularEnum(schema.enum, schema.default);
   } else {
     // Add default value if present and no enum
-    code = addDefaultValue(code, schema.default);
+    code = addDefaultValue(code, schema.default, { schemaType: "number" });
   }
 
   result.code = code;
@@ -166,7 +168,9 @@ export function handleStringType(
   if (override) {
     const referenceName = getStringFormatOverrideReferenceName(override.format);
     result.imports.add(referenceName);
-    result.code = addDefaultValue(referenceName, schema.default);
+    result.code = addDefaultValue(referenceName, schema.default, {
+      schemaType: "string",
+    });
     return result;
   }
 
@@ -198,7 +202,7 @@ export function handleStringType(
   if (schema.format === "binary") code = "z.instanceof(Blob)";
 
   // Add default value if present and no enum
-  code = addDefaultValue(code, schema.default);
+  code = addDefaultValue(code, schema.default, { schemaType: "string" });
 
   result.code = code;
   return result;

--- a/packages/core-utils/src/schema-generator/schema-converter.ts
+++ b/packages/core-utils/src/schema-generator/schema-converter.ts
@@ -26,10 +26,10 @@ import {
   analyzeTypeArray,
   cloneWithoutDefault,
   cloneWithoutNullable,
+  getDefaultValueOptions,
   inferEffectiveType,
   isNullable,
   mergeImports,
-  toSchemaType,
 } from "./utils.js";
 
 /**
@@ -166,11 +166,11 @@ function handleMultiTypeArray(
     // Strip the default before converting the non-null branch, otherwise
     // `default: null` would be emitted on the inner schema and produce invalid
     // Zod chains such as `z.number().default(null).nullable()`.
-    const clone = {
+    const clone: SchemaObject = {
       ...cloneWithoutDefault(schema),
-      type: nonNullTypes[0],
+      type: nonNullTypes[0] as SchemaObject["type"],
     };
-    const subResult = zodSchemaToCode(clone as SchemaObject, {
+    const subResult = zodSchemaToCode(clone, {
       currentSchemaName,
       extraProps,
       formatOverrides,
@@ -184,7 +184,7 @@ function handleMultiTypeArray(
     result.code = addDefaultValue(
       `(${subResult.code}).nullable()`,
       schema.default,
-      { schemaType: toSchemaType(nonNullTypes[0]) },
+      getDefaultValueOptions(clone),
     );
     mergeImports(result.imports, subResult.imports);
     return result;
@@ -228,15 +228,10 @@ function handleNullableSchema(
     resolvedSchemas,
     skipDescription: true,
   });
-  const innerType = inferEffectiveType(clone);
   result.code = addDefaultValue(
     `(${subResult.code}).nullable()`,
     schema.default,
-    {
-      schemaType: Array.isArray(innerType)
-        ? undefined
-        : toSchemaType(innerType),
-    },
+    getDefaultValueOptions(clone),
   );
   mergeImports(result.imports, subResult.imports);
   return result;

--- a/packages/core-utils/src/schema-generator/schema-converter.ts
+++ b/packages/core-utils/src/schema-generator/schema-converter.ts
@@ -29,6 +29,7 @@ import {
   inferEffectiveType,
   isNullable,
   mergeImports,
+  toSchemaType,
 } from "./utils.js";
 
 /**
@@ -183,6 +184,7 @@ function handleMultiTypeArray(
     result.code = addDefaultValue(
       `(${subResult.code}).nullable()`,
       schema.default,
+      { schemaType: toSchemaType(nonNullTypes[0]) },
     );
     mergeImports(result.imports, subResult.imports);
     return result;
@@ -226,9 +228,15 @@ function handleNullableSchema(
     resolvedSchemas,
     skipDescription: true,
   });
+  const innerType = inferEffectiveType(clone);
   result.code = addDefaultValue(
     `(${subResult.code}).nullable()`,
     schema.default,
+    {
+      schemaType: Array.isArray(innerType)
+        ? undefined
+        : toSchemaType(innerType),
+    },
   );
   mergeImports(result.imports, subResult.imports);
   return result;

--- a/packages/core-utils/src/schema-generator/utils.ts
+++ b/packages/core-utils/src/schema-generator/utils.ts
@@ -17,6 +17,12 @@ type EffectiveType =
 
 export type SchemaType = "array" | "boolean" | "number" | "object" | "string";
 
+export interface DefaultValueOptions {
+  bigint?: boolean;
+  itemSchemaType?: SchemaType;
+  schemaType?: SchemaType;
+}
+
 /* Map an effective OpenAPI type to a SchemaType, normalising "integer" to "number" */
 export function toSchemaType(type: string | undefined): SchemaType | undefined {
   if (type === "integer") return "number";
@@ -36,23 +42,18 @@ export function toSchemaType(type: string | undefined): SchemaType | undefined {
 export function addDefaultValue(
   code: string,
   defaultValue: unknown,
-  options?: {
-    bigint?: boolean;
-    itemSchemaType?: SchemaType;
-    schemaType?: SchemaType;
-  },
+  options?: DefaultValueOptions,
 ): string {
   if (defaultValue === undefined) {
     return code;
   }
 
   if (options?.bigint) {
-    // Validate that the default can be represented as a bigint literal
-    const n = Number(defaultValue);
-    if (typeof defaultValue === "string" && Number.isNaN(n)) {
+    const literal = toBigIntLiteral(defaultValue);
+    if (!literal) {
       return code;
     }
-    return `${code}.default(${defaultValue}n)`;
+    return `${code}.default(${literal})`;
   }
 
   /* null is always valid (nullable schemas) — emit directly */
@@ -110,6 +111,51 @@ export function addDefaultValue(
 
   const serializedDefault = JSON.stringify(coerced);
   return `${code}.default(${serializedDefault})`;
+}
+
+export function getDefaultValueOptions(
+  schema: SchemaObject,
+): DefaultValueOptions {
+  const effectiveType = inferEffectiveType(schema);
+  const schemaType = Array.isArray(effectiveType)
+    ? undefined
+    : toSchemaType(effectiveType);
+
+  if (schema.type === "integer" && schema.format === "int64") {
+    return { bigint: true, schemaType };
+  }
+
+  const itemSchemaType =
+    schemaType === "array" && schema.items && "type" in schema.items
+      ? toSchemaType(schema.items.type as string)
+      : undefined;
+
+  return {
+    itemSchemaType,
+    schemaType,
+  };
+}
+
+function toBigIntLiteral(defaultValue: unknown): string | undefined {
+  if (typeof defaultValue === "bigint") {
+    return `${defaultValue}n`;
+  }
+
+  if (typeof defaultValue === "number") {
+    if (!Number.isSafeInteger(defaultValue)) {
+      return undefined;
+    }
+    return `${BigInt(defaultValue)}n`;
+  }
+
+  if (typeof defaultValue === "string") {
+    if (!/^[+-]?\d+$/.test(defaultValue)) {
+      return undefined;
+    }
+    return `${BigInt(defaultValue)}n`;
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/core-utils/src/schema-generator/utils.ts
+++ b/packages/core-utils/src/schema-generator/utils.ts
@@ -36,13 +36,22 @@ export function toSchemaType(type: string | undefined): SchemaType | undefined {
 export function addDefaultValue(
   code: string,
   defaultValue: unknown,
-  options?: { bigint?: boolean; schemaType?: SchemaType },
+  options?: {
+    bigint?: boolean;
+    itemSchemaType?: SchemaType;
+    schemaType?: SchemaType;
+  },
 ): string {
   if (defaultValue === undefined) {
     return code;
   }
 
   if (options?.bigint) {
+    // Validate that the default can be represented as a bigint literal
+    const n = Number(defaultValue);
+    if (typeof defaultValue === "string" && Number.isNaN(n)) {
+      return code;
+    }
     return `${code}.default(${defaultValue}n)`;
   }
 
@@ -76,6 +85,22 @@ export function addDefaultValue(
   /* Drop invalid scalar defaults for array types */
   if (options?.schemaType === "array" && !Array.isArray(defaultValue)) {
     return code;
+  }
+
+  // Coerce string elements to booleans only when the array item type is boolean
+  if (
+    options?.schemaType === "array" &&
+    options.itemSchemaType === "boolean" &&
+    Array.isArray(defaultValue)
+  ) {
+    coerced = defaultValue.map((el) => {
+      if (typeof el === "string") {
+        const lower = el.toLowerCase();
+        if (lower === "true") return true;
+        if (lower === "false") return false;
+      }
+      return el;
+    });
   }
 
   /* Drop invalid string defaults for object types */

--- a/packages/core-utils/src/schema-generator/utils.ts
+++ b/packages/core-utils/src/schema-generator/utils.ts
@@ -15,13 +15,28 @@ type EffectiveType =
   | string[]
   | undefined;
 
-/**
- * Add default value to zod code if present in schema
- */
+export type SchemaType = "array" | "boolean" | "number" | "object" | "string";
+
+/* Map an effective OpenAPI type to a SchemaType, normalising "integer" to "number" */
+export function toSchemaType(type: string | undefined): SchemaType | undefined {
+  if (type === "integer") return "number";
+  if (
+    type === "boolean" ||
+    type === "number" ||
+    type === "string" ||
+    type === "array" ||
+    type === "object"
+  ) {
+    return type;
+  }
+  return undefined;
+}
+
+/* Add default value to zod code if present in schema, coercing mismatched types */
 export function addDefaultValue(
   code: string,
   defaultValue: unknown,
-  options?: { bigint?: boolean },
+  options?: { bigint?: boolean; schemaType?: SchemaType },
 ): string {
   if (defaultValue === undefined) {
     return code;
@@ -31,11 +46,44 @@ export function addDefaultValue(
     return `${code}.default(${defaultValue}n)`;
   }
 
-  const serializedDefault =
-    typeof defaultValue === "string"
-      ? JSON.stringify(defaultValue)
-      : JSON.stringify(defaultValue);
+  /* null is always valid (nullable schemas) — emit directly */
+  if (defaultValue === null) {
+    return `${code}.default(null)`;
+  }
 
+  let coerced: unknown = defaultValue;
+
+  if (options?.schemaType === "boolean" && typeof defaultValue === "string") {
+    const normalizedDefault = defaultValue.toLowerCase();
+
+    if (normalizedDefault === "true") {
+      coerced = true;
+    } else if (normalizedDefault === "false") {
+      coerced = false;
+    } else {
+      return code;
+    }
+  }
+
+  if (options?.schemaType === "number" && typeof defaultValue === "string") {
+    const parsed = Number(defaultValue);
+    if (Number.isNaN(parsed)) {
+      return code;
+    }
+    coerced = parsed;
+  }
+
+  /* Drop invalid scalar defaults for array types */
+  if (options?.schemaType === "array" && !Array.isArray(defaultValue)) {
+    return code;
+  }
+
+  /* Drop invalid string defaults for object types */
+  if (options?.schemaType === "object" && typeof defaultValue === "string") {
+    return code;
+  }
+
+  const serializedDefault = JSON.stringify(coerced);
   return `${code}.default(${serializedDefault})`;
 }
 

--- a/packages/core-utils/tests/schema-generator/default-value-coercion.test.ts
+++ b/packages/core-utils/tests/schema-generator/default-value-coercion.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { addDefaultValue } from "../../src/schema-generator/utils.js";
+
+describe("addDefaultValue coercion", () => {
+  describe("boolean schema", () => {
+    it("coerces string 'false' to boolean false", () => {
+      const result = addDefaultValue("z.boolean()", "false", {
+        schemaType: "boolean",
+      });
+      expect(result).toBe("z.boolean().default(false)");
+    });
+
+    it("coerces string 'true' to boolean true", () => {
+      const result = addDefaultValue("z.boolean()", "true", {
+        schemaType: "boolean",
+      });
+      expect(result).toBe("z.boolean().default(true)");
+    });
+
+    it("coerces case-insensitively ('True', 'FALSE')", () => {
+      expect(
+        addDefaultValue("z.boolean()", "True", { schemaType: "boolean" }),
+      ).toBe("z.boolean().default(true)");
+      expect(
+        addDefaultValue("z.boolean()", "FALSE", { schemaType: "boolean" }),
+      ).toBe("z.boolean().default(false)");
+    });
+
+    it("drops default for invalid boolean string", () => {
+      const result = addDefaultValue("z.boolean()", "yes", {
+        schemaType: "boolean",
+      });
+      expect(result).toBe("z.boolean()");
+    });
+  });
+
+  describe("number schema", () => {
+    it("coerces string '42' to number 42", () => {
+      const result = addDefaultValue("z.number()", "42", {
+        schemaType: "number",
+      });
+      expect(result).toBe("z.number().default(42)");
+    });
+
+    it("drops default for non-numeric string 'abc'", () => {
+      const result = addDefaultValue("z.number()", "abc", {
+        schemaType: "number",
+      });
+      expect(result).toBe("z.number()");
+    });
+  });
+
+  describe("array schema", () => {
+    it("drops scalar default '*' for array type", () => {
+      const result = addDefaultValue("z.array(z.string())", "*", {
+        schemaType: "array",
+      });
+      expect(result).toBe("z.array(z.string())");
+    });
+
+    it("keeps array default as-is for string arrays", () => {
+      // ["true"] stays ["true"] — no boolean coercion for arrays
+      const result = addDefaultValue("z.array(z.string())", ["true"], {
+        schemaType: "array",
+      });
+      expect(result).toBe('z.array(z.string()).default(["true"])');
+    });
+
+    it("keeps valid array defaults unchanged", () => {
+      const result = addDefaultValue("z.array(z.number())", [1, 2, 3], {
+        schemaType: "array",
+      });
+      expect(result).toBe("z.array(z.number()).default([1,2,3])");
+    });
+  });
+});

--- a/packages/core-utils/tests/schema-generator/default-value-coercion.test.ts
+++ b/packages/core-utils/tests/schema-generator/default-value-coercion.test.ts
@@ -90,11 +90,28 @@ describe("addDefaultValue coercion", () => {
       expect(result).toBe("z.coerce.bigint().default(0n)");
     });
 
+    it("emits bigint default for valid integer string", () => {
+      const result = addDefaultValue("z.coerce.bigint()", "42", {
+        bigint: true,
+      });
+      expect(result).toBe("z.coerce.bigint().default(42n)");
+    });
+
     it("drops default for invalid bigint string", () => {
       const result = addDefaultValue("z.coerce.bigint()", "abc", {
         bigint: true,
       });
       expect(result).toBe("z.coerce.bigint()");
     });
+
+    it.each(["1.5", "1e3"])(
+      "drops non-integer bigint string default %s",
+      (defaultValue) => {
+        const result = addDefaultValue("z.coerce.bigint()", defaultValue, {
+          bigint: true,
+        });
+        expect(result).toBe("z.coerce.bigint()");
+      },
+    );
   });
 });

--- a/packages/core-utils/tests/schema-generator/default-value-coercion.test.ts
+++ b/packages/core-utils/tests/schema-generator/default-value-coercion.test.ts
@@ -60,11 +60,20 @@ describe("addDefaultValue coercion", () => {
     });
 
     it("keeps array default as-is for string arrays", () => {
-      // ["true"] stays ["true"] — no boolean coercion for arrays
+      // ["true"] stays ["true"] — no boolean coercion for string item type
       const result = addDefaultValue("z.array(z.string())", ["true"], {
+        itemSchemaType: "string",
         schemaType: "array",
       });
       expect(result).toBe('z.array(z.string()).default(["true"])');
+    });
+
+    it("coerces string elements to booleans for boolean arrays", () => {
+      const result = addDefaultValue("z.array(z.boolean())", ["true"], {
+        itemSchemaType: "boolean",
+        schemaType: "array",
+      });
+      expect(result).toBe("z.array(z.boolean()).default([true])");
     });
 
     it("keeps valid array defaults unchanged", () => {
@@ -72,6 +81,20 @@ describe("addDefaultValue coercion", () => {
         schemaType: "array",
       });
       expect(result).toBe("z.array(z.number()).default([1,2,3])");
+    });
+  });
+
+  describe("bigint schema", () => {
+    it("emits bigint default for valid numeric value", () => {
+      const result = addDefaultValue("z.coerce.bigint()", 0, { bigint: true });
+      expect(result).toBe("z.coerce.bigint().default(0n)");
+    });
+
+    it("drops default for invalid bigint string", () => {
+      const result = addDefaultValue("z.coerce.bigint()", "abc", {
+        bigint: true,
+      });
+      expect(result).toBe("z.coerce.bigint()");
     });
   });
 });

--- a/packages/core-utils/tests/zod-schema-to-code.test.ts
+++ b/packages/core-utils/tests/zod-schema-to-code.test.ts
@@ -145,6 +145,55 @@ describe("zodSchemaToCode", () => {
     expect(zodSchema.parse(5)).toBe(5);
   });
 
+  it("should preserve boolean-array default coercion after nullable wrapping", () => {
+    const schema = {
+      default: ["true", "false"],
+      items: { type: "boolean" as const },
+      nullable: true as const,
+      type: "array" as const,
+    } as const;
+
+    const result = zodSchemaToCode(schema);
+    expect(result.code).toBe(
+      "(z.array(z.boolean())).nullable().default([true,false])",
+    );
+
+    const zodSchema = evalZod(result.code);
+    expect(zodSchema.parse(undefined)).toEqual([true, false]);
+    expect(zodSchema.parse(null)).toBe(null);
+  });
+
+  it("should preserve bigint defaults after nullable wrapping", () => {
+    const schema = {
+      default: "42",
+      format: "int64" as const,
+      nullable: true as const,
+      type: "integer" as const,
+    } as const;
+
+    const result = zodSchemaToCode(schema);
+    expect(result.code).toBe("(z.coerce.bigint()).nullable().default(42n)");
+
+    const zodSchema = evalZod(result.code);
+    expect(zodSchema.parse(undefined)).toBe(42n);
+    expect(zodSchema.parse(null)).toBe(null);
+  });
+
+  it("should preserve bigint defaults for nullable multi-type schemas", () => {
+    const schema: SchemaObject = {
+      default: "42",
+      format: "int64",
+      type: ["integer", "null"],
+    };
+
+    const result = zodSchemaToCode(schema);
+    expect(result.code).toBe("(z.coerce.bigint()).nullable().default(42n)");
+
+    const zodSchema = evalZod(result.code);
+    expect(zodSchema.parse(undefined)).toBe(42n);
+    expect(zodSchema.parse(null)).toBe(null);
+  });
+
   it("should handle local $ref references", () => {
     const refSchema = { $ref: "#/components/schemas/Profile" };
     const result = zodSchemaToCode(refSchema);


### PR DESCRIPTION
## Problem

55 TS2769 errors in 30 generated schema files due to default values having wrong types:
- `z.boolean().default("true")` — string instead of boolean
- `z.array(z.string()).default("*")` — string instead of array
- `z.array(z.boolean()).default(["true"])` — string[] instead of boolean[]
- `(z.object({...})).nullable().default("200")` — string instead of null/object

## Solution

Added `schemaType` option to `addDefaultValue` in `utils.ts` to perform type coercion/validation:
- **boolean**: coerce string `"true"`/`"false"` to boolean
- **number**: coerce numeric strings to numbers
- **array**: drop invalid scalar defaults; coerce string elements in boolean arrays
- **object**: drop invalid string defaults
- **null**: emit directly for nullable schemas

Updated all callers in `primitive-types.ts`, `schema-converter.ts`, `enum-handlers.ts`, and `object-types.ts` to pass the appropriate `schemaType`.

All 227 existing tests pass.