### PR TITLE
fix(core-utils): use z.lazy() for recursive schema self-references

### DIFF
--- a/packages/core-utils/src/schema-generator/discriminated-union.ts
+++ b/packages/core-utils/src/schema-generator/discriminated-union.ts
@@ -3,6 +3,7 @@ import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
 import { isReferenceObject, isSchemaObject } from "openapi3-ts/oas31";
 
 import type { ResolvedSchemas } from "./types.js";
+import { parseSchemaReference } from "./schema-references.js";
 import { isNullable } from "./utils.js";
 
 interface DiscriminatedUnionMember {
@@ -107,12 +108,12 @@ function resolveReferencedSchema(
     return null;
   }
 
-  const refName = extractSchemaNameFromRef(schema.$ref);
+  const refName = parseSchemaReference(schema.$ref);
   if (!refName) {
     return null;
   }
 
-  const resolvedSchema = resolvedSchemas[refName];
+  const resolvedSchema = resolvedSchemas[refName.originalName];
   return resolvedSchema && isSchemaObject(resolvedSchema)
     ? resolvedSchema
     : null;
@@ -246,13 +247,4 @@ function stripEnclosingParens(code: string): string {
   }
 
   return code.slice(1, -1);
-}
-
-function extractSchemaNameFromRef(ref: string | undefined): null | string {
-  if (!ref) {
-    return null;
-  }
-
-  const refMatch = ref.match(/\/([^/]+)$/);
-  return refMatch ? refMatch[1] : null;
 }

--- a/packages/core-utils/src/schema-generator/file-generators.ts
+++ b/packages/core-utils/src/schema-generator/file-generators.ts
@@ -303,6 +303,10 @@ export async function generateSchemaFile(
     path.join(schemaDirectory || ".", `${name}.ts`),
     options.formatOverrides,
   );
+  const recursiveTypeAlias =
+    isSelfRecursive && hasDirectSelfReference(schema, name)
+      ? renderSchemaType(schema)
+      : undefined;
 
   const content = assembleFileContent(
     name,
@@ -310,7 +314,7 @@ export async function generateSchemaFile(
     importsSection,
     schemaResult.code,
     schemaResult.extensibleEnumValues,
-    isSelfRecursive,
+    recursiveTypeAlias,
   );
 
   /* Generate complete variant schema files if this is a base schema (no schemaContext) */
@@ -355,7 +359,7 @@ function assembleFileContent(
   importsSection: string,
   schemaCode: string,
   extensibleEnumValues?: unknown[],
-  isRecursive?: boolean,
+  recursiveTypeAlias?: string,
 ): string {
   if (extensibleEnumValues) {
     const enumValues = extensibleEnumValues
@@ -365,20 +369,13 @@ function assembleFileContent(
     const schemaContent = `${commentSection}export const ${name} = ${schemaCode};`;
     return `import * as z from 'zod';\n${importsSection}\n${schemaContent}\n${typeContent}`;
   } else {
-    /*
-     * Only add the broad ZodType annotation when the generated schema code
-     * directly references its own exported identifier. Wider recursive graph
-     * membership alone should not discard the precise inferred schema type.
-     */
-    const directSelfReferencePattern = new RegExp(`\\b${name}\\b`);
-    const needsExplicitRecursiveAnnotation =
-      Boolean(isRecursive) && directSelfReferencePattern.test(schemaCode);
-    const typeAnnotation = needsExplicitRecursiveAnnotation
-      ? ": z.ZodType"
-      : "";
-    const schemaContent = `${commentSection}export const ${name}${typeAnnotation} = ${schemaCode};`;
-    const typeContent = `export type ${name} = z.infer<typeof ${name}>;`;
-    return `import * as z from 'zod';\n${importsSection}\n${schemaContent}\n${typeContent}`;
+    const schemaContent = recursiveTypeAlias
+      ? `${commentSection}export const ${name}: z.ZodType<${name}> = ${schemaCode};`
+      : `${commentSection}export const ${name} = ${schemaCode};`;
+    const typeContent = recursiveTypeAlias
+      ? `export type ${name} = ${recursiveTypeAlias};`
+      : `export type ${name} = z.infer<typeof ${name}>;`;
+    return `import * as z from 'zod';\n${importsSection}\n${typeContent}\n${schemaContent}`;
   }
 }
 
@@ -585,6 +582,128 @@ function getSchemaNameFromReference(ref: string): string | undefined {
   }
 
   return undefined;
+}
+
+function hasDirectSelfReference(
+  schema: SchemaObject,
+  schemaName: string,
+): boolean {
+  return findReferencesInSchema(schema).some(
+    (ref) => getSchemaNameFromReference(ref) === schemaName,
+  );
+}
+
+function renderSchemaType(schema: ReferenceObject | SchemaObject): string {
+  if (isReferenceObject(schema)) {
+    return getSchemaNameFromReference(schema.$ref) ?? "unknown";
+  }
+
+  if (schema.enum?.length) {
+    return schema.enum.map((value) => JSON.stringify(value)).join(" | ");
+  }
+
+  if ("const" in schema && schema.const !== undefined) {
+    return JSON.stringify(schema.const);
+  }
+
+  const compositionType = renderCompositionType(schema);
+  const baseType = compositionType ?? renderSimpleSchemaType(schema);
+  const isNullable = "nullable" in schema && schema.nullable === true;
+
+  return isNullable ? `${baseType} | null` : baseType;
+}
+
+function renderCompositionType(schema: SchemaObject): string | undefined {
+  if (schema.allOf?.length) {
+    return schema.allOf.map(renderSchemaType).join(" & ");
+  }
+
+  if (schema.anyOf?.length) {
+    return schema.anyOf.map(renderSchemaType).join(" | ");
+  }
+
+  if (schema.oneOf?.length) {
+    return schema.oneOf.map(renderSchemaType).join(" | ");
+  }
+
+  return undefined;
+}
+
+function renderSimpleSchemaType(schema: SchemaObject): string {
+  if (schema.type === "array" || schema.items) {
+    return `Array<${renderSchemaType(schema.items ?? {})}>`;
+  }
+
+  if (
+    schema.type === "object" ||
+    schema.properties ||
+    schema.additionalProperties !== undefined
+  ) {
+    return renderObjectSchemaType(schema);
+  }
+
+  if (Array.isArray(schema.type)) {
+    return schema.type.map(renderPrimitiveType).join(" | ");
+  }
+
+  if (schema.type) {
+    return renderPrimitiveType(schema.type);
+  }
+
+  return "unknown";
+}
+
+function renderObjectSchemaType(schema: SchemaObject): string {
+  const requiredProperties = new Set(schema.required ?? []);
+  const propertyEntries = Object.entries(schema.properties ?? {}).map(
+    ([propertyName, propertySchema]) =>
+      `${JSON.stringify(propertyName)}${requiredProperties.has(propertyName) ? "" : "?"}: ${renderSchemaType(propertySchema)}`,
+  );
+  const propertyType =
+    propertyEntries.length > 0 ? `{ ${propertyEntries.join("; ")} }` : "{}";
+  const additionalPropertiesType = renderAdditionalPropertiesType(
+    schema.additionalProperties,
+  );
+
+  if (!additionalPropertiesType) {
+    return propertyType;
+  }
+
+  return propertyEntries.length > 0
+    ? `${propertyType} & ${additionalPropertiesType}`
+    : additionalPropertiesType;
+}
+
+function renderAdditionalPropertiesType(
+  additionalProperties: SchemaObject["additionalProperties"],
+): string | undefined {
+  if (additionalProperties === undefined || additionalProperties === false) {
+    return undefined;
+  }
+
+  if (additionalProperties === true) {
+    return "{ [key: string]: unknown }";
+  }
+
+  return `{ [key: string]: ${renderSchemaType(additionalProperties)} }`;
+}
+
+function renderPrimitiveType(
+  type: Exclude<SchemaObject["type"], readonly string[] | undefined>,
+): string {
+  switch (type) {
+    case "boolean":
+      return "boolean";
+    case "integer":
+    case "number":
+      return "number";
+    case "null":
+      return "null";
+    case "string":
+      return "string";
+    default:
+      return "unknown";
+  }
 }
 
 // Export for testing

--- a/packages/core-utils/src/schema-generator/file-generators.ts
+++ b/packages/core-utils/src/schema-generator/file-generators.ts
@@ -277,21 +277,12 @@ export async function generateSchemaFile(
 
   const context = recursiveContext || createRecursiveContext();
 
-  /*
-   * For non-object recursive schemas that can't use the getter-based approach,
-   * enable z.lazy() wrapping so self-references don't cause TS7022/TS2448.
-   */
-  const isSelfRecursive = context.recursiveSchemas.has(name);
-  const effectiveContext = isSelfRecursive
-    ? { ...context, useLazyWrapping: true }
-    : context;
-
   const schemaResult = zodSchemaToCode(schema, {
     currentSchemaName: name,
     extraProps,
     formatOverrides: options.formatOverrides,
     isTopLevel: true,
-    recursiveContext: effectiveContext,
+    recursiveContext: context,
     resolvedSchemas,
     schemaContext,
   });
@@ -303,10 +294,9 @@ export async function generateSchemaFile(
     path.join(schemaDirectory || ".", `${name}.ts`),
     options.formatOverrides,
   );
-  const recursiveTypeAlias =
-    isSelfRecursive && hasDirectSelfReference(schema, name)
-      ? renderSchemaType(schema)
-      : undefined;
+  const recursiveTypeAlias = hasDirectSelfReference(schema, name)
+    ? renderSchemaType(schema)
+    : undefined;
 
   const content = assembleFileContent(
     name,

--- a/packages/core-utils/src/schema-generator/file-generators.ts
+++ b/packages/core-utils/src/schema-generator/file-generators.ts
@@ -156,7 +156,7 @@ export async function generateRecursiveSchemaFile(
           : undefined;
       const isSingleSelfReference = singleRefTarget === name;
       const baseType = isSingleSelfReference
-        ? `typeof ${name}`
+        ? `z.ZodLazy<typeof ${name}>`
         : "z.ZodTypeAny";
       const returnType = isRequired ? baseType : `z.ZodOptional<${baseType}>`;
       shape.push(

--- a/packages/core-utils/src/schema-generator/file-generators.ts
+++ b/packages/core-utils/src/schema-generator/file-generators.ts
@@ -277,12 +277,21 @@ export async function generateSchemaFile(
 
   const context = recursiveContext || createRecursiveContext();
 
+  /*
+   * For non-object recursive schemas that can't use the getter-based approach,
+   * enable z.lazy() wrapping so self-references don't cause TS7022/TS2448.
+   */
+  const isSelfRecursive = context.recursiveSchemas.has(name);
+  const effectiveContext = isSelfRecursive
+    ? { ...context, useLazyWrapping: true }
+    : context;
+
   const schemaResult = zodSchemaToCode(schema, {
     currentSchemaName: name,
     extraProps,
     formatOverrides: options.formatOverrides,
     isTopLevel: true,
-    recursiveContext: context,
+    recursiveContext: effectiveContext,
     resolvedSchemas,
     schemaContext,
   });
@@ -301,6 +310,7 @@ export async function generateSchemaFile(
     importsSection,
     schemaResult.code,
     schemaResult.extensibleEnumValues,
+    isSelfRecursive,
   );
 
   /* Generate complete variant schema files if this is a base schema (no schemaContext) */
@@ -345,6 +355,7 @@ function assembleFileContent(
   importsSection: string,
   schemaCode: string,
   extensibleEnumValues?: unknown[],
+  isRecursive?: boolean,
 ): string {
   if (extensibleEnumValues) {
     const enumValues = extensibleEnumValues
@@ -354,7 +365,18 @@ function assembleFileContent(
     const schemaContent = `${commentSection}export const ${name} = ${schemaCode};`;
     return `import * as z from 'zod';\n${importsSection}\n${schemaContent}\n${typeContent}`;
   } else {
-    const schemaContent = `${commentSection}export const ${name} = ${schemaCode};`;
+    /*
+     * Only add the broad ZodType annotation when the generated schema code
+     * directly references its own exported identifier. Wider recursive graph
+     * membership alone should not discard the precise inferred schema type.
+     */
+    const directSelfReferencePattern = new RegExp(`\\b${name}\\b`);
+    const needsExplicitRecursiveAnnotation =
+      Boolean(isRecursive) && directSelfReferencePattern.test(schemaCode);
+    const typeAnnotation = needsExplicitRecursiveAnnotation
+      ? ": z.ZodType"
+      : "";
+    const schemaContent = `${commentSection}export const ${name}${typeAnnotation} = ${schemaCode};`;
     const typeContent = `export type ${name} = z.infer<typeof ${name}>;`;
     return `import * as z from 'zod';\n${importsSection}\n${schemaContent}\n${typeContent}`;
   }

--- a/packages/core-utils/src/schema-generator/file-generators.ts
+++ b/packages/core-utils/src/schema-generator/file-generators.ts
@@ -1,6 +1,4 @@
-import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
-
-import { isReferenceObject } from "openapi3-ts/oas31";
+import type { SchemaObject } from "openapi3-ts/oas31";
 import path from "node:path";
 
 import type { ExtraPropsMode, SchemaContext } from "../shared/types.js";
@@ -14,12 +12,10 @@ import {
   renderStringFormatOverrideImports,
 } from "./format-overrides.js";
 import { generateObjectCode } from "./object-properties.js";
-import {
-  createRecursiveContext,
-  findReferencesInSchema,
-} from "./recursive-handlers.js";
+import { buildRecursiveShape } from "./recursive-schema-properties.js";
+import { createRecursiveContext } from "./recursive-handlers.js";
+import { renderRecursiveTypeAlias } from "./recursive-type-renderer.js";
 import { zodSchemaToCode } from "./schema-converter.js";
-import { sanitizeIdentifier } from "./utils.js";
 
 /**
  * Options for recursive schema file generation
@@ -97,94 +93,15 @@ export async function generateRecursiveSchemaFile(
   }
 
   const commentSection = generateCommentSection(description);
-  const shape: string[] = [];
-  const requiredFields = schema.required || [];
-  const imports = new Set<string>();
-
-  /* Process each property to generate the correct Zod code */
-  for (const [key, propSchema] of Object.entries(schema.properties)) {
-    const isRequired = requiredFields.includes(key);
-    const isRecursive = isRecursiveProperty(
-      propSchema,
-      originalSchemaName,
-      recursiveContext,
-    );
-
-    if (isRecursive && getRecursiveReferenceName(propSchema) !== undefined) {
-      const referencedSchemaName = getRecursiveReferenceName(propSchema)!;
-      if (referencedSchemaName !== name) {
-        imports.add(referencedSchemaName);
-      }
-      const getterCode = generateGetterCode(key, propSchema, name, isRequired);
-      shape.push(getterCode);
-    } else if (isRecursive) {
-      /*
-       * Composition (allOf/anyOf/oneOf) containing a self-reference.
-       * Generate code using zodSchemaToCode but wrap in a getter to defer
-       * evaluation and avoid TypeScript "used before declaration" errors.
-       */
-      const propResult = zodSchemaToCode(propSchema, {
-        currentSchemaName: name,
-        extraProps,
-        formatOverrides,
-        imports: new Set(),
-        recursiveContext,
-        resolvedSchemas,
-      });
-
-      propResult.imports.forEach((imp) => {
-        if (imp !== name) {
-          imports.add(imp);
-        }
-      });
-
-      const code = isRequired
-        ? propResult.code
-        : `${propResult.code}.optional()`;
-
-      /*
-       * Use precise return type when the composition resolves to a single
-       * self-reference (e.g. allOf/anyOf/oneOf with one $ref to self).
-       * Otherwise fall back to z.ZodTypeAny.
-       */
-      const compositionItems = !isReferenceObject(propSchema)
-        ? (propSchema.allOf ?? propSchema.anyOf ?? propSchema.oneOf)
-        : undefined;
-      const singleRefTarget =
-        compositionItems?.length === 1 && isReferenceObject(compositionItems[0])
-          ? getSchemaNameFromReference(compositionItems[0].$ref)
-          : undefined;
-      const isSingleSelfReference = singleRefTarget === name;
-      const baseType = isSingleSelfReference
-        ? `z.ZodLazy<typeof ${name}>`
-        : "z.ZodTypeAny";
-      const returnType = isRequired ? baseType : `z.ZodOptional<${baseType}>`;
-      shape.push(
-        `get ${JSON.stringify(key)}(): ${returnType} { return ${code}; }`,
-      );
-    } else {
-      const propResult = zodSchemaToCode(propSchema, {
-        currentSchemaName: name,
-        extraProps,
-        formatOverrides,
-        imports: new Set(),
-        recursiveContext,
-        resolvedSchemas,
-      });
-
-      propResult.imports.forEach((imp) => {
-        if (imp !== name) {
-          imports.add(imp);
-        }
-      });
-
-      const propCode = isRequired
-        ? propResult.code
-        : `${propResult.code}.optional()`;
-
-      shape.push(`${JSON.stringify(key)}: ${propCode}`);
-    }
-  }
+  const { imports, shape } = buildRecursiveShape({
+    extraProps,
+    formatOverrides,
+    name,
+    originalSchemaName,
+    recursiveContext,
+    resolvedSchemas,
+    schema,
+  });
 
   /*
    * Use additionalProperties to determine object type and generate code using common function
@@ -294,9 +211,7 @@ export async function generateSchemaFile(
     path.join(schemaDirectory || ".", `${name}.ts`),
     options.formatOverrides,
   );
-  const recursiveTypeAlias = hasDirectSelfReference(schema, name)
-    ? renderSchemaType(schema)
-    : undefined;
+  const recursiveTypeAlias = renderRecursiveTypeAlias(schema, name);
 
   const content = assembleFileContent(
     name,
@@ -380,49 +295,6 @@ function generateCommentSection(description?: string): string {
     .join("\n * ")}\n */\n`;
 }
 
-/* Helper function to generate getter code for recursive properties */
-function generateGetterCode(
-  key: string,
-  propSchema: ReferenceObject | SchemaObject,
-  name: string,
-  isRequired: boolean,
-): string {
-  const referencedSchemaName = getRecursiveReferenceName(propSchema) ?? name;
-  const isCrossSchemaReference = referencedSchemaName !== name;
-  /**
-   * Generate getter with proper TypeScript return type annotation to resolve circular reference issues.
-   * This follows the pattern from Zod documentation: https://zod.dev/api?id=circularity-errors
-   */
-  const baseGetter = (code: string, returnType: string) =>
-    `get ${JSON.stringify(key)}(): ${returnType} { return ${code}${isRequired ? "" : ".optional()"}; }`;
-
-  /* Array with reference items - wrap in z.array() */
-  if (
-    !isReferenceObject(propSchema) &&
-    propSchema.type === "array" &&
-    propSchema.items &&
-    isReferenceObject(propSchema.items)
-  ) {
-    const arrayItemType = isCrossSchemaReference
-      ? "z.ZodTypeAny"
-      : `typeof ${referencedSchemaName}`;
-    const returnType = isRequired
-      ? `z.ZodArray<${arrayItemType}>`
-      : `z.ZodOptional<z.ZodArray<${arrayItemType}>>`;
-    return baseGetter(`z.array(${referencedSchemaName})`, returnType);
-  }
-
-  /* All other cases (direct references, objects with nested references) - use schema directly */
-  const returnType = isRequired
-    ? isCrossSchemaReference
-      ? "z.ZodTypeAny"
-      : `typeof ${referencedSchemaName}`
-    : isCrossSchemaReference
-      ? "z.ZodOptional<z.ZodTypeAny>"
-      : `z.ZodOptional<typeof ${referencedSchemaName}>`;
-  return baseGetter(referencedSchemaName, returnType);
-}
-
 /* Helper function to generate imports section */
 function generateImportsSection(
   imports: Set<string>,
@@ -499,202 +371,5 @@ async function generateVariantSchemaFiles(
   return files.length > 0 ? files : undefined;
 }
 
-/* Helper function to check if a property is recursive */
-function isRecursiveProperty(
-  propSchema: ReferenceObject | SchemaObject,
-  originalSchemaName: string,
-  recursiveContext: RecursiveContext,
-): boolean {
-  /* Check for direct self-reference via $ref */
-  if ("$ref" in propSchema) {
-    const ref = propSchema.$ref;
-    if (!ref) {
-      return false;
-    }
-    const selfRef = `#/components/schemas/${originalSchemaName}`;
-    const shortSelfRef = `#/${originalSchemaName}`;
-    if (ref === selfRef || ref === shortSelfRef) {
-      return true;
-    }
-    if (ref.startsWith("#/components/schemas/")) {
-      const referencedSchema = getSchemaNameFromReference(ref);
-      return !!(
-        referencedSchema &&
-        recursiveContext.recursiveSchemas.has(referencedSchema)
-      );
-    }
-    return false;
-  }
-
-  /* Check for indirect self-references within schema properties */
-  const refs = findReferencesInSchema(propSchema);
-  const selfRef = `#/components/schemas/${originalSchemaName}`;
-  const shortSelfRef = `#/${originalSchemaName}`;
-  return refs.some((ref) => {
-    if (ref === selfRef || ref === shortSelfRef) {
-      return true;
-    }
-    const referencedSchema = getSchemaNameFromReference(ref);
-    return !!(
-      referencedSchema &&
-      recursiveContext.recursiveSchemas.has(referencedSchema)
-    );
-  });
-}
-
-function getRecursiveReferenceName(
-  propSchema: ReferenceObject | SchemaObject,
-): string | undefined {
-  if (isReferenceObject(propSchema)) {
-    return getSchemaNameFromReference(propSchema.$ref);
-  }
-
-  if (
-    propSchema.type === "array" &&
-    propSchema.items &&
-    isReferenceObject(propSchema.items)
-  ) {
-    return getSchemaNameFromReference(propSchema.items.$ref);
-  }
-
-  return undefined;
-}
-
-function getSchemaNameFromReference(ref: string): string | undefined {
-  if (ref.startsWith("#/components/schemas/")) {
-    return sanitizeIdentifier(ref.replace("#/components/schemas/", ""));
-  }
-
-  /* Handle short-form references like #/SchemaName */
-  const shortFormMatch = /^#\/([^/]+)$/.exec(ref);
-  if (shortFormMatch) {
-    return sanitizeIdentifier(shortFormMatch[1]);
-  }
-
-  return undefined;
-}
-
-function hasDirectSelfReference(
-  schema: SchemaObject,
-  schemaName: string,
-): boolean {
-  return findReferencesInSchema(schema).some(
-    (ref) => getSchemaNameFromReference(ref) === schemaName,
-  );
-}
-
-function renderSchemaType(schema: ReferenceObject | SchemaObject): string {
-  if (isReferenceObject(schema)) {
-    return getSchemaNameFromReference(schema.$ref) ?? "unknown";
-  }
-
-  if (schema.enum?.length) {
-    return schema.enum.map((value) => JSON.stringify(value)).join(" | ");
-  }
-
-  if ("const" in schema && schema.const !== undefined) {
-    return JSON.stringify(schema.const);
-  }
-
-  const compositionType = renderCompositionType(schema);
-  const baseType = compositionType ?? renderSimpleSchemaType(schema);
-  const isNullable = "nullable" in schema && schema.nullable === true;
-
-  return isNullable ? `${baseType} | null` : baseType;
-}
-
-function renderCompositionType(schema: SchemaObject): string | undefined {
-  if (schema.allOf?.length) {
-    return schema.allOf.map(renderSchemaType).join(" & ");
-  }
-
-  if (schema.anyOf?.length) {
-    return schema.anyOf.map(renderSchemaType).join(" | ");
-  }
-
-  if (schema.oneOf?.length) {
-    return schema.oneOf.map(renderSchemaType).join(" | ");
-  }
-
-  return undefined;
-}
-
-function renderSimpleSchemaType(schema: SchemaObject): string {
-  if (schema.type === "array" || schema.items) {
-    return `Array<${renderSchemaType(schema.items ?? {})}>`;
-  }
-
-  if (
-    schema.type === "object" ||
-    schema.properties ||
-    schema.additionalProperties !== undefined
-  ) {
-    return renderObjectSchemaType(schema);
-  }
-
-  if (Array.isArray(schema.type)) {
-    return schema.type.map(renderPrimitiveType).join(" | ");
-  }
-
-  if (schema.type) {
-    return renderPrimitiveType(schema.type);
-  }
-
-  return "unknown";
-}
-
-function renderObjectSchemaType(schema: SchemaObject): string {
-  const requiredProperties = new Set(schema.required ?? []);
-  const propertyEntries = Object.entries(schema.properties ?? {}).map(
-    ([propertyName, propertySchema]) =>
-      `${JSON.stringify(propertyName)}${requiredProperties.has(propertyName) ? "" : "?"}: ${renderSchemaType(propertySchema)}`,
-  );
-  const propertyType =
-    propertyEntries.length > 0 ? `{ ${propertyEntries.join("; ")} }` : "{}";
-  const additionalPropertiesType = renderAdditionalPropertiesType(
-    schema.additionalProperties,
-  );
-
-  if (!additionalPropertiesType) {
-    return propertyType;
-  }
-
-  return propertyEntries.length > 0
-    ? `${propertyType} & ${additionalPropertiesType}`
-    : additionalPropertiesType;
-}
-
-function renderAdditionalPropertiesType(
-  additionalProperties: SchemaObject["additionalProperties"],
-): string | undefined {
-  if (additionalProperties === undefined || additionalProperties === false) {
-    return undefined;
-  }
-
-  if (additionalProperties === true) {
-    return "{ [key: string]: unknown }";
-  }
-
-  return `{ [key: string]: ${renderSchemaType(additionalProperties)} }`;
-}
-
-function renderPrimitiveType(
-  type: Exclude<SchemaObject["type"], readonly string[] | undefined>,
-): string {
-  switch (type) {
-    case "boolean":
-      return "boolean";
-    case "integer":
-    case "number":
-      return "number";
-    case "null":
-      return "null";
-    case "string":
-      return "string";
-    default:
-      return "unknown";
-  }
-}
-
 // Export for testing
-export { generateGetterCode };
+export { generateGetterCode } from "./recursive-schema-properties.js";

--- a/packages/core-utils/src/schema-generator/recursive-handlers.ts
+++ b/packages/core-utils/src/schema-generator/recursive-handlers.ts
@@ -24,8 +24,6 @@ export interface RecursiveContext {
   recursiveSchemas: Set<string>;
   /* Stack of currently processing schema references to detect cycles */
   referenceStack: string[];
-  /* When true, direct self-references emit z.lazy(() => name) instead of bare name */
-  useLazyWrapping?: boolean;
 }
 
 /**

--- a/packages/core-utils/src/schema-generator/recursive-handlers.ts
+++ b/packages/core-utils/src/schema-generator/recursive-handlers.ts
@@ -24,6 +24,8 @@ export interface RecursiveContext {
   recursiveSchemas: Set<string>;
   /* Stack of currently processing schema references to detect cycles */
   referenceStack: string[];
+  /* When true, direct self-references emit z.lazy(() => name) instead of bare name */
+  useLazyWrapping?: boolean;
 }
 
 /**

--- a/packages/core-utils/src/schema-generator/recursive-handlers.ts
+++ b/packages/core-utils/src/schema-generator/recursive-handlers.ts
@@ -2,6 +2,7 @@ import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
 
 import { isReferenceObject } from "openapi3-ts/oas31";
 
+import { parseSchemaReference } from "./schema-references.js";
 import { sanitizeIdentifier } from "./utils.js";
 
 /**
@@ -18,8 +19,6 @@ interface RecursiveAnalysisResult {
  * Context for tracking recursive references during schema generation
  */
 export interface RecursiveContext {
-  /* Map of recursive properties within schemas */
-  recursiveProperties: Map<string, Set<string>>;
   /* Set of schemas that have been identified as recursive */
   recursiveSchemas: Set<string>;
   /* Stack of currently processing schema references to detect cycles */
@@ -38,8 +37,12 @@ export function analyzeRecursiveReference(
     return { isRecursive: false };
   }
 
-  const referenceName = ref.replace("#/components/schemas/", "");
-  const sanitizedReferenceName = sanitizeIdentifier(referenceName);
+  const schemaReference = parseSchemaReference(ref);
+  if (!schemaReference) {
+    return { isRecursive: false };
+  }
+
+  const sanitizedReferenceName = schemaReference.identifierName;
 
   /* Direct self-reference */
   if (currentSchemaName && sanitizedReferenceName === currentSchemaName) {
@@ -158,7 +161,6 @@ export function findRecursiveSchemas(
  */
 export function createRecursiveContext(): RecursiveContext {
   return {
-    recursiveProperties: new Map(),
     recursiveSchemas: new Set(),
     referenceStack: [],
   };

--- a/packages/core-utils/src/schema-generator/recursive-schema-properties.ts
+++ b/packages/core-utils/src/schema-generator/recursive-schema-properties.ts
@@ -1,0 +1,251 @@
+import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
+
+import { isReferenceObject } from "openapi3-ts/oas31";
+
+import type { ExtraPropsMode } from "../shared/types.js";
+import type { StringFormatOverrideRegistry } from "./format-overrides.js";
+import type { RecursiveContext } from "./recursive-handlers.js";
+import type { ResolvedSchemas } from "./types.js";
+
+import { findReferencesInSchema } from "./recursive-handlers.js";
+import { getSchemaNameFromReference } from "./schema-references.js";
+import { zodSchemaToCode } from "./schema-converter.js";
+
+interface BuildRecursiveShapeOptions {
+  extraProps?: ExtraPropsMode;
+  formatOverrides?: StringFormatOverrideRegistry;
+  name: string;
+  originalSchemaName: string;
+  recursiveContext: RecursiveContext;
+  resolvedSchemas?: ResolvedSchemas;
+  schema: SchemaObject;
+}
+
+interface RecursivePropertyCodeOptions extends Omit<
+  BuildRecursiveShapeOptions,
+  "schema"
+> {
+  imports: Set<string>;
+  isRequired: boolean;
+  key: string;
+  propSchema: ReferenceObject | SchemaObject;
+}
+
+export function buildRecursiveShape(options: BuildRecursiveShapeOptions): {
+  imports: Set<string>;
+  shape: string[];
+} {
+  const { schema } = options;
+  const shape: string[] = [];
+  const imports = new Set<string>();
+  const requiredFields = new Set(schema.required ?? []);
+
+  for (const [key, propSchema] of Object.entries(schema.properties ?? {})) {
+    shape.push(
+      generateRecursivePropertyCode({
+        ...options,
+        imports,
+        isRequired: requiredFields.has(key),
+        key,
+        propSchema,
+      }),
+    );
+  }
+
+  return { imports, shape };
+}
+
+/* Exported for targeted getter tests. */
+export function generateGetterCode(
+  key: string,
+  propSchema: ReferenceObject | SchemaObject,
+  name: string,
+  isRequired: boolean,
+): string {
+  const referencedSchemaName = getRecursiveReferenceName(propSchema) ?? name;
+  const isCrossSchemaReference = referencedSchemaName !== name;
+  const baseGetter = (code: string, returnType: string) =>
+    `get ${JSON.stringify(key)}(): ${returnType} { return ${code}${isRequired ? "" : ".optional()"}; }`;
+
+  if (
+    !isReferenceObject(propSchema) &&
+    propSchema.type === "array" &&
+    propSchema.items &&
+    isReferenceObject(propSchema.items)
+  ) {
+    const arrayItemType = isCrossSchemaReference
+      ? "z.ZodTypeAny"
+      : `typeof ${referencedSchemaName}`;
+    const returnType = isRequired
+      ? `z.ZodArray<${arrayItemType}>`
+      : `z.ZodOptional<z.ZodArray<${arrayItemType}>>`;
+    return baseGetter(`z.array(${referencedSchemaName})`, returnType);
+  }
+
+  const returnType = isRequired
+    ? isCrossSchemaReference
+      ? "z.ZodTypeAny"
+      : `typeof ${referencedSchemaName}`
+    : isCrossSchemaReference
+      ? "z.ZodOptional<z.ZodTypeAny>"
+      : `z.ZodOptional<typeof ${referencedSchemaName}>`;
+  return baseGetter(referencedSchemaName, returnType);
+}
+
+function generateRecursivePropertyCode(
+  options: RecursivePropertyCodeOptions,
+): string {
+  const { imports, isRequired, key, name, propSchema } = options;
+
+  if (
+    !isRecursiveProperty(
+      propSchema,
+      options.originalSchemaName,
+      options.recursiveContext,
+    )
+  ) {
+    return generateRegularPropertyCode(options);
+  }
+
+  const referencedSchemaName = getRecursiveReferenceName(propSchema);
+  if (referencedSchemaName) {
+    addImport(imports, referencedSchemaName, name);
+    return generateGetterCode(key, propSchema, name, isRequired);
+  }
+
+  const propertyResult = zodSchemaToCode(propSchema, {
+    currentSchemaName: name,
+    extraProps: options.extraProps,
+    formatOverrides: options.formatOverrides,
+    imports: new Set(),
+    recursiveContext: options.recursiveContext,
+    resolvedSchemas: options.resolvedSchemas,
+  });
+  addImports(imports, propertyResult.imports, name);
+
+  const code = wrapOptional(propertyResult.code, isRequired);
+  const returnType = getRecursiveCompositionReturnType(
+    propSchema,
+    name,
+    isRequired,
+  );
+  return `get ${JSON.stringify(key)}(): ${returnType} { return ${code}; }`;
+}
+
+function generateRegularPropertyCode(
+  options: RecursivePropertyCodeOptions,
+): string {
+  const propertyResult = zodSchemaToCode(options.propSchema, {
+    currentSchemaName: options.name,
+    extraProps: options.extraProps,
+    formatOverrides: options.formatOverrides,
+    imports: new Set(),
+    recursiveContext: options.recursiveContext,
+    resolvedSchemas: options.resolvedSchemas,
+  });
+  addImports(options.imports, propertyResult.imports, options.name);
+
+  return `${JSON.stringify(options.key)}: ${wrapOptional(propertyResult.code, options.isRequired)}`;
+}
+
+function addImport(
+  imports: Set<string>,
+  importName: string,
+  currentSchemaName: string,
+): void {
+  if (importName !== currentSchemaName) {
+    imports.add(importName);
+  }
+}
+
+function addImports(
+  imports: Set<string>,
+  propertyImports: Set<string>,
+  currentSchemaName: string,
+): void {
+  propertyImports.forEach((importName) =>
+    addImport(imports, importName, currentSchemaName),
+  );
+}
+
+function wrapOptional(code: string, isRequired: boolean): string {
+  return isRequired ? code : `${code}.optional()`;
+}
+
+function getRecursiveCompositionReturnType(
+  propSchema: ReferenceObject | SchemaObject,
+  schemaName: string,
+  isRequired: boolean,
+): string {
+  const compositionItems = isReferenceObject(propSchema)
+    ? undefined
+    : (propSchema.allOf ?? propSchema.anyOf ?? propSchema.oneOf);
+  const singleRefTarget =
+    compositionItems?.length === 1 && isReferenceObject(compositionItems[0])
+      ? getSchemaNameFromReference(compositionItems[0].$ref)
+      : undefined;
+  const baseType =
+    singleRefTarget === schemaName
+      ? `z.ZodLazy<typeof ${schemaName}>`
+      : "z.ZodTypeAny";
+
+  return isRequired ? baseType : `z.ZodOptional<${baseType}>`;
+}
+
+function isRecursiveProperty(
+  propSchema: ReferenceObject | SchemaObject,
+  originalSchemaName: string,
+  recursiveContext: RecursiveContext,
+): boolean {
+  if ("$ref" in propSchema) {
+    const ref = propSchema.$ref;
+    if (!ref) {
+      return false;
+    }
+
+    const selfRef = `#/components/schemas/${originalSchemaName}`;
+    const shortSelfRef = `#/${originalSchemaName}`;
+    if (ref === selfRef || ref === shortSelfRef) {
+      return true;
+    }
+
+    const referencedSchema = getSchemaNameFromReference(ref);
+    return !!(
+      referencedSchema &&
+      recursiveContext.recursiveSchemas.has(referencedSchema)
+    );
+  }
+
+  const refs = findReferencesInSchema(propSchema);
+  const selfRef = `#/components/schemas/${originalSchemaName}`;
+  const shortSelfRef = `#/${originalSchemaName}`;
+  return refs.some((ref) => {
+    if (ref === selfRef || ref === shortSelfRef) {
+      return true;
+    }
+
+    const referencedSchema = getSchemaNameFromReference(ref);
+    return !!(
+      referencedSchema &&
+      recursiveContext.recursiveSchemas.has(referencedSchema)
+    );
+  });
+}
+
+function getRecursiveReferenceName(
+  propSchema: ReferenceObject | SchemaObject,
+): string | undefined {
+  if (isReferenceObject(propSchema)) {
+    return getSchemaNameFromReference(propSchema.$ref);
+  }
+
+  if (
+    propSchema.type === "array" &&
+    propSchema.items &&
+    isReferenceObject(propSchema.items)
+  ) {
+    return getSchemaNameFromReference(propSchema.items.$ref);
+  }
+
+  return undefined;
+}

--- a/packages/core-utils/src/schema-generator/recursive-type-renderer.ts
+++ b/packages/core-utils/src/schema-generator/recursive-type-renderer.ts
@@ -1,0 +1,137 @@
+import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
+
+import { isReferenceObject } from "openapi3-ts/oas31";
+
+import { findReferencesInSchema } from "./recursive-handlers.js";
+import { getSchemaNameFromReference } from "./schema-references.js";
+
+export function renderRecursiveTypeAlias(
+  schema: SchemaObject,
+  schemaName: string,
+): string | undefined {
+  return hasDirectSelfReference(schema, schemaName)
+    ? renderSchemaType(schema)
+    : undefined;
+}
+
+function hasDirectSelfReference(
+  schema: SchemaObject,
+  schemaName: string,
+): boolean {
+  return findReferencesInSchema(schema).some(
+    (ref) => getSchemaNameFromReference(ref) === schemaName,
+  );
+}
+
+function renderSchemaType(schema: ReferenceObject | SchemaObject): string {
+  if (isReferenceObject(schema)) {
+    return getSchemaNameFromReference(schema.$ref) ?? "unknown";
+  }
+
+  if (schema.enum?.length) {
+    return schema.enum.map((value) => JSON.stringify(value)).join(" | ");
+  }
+
+  if ("const" in schema && schema.const !== undefined) {
+    return JSON.stringify(schema.const);
+  }
+
+  const compositionType = renderCompositionType(schema);
+  const baseType = compositionType ?? renderSimpleSchemaType(schema);
+  const isNullable = "nullable" in schema && schema.nullable === true;
+
+  return isNullable ? `${baseType} | null` : baseType;
+}
+
+function renderCompositionType(schema: SchemaObject): string | undefined {
+  if (schema.allOf?.length) {
+    return schema.allOf.map(renderSchemaType).join(" & ");
+  }
+
+  if (schema.anyOf?.length) {
+    return schema.anyOf.map(renderSchemaType).join(" | ");
+  }
+
+  if (schema.oneOf?.length) {
+    return schema.oneOf.map(renderSchemaType).join(" | ");
+  }
+
+  return undefined;
+}
+
+function renderSimpleSchemaType(schema: SchemaObject): string {
+  if (schema.type === "array" || schema.items) {
+    return `Array<${renderSchemaType(schema.items ?? {})}>`;
+  }
+
+  if (
+    schema.type === "object" ||
+    schema.properties ||
+    schema.additionalProperties !== undefined
+  ) {
+    return renderObjectSchemaType(schema);
+  }
+
+  if (Array.isArray(schema.type)) {
+    return schema.type.map(renderPrimitiveType).join(" | ");
+  }
+
+  if (schema.type) {
+    return renderPrimitiveType(schema.type);
+  }
+
+  return "unknown";
+}
+
+function renderObjectSchemaType(schema: SchemaObject): string {
+  const requiredProperties = new Set(schema.required ?? []);
+  const propertyEntries = Object.entries(schema.properties ?? {}).map(
+    ([propertyName, propertySchema]) =>
+      `${JSON.stringify(propertyName)}${requiredProperties.has(propertyName) ? "" : "?"}: ${renderSchemaType(propertySchema)}`,
+  );
+  const propertyType =
+    propertyEntries.length > 0 ? `{ ${propertyEntries.join("; ")} }` : "{}";
+  const additionalPropertiesType = renderAdditionalPropertiesType(
+    schema.additionalProperties,
+  );
+
+  if (!additionalPropertiesType) {
+    return propertyType;
+  }
+
+  return propertyEntries.length > 0
+    ? `${propertyType} & ${additionalPropertiesType}`
+    : additionalPropertiesType;
+}
+
+function renderAdditionalPropertiesType(
+  additionalProperties: SchemaObject["additionalProperties"],
+): string | undefined {
+  if (additionalProperties === undefined || additionalProperties === false) {
+    return undefined;
+  }
+
+  if (additionalProperties === true) {
+    return "{ [key: string]: unknown }";
+  }
+
+  return `{ [key: string]: ${renderSchemaType(additionalProperties)} }`;
+}
+
+function renderPrimitiveType(
+  type: Exclude<SchemaObject["type"], readonly string[] | undefined>,
+): string {
+  switch (type) {
+    case "boolean":
+      return "boolean";
+    case "integer":
+    case "number":
+      return "number";
+    case "null":
+      return "null";
+    case "string":
+      return "string";
+    default:
+      return "unknown";
+  }
+}

--- a/packages/core-utils/src/schema-generator/reference-handlers.ts
+++ b/packages/core-utils/src/schema-generator/reference-handlers.ts
@@ -36,6 +36,11 @@ function handleReference(
       const originalSchemaName = ref.replace("#/components/schemas/", "");
       const schemaName: string = sanitizeIdentifier(originalSchemaName);
 
+      if (options.currentSchemaName === schemaName) {
+        result.code = `z.lazy(() => ${schemaName})`;
+        return result;
+      }
+
       /* Check for recursive references if context is available */
       if (options.recursiveContext) {
         const analysis = analyzeRecursiveReference(
@@ -45,14 +50,6 @@ function handleReference(
         );
 
         if (analysis.isRecursive) {
-          /* For direct self-references with lazy wrapping enabled, emit z.lazy() */
-          if (
-            analysis.isDirectSelfReference &&
-            options.recursiveContext.useLazyWrapping
-          ) {
-            result.code = `z.lazy(() => ${schemaName})`;
-            return result;
-          }
           /* For recursive references, we don't add imports here as they'll be handled
              by the recursive schema generation */
           result.code = schemaName;

--- a/packages/core-utils/src/schema-generator/reference-handlers.ts
+++ b/packages/core-utils/src/schema-generator/reference-handlers.ts
@@ -45,6 +45,14 @@ function handleReference(
         );
 
         if (analysis.isRecursive) {
+          /* For direct self-references with lazy wrapping enabled, emit z.lazy() */
+          if (
+            analysis.isDirectSelfReference &&
+            options.recursiveContext.useLazyWrapping
+          ) {
+            result.code = `z.lazy(() => ${schemaName})`;
+            return result;
+          }
           /* For recursive references, we don't add imports here as they'll be handled
              by the recursive schema generation */
           result.code = schemaName;

--- a/packages/core-utils/src/schema-generator/reference-handlers.ts
+++ b/packages/core-utils/src/schema-generator/reference-handlers.ts
@@ -3,7 +3,7 @@ import type { ReferenceObject } from "openapi3-ts/oas31";
 import type { RecursiveContext } from "./recursive-handlers.js";
 
 import { analyzeRecursiveReference } from "./recursive-handlers.js";
-import { sanitizeIdentifier } from "./utils.js";
+import { parseSchemaReference } from "./schema-references.js";
 
 /**
  * Options for reference handling
@@ -31,10 +31,9 @@ function handleReference(
 ): ZodSchemaResult {
   if ("$ref" in schema && schema.$ref) {
     const ref = schema.$ref;
-    // Check if it's a local reference to components/schemas
-    if (ref.startsWith("#/components/schemas/")) {
-      const originalSchemaName = ref.replace("#/components/schemas/", "");
-      const schemaName: string = sanitizeIdentifier(originalSchemaName);
+    const schemaReference = parseSchemaReference(ref);
+    if (schemaReference) {
+      const { identifierName: schemaName } = schemaReference;
 
       if (options.currentSchemaName === schemaName) {
         result.code = `z.lazy(() => ${schemaName})`;

--- a/packages/core-utils/src/schema-generator/schema-references.ts
+++ b/packages/core-utils/src/schema-generator/schema-references.ts
@@ -1,0 +1,47 @@
+import { sanitizeIdentifier } from "./utils.js";
+
+/**
+ * Parsed local schema reference names in both their original and sanitized form.
+ */
+export interface ParsedSchemaReference {
+  identifierName: string;
+  originalName: string;
+}
+
+/**
+ * Parses local schema references used by generated schema code.
+ */
+export function parseSchemaReference(
+  ref: string | undefined,
+): ParsedSchemaReference | undefined {
+  if (!ref) {
+    return undefined;
+  }
+
+  const componentMatch = /^#\/components\/schemas\/([^/]+)$/.exec(ref);
+  if (componentMatch) {
+    return createParsedSchemaReference(componentMatch[1]);
+  }
+
+  const shortFormMatch = /^#\/([^/]+)$/.exec(ref);
+  if (shortFormMatch) {
+    return createParsedSchemaReference(shortFormMatch[1]);
+  }
+
+  return undefined;
+}
+
+export function getSchemaNameFromReference(
+  ref: string | undefined,
+): string | undefined {
+  return parseSchemaReference(ref)?.identifierName;
+}
+
+function createParsedSchemaReference(
+  originalName: string,
+): ParsedSchemaReference {
+  return {
+    identifierName: sanitizeIdentifier(originalName),
+    originalName,
+  };
+}

--- a/packages/core-utils/src/schema-generator/union-types.ts
+++ b/packages/core-utils/src/schema-generator/union-types.ts
@@ -11,6 +11,7 @@ import type { ExtraPropsMode } from "../shared/types.js";
 import type { StringFormatOverrideRegistry } from "./format-overrides.js";
 import type { RecursiveContext } from "./recursive-handlers.js";
 import { buildDiscriminatedUnionCode } from "./discriminated-union.js";
+import { parseSchemaReference } from "./schema-references.js";
 import { mergeImports, sanitizeIdentifier } from "./utils.js";
 
 /**
@@ -63,9 +64,9 @@ export function handleAllOfSchema(
     currentSchemaName &&
     schemas.some((schema) => {
       if (isReferenceObject(schema)) {
-        const refName = extractSchemaNameFromRef(schema.$ref);
+        const refName = parseSchemaReference(schema.$ref);
         return (
-          refName !== null &&
+          refName !== undefined &&
           sanitizeIdentifier(refName.originalName) === currentSchemaName
         );
       }
@@ -103,7 +104,7 @@ export function handleAllOfSchema(
 
     for (const schema of objectSchemas) {
       if (isReferenceObject(schema)) {
-        const refName = extractSchemaNameFromRef(schema.$ref);
+        const refName = parseSchemaReference(schema.$ref);
         if (refName) {
           allImports.add(refName.identifierName);
           shapeExpressions.push(`...${refName.identifierName}.shape`);
@@ -341,7 +342,7 @@ function isObjectSchemaType(
 ): boolean {
   if (isReferenceObject(schema)) {
     if (!resolvedSchemas) return false;
-    const refName = extractSchemaNameFromRef(schema.$ref);
+    const refName = parseSchemaReference(schema.$ref);
     if (!refName) return false;
     if (seenRefs.has(refName.originalName)) return false;
     const resolved = resolvedSchemas[refName.originalName];
@@ -369,23 +370,4 @@ function isObjectSchemaType(
   }
 
   return !schema.type || schema.type === "object";
-}
-
-function extractSchemaNameFromRef(
-  ref: string | undefined,
-): null | { identifierName: string; originalName: string } {
-  if (!ref) return null;
-  const refMatch = ref.match(/\/([^/]+)$/);
-  if (!refMatch) {
-    return null;
-  }
-
-  const originalName = refMatch[1];
-  return {
-    // Keep both names because OpenAPI component keys and TS identifiers have
-    // different constraints: `data_center` must stay the lookup key, while
-    // `dataCenter` is the legal import/symbol name in generated code.
-    identifierName: sanitizeIdentifier(originalName),
-    originalName,
-  };
 }

--- a/packages/core-utils/src/shared/schema-type-resolver.ts
+++ b/packages/core-utils/src/shared/schema-type-resolver.ts
@@ -7,6 +7,7 @@ import { isReferenceObject, isSchemaObject } from "openapi3-ts/oas31";
 
 import type { ContentTypeMapping } from "./types.js";
 
+import { parseSchemaReference } from "../schema-generator/schema-references.js";
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
 import { analyzeReadWriteProperties } from "./types.js";
 
@@ -34,13 +35,13 @@ export function resolveSchemaTypeName(
   resolvedSchemas?: Record<string, ReferenceObject | SchemaObject>,
 ): string {
   if (isReferenceObject(schema)) {
-    const originalSchemaName = schema.$ref.split("/").pop();
-    assert(originalSchemaName, "Invalid $ref in schema");
-    const baseName = sanitizeIdentifier(originalSchemaName as string);
+    const schemaReference = parseSchemaReference(schema.$ref);
+    assert(schemaReference, "Invalid $ref in schema");
+    const { identifierName: baseName, originalName } = schemaReference;
 
     /* Check for readOnly/writeOnly variants when context and resolved schemas are provided */
     if (context && resolvedSchemas) {
-      const referencedSchema = resolvedSchemas[originalSchemaName];
+      const referencedSchema = resolvedSchemas[originalName];
       if (referencedSchema && isSchemaObject(referencedSchema)) {
         const analysis = analyzeReadWriteProperties(referencedSchema);
 

--- a/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
@@ -1,3 +1,8 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import { promisify } from "node:util";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import type { SchemaObject } from "openapi3-ts/oas31";
@@ -204,13 +209,12 @@ describe("file-generators - z.lazy() for non-object recursive schemas", () => {
 
     /* Should wrap self-reference in z.lazy() */
     expect(result.content).toContain("z.lazy(() => requestTracerTrace)");
-    /* Should add explicit z.ZodType annotation */
+    /* Should add an explicit recursive public type instead of widening to unknown */
     expect(result.content).toContain(
-      "export const requestTracerTrace: z.ZodType =",
+      'export type requestTracerTrace = Array<{ "trace"?: requestTracerTrace }>;',
     );
-    /* Should still export the type alias */
     expect(result.content).toContain(
-      "export type requestTracerTrace = z.infer<typeof requestTracerTrace>;",
+      "export const requestTracerTrace: z.ZodType<requestTracerTrace> =",
     );
   });
 
@@ -248,8 +252,12 @@ describe("file-generators - z.lazy() for non-object recursive schemas", () => {
 
     /* Should wrap self-references in z.lazy() */
     expect(result.content).toContain("z.lazy(() => workersKvAny)");
-    /* Should add explicit z.ZodType annotation */
-    expect(result.content).toContain("export const workersKvAny: z.ZodType =");
+    expect(result.content).toContain(
+      "export type workersKvAny = string | number | boolean | Array<workersKvAny> | { [key: string]: workersKvAny };",
+    );
+    expect(result.content).toContain(
+      "export const workersKvAny: z.ZodType<workersKvAny> =",
+    );
   });
 
   it("should NOT add z.ZodType annotation for non-recursive schemas", async () => {
@@ -271,7 +279,7 @@ describe("file-generators - z.lazy() for non-object recursive schemas", () => {
 
     /* Should NOT have type annotation */
     expect(result.content).toContain("export const SimpleSchema =");
-    expect(result.content).not.toContain(": z.ZodType");
+    expect(result.content).not.toContain(": z.ZodType<");
   });
 
   it("should NOT add z.ZodType annotation for schemas in recursive set without direct self-reference", async () => {
@@ -293,6 +301,192 @@ describe("file-generators - z.lazy() for non-object recursive schemas", () => {
 
     /* Should NOT have z.ZodType annotation since code doesn't reference IndirectNode */
     expect(result.content).toContain("export const IndirectNode =");
-    expect(result.content).not.toContain(": z.ZodType");
+    expect(result.content).not.toContain(": z.ZodType<");
   });
 });
+
+describe("file-generators - recursive generated types compile", () => {
+  it("should preserve exported types for direct self-recursive non-object schemas", async () => {
+    const recursiveContext = createRecursiveContext();
+    recursiveContext.recursiveSchemas.add("workersKvAny");
+    recursiveContext.recursiveSchemas.add("requestTracerTrace");
+
+    const workersKvAny = await generateSchemaFile(
+      "workersKvAny",
+      {
+        anyOf: [
+          { type: "string" },
+          { type: "number" },
+          { type: "boolean" },
+          {
+            type: "array",
+            items: { $ref: "#/components/schemas/workersKvAny" },
+          },
+          {
+            type: "object",
+            additionalProperties: {
+              $ref: "#/components/schemas/workersKvAny",
+            },
+          },
+        ],
+      },
+      undefined,
+      { recursiveContext },
+    );
+
+    const requestTracerTrace = await generateSchemaFile(
+      "requestTracerTrace",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            trace: {
+              $ref: "#/components/schemas/requestTracerTrace",
+            },
+          },
+        },
+      },
+      undefined,
+      { recursiveContext },
+    );
+
+    await expect(
+      typecheckGeneratedSchemas({
+        "requestTracerTrace.ts": requestTracerTrace.content,
+        "workersKvAny.ts": workersKvAny.content,
+        "recursive-types.ts": `
+import type { requestTracerTrace as RequestTracerTrace } from "./requestTracerTrace.js";
+import { requestTracerTrace } from "./requestTracerTrace.js";
+import type { workersKvAny as WorkersKvAny } from "./workersKvAny.js";
+import { workersKvAny } from "./workersKvAny.js";
+
+type IsUnknown<T> = unknown extends T ? ([T] extends [unknown] ? true : false) : false;
+
+const traceValue: RequestTracerTrace = [{ trace: [] }];
+const kvValue: WorkersKvAny = [{ nested: ["value", 1, false] }];
+const parsedTrace: RequestTracerTrace = requestTracerTrace.parse(traceValue);
+const parsedKv: WorkersKvAny = workersKvAny.parse(kvValue);
+const traceIsUnknown: IsUnknown<RequestTracerTrace> = false;
+const kvIsUnknown: IsUnknown<WorkersKvAny> = false;
+
+void parsedTrace;
+void parsedKv;
+void traceIsUnknown;
+void kvIsUnknown;
+
+// @ts-expect-error requestTracerTrace should stay an array type
+const invalidTrace: RequestTracerTrace = { trace: [] };
+// @ts-expect-error workersKvAny should reject null
+const invalidKv: WorkersKvAny = null;
+
+void invalidTrace;
+void invalidKv;
+`,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should keep indirect recursive object cycles compiling without direct-self annotations", async () => {
+    const recursiveContext = createRecursiveContext();
+    recursiveContext.recursiveSchemas.add("Category");
+    recursiveContext.recursiveSchemas.add("CategoryParent");
+
+    const category = await generateRecursiveSchemaFile({
+      description: "Category node",
+      name: "Category",
+      originalSchemaName: "Category",
+      recursiveContext,
+      schema: {
+        properties: {
+          parent: { $ref: "#/components/schemas/CategoryParent" },
+        },
+        type: "object",
+      },
+    });
+    const categoryParent = await generateRecursiveSchemaFile({
+      description: "Category parent node",
+      name: "CategoryParent",
+      originalSchemaName: "CategoryParent",
+      recursiveContext,
+      schema: {
+        properties: {
+          child: { $ref: "#/components/schemas/Category" },
+        },
+        type: "object",
+      },
+    });
+
+    expect(category.content).not.toContain(": z.ZodType<");
+    expect(categoryParent.content).not.toContain(": z.ZodType<");
+
+    await expect(
+      typecheckGeneratedSchemas({
+        "Category.ts": category.content,
+        "CategoryParent.ts": categoryParent.content,
+        "indirect-cycle.ts": `
+import type { Category } from "./Category.js";
+import type { CategoryParent } from "./CategoryParent.js";
+
+const categoryValue: Category = {};
+const parentValue: CategoryParent = { child: categoryValue };
+
+void categoryValue;
+void parentValue;
+`,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+const execFileAsync = promisify(execFile);
+
+async function typecheckGeneratedSchemas(
+  files: Record<string, string>,
+): Promise<void> {
+  const workspaceDir = path.join(
+    process.cwd(),
+    "tests",
+    ".recursive-schema-typecheck",
+  );
+
+  await fs.rm(workspaceDir, { force: true, recursive: true });
+  await fs.mkdir(workspaceDir, { recursive: true });
+
+  try {
+    await Promise.all(
+      Object.entries(files).map(async ([fileName, content]) => {
+        await fs.writeFile(path.join(workspaceDir, fileName), content);
+      }),
+    );
+
+    await fs.writeFile(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["./**/*.ts"],
+      }),
+    );
+
+    await execFileAsync(
+      "pnpm",
+      [
+        "exec",
+        "tsgo",
+        "--noEmit",
+        "-p",
+        path.join(workspaceDir, "tsconfig.json"),
+      ],
+      { cwd: process.cwd() },
+    );
+  } finally {
+    await fs.rm(workspaceDir, { force: true, recursive: true });
+  }
+}

--- a/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
@@ -437,6 +437,47 @@ void parentValue;
       }),
     ).resolves.toBeUndefined();
   });
+
+  it("should keep single-self-reference compositions compiling", async () => {
+    const recursiveContext = createRecursiveContext();
+    recursiveContext.recursiveSchemas.add("NotificationEvent");
+
+    const notificationEvent = await generateRecursiveSchemaFile({
+      description: "Notification event",
+      name: "NotificationEvent",
+      originalSchemaName: "NotificationEvent",
+      recursiveContext,
+      schema: {
+        properties: {
+          templateEvent: {
+            allOf: [{ $ref: "#/components/schemas/NotificationEvent" }],
+            description:
+              "The template of the event. Only custom events configured by Jira administrators have template.",
+          },
+        },
+        type: "object",
+      },
+    });
+
+    expect(notificationEvent.content).toContain(
+      'get "templateEvent"(): z.ZodOptional<z.ZodLazy<typeof NotificationEvent>>',
+    );
+
+    await expect(
+      typecheckGeneratedSchemas({
+        "NotificationEvent.ts": notificationEvent.content,
+        "notification-event.ts": `
+import type { NotificationEvent } from "./NotificationEvent.js";
+import { NotificationEvent as NotificationEventSchema } from "./NotificationEvent.js";
+
+const value: NotificationEvent = {};
+const parsedValue: NotificationEvent = NotificationEventSchema.parse(value);
+
+void parsedValue;
+`,
+      }),
+    ).resolves.toBeUndefined();
+  });
 });
 
 const execFileAsync = promisify(execFile);

--- a/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { SchemaObject } from "openapi3-ts/oas31";
 
-import { generateRecursiveSchemaFile } from "../../src/schema-generator/file-generators.js";
+import {
+  generateRecursiveSchemaFile,
+  generateSchemaFile,
+} from "../../src/schema-generator/file-generators.js";
 import { createRecursiveContext } from "../../src/schema-generator/recursive-handlers.js";
 
 describe("file-generators - direct $ref recursive properties", () => {
@@ -171,5 +174,125 @@ describe("file-generators - direct $ref recursive properties", () => {
     /* Required property doesn't have .optional() */
     expect(result.content).toContain('"value": z.number()');
     expect(result.content).not.toContain('"value": z.number().optional()');
+  });
+});
+
+describe("file-generators - z.lazy() for non-object recursive schemas", () => {
+  it("should use z.lazy() for array schemas that self-reference", async () => {
+    const recursiveContext = createRecursiveContext();
+    recursiveContext.recursiveSchemas.add("requestTracerTrace");
+
+    /* Array schema where items contain a self-reference */
+    const traceSchema: SchemaObject = {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          trace: {
+            $ref: "#/components/schemas/requestTracerTrace",
+          },
+        },
+      },
+    };
+
+    const result = await generateSchemaFile(
+      "requestTracerTrace",
+      traceSchema,
+      undefined,
+      { recursiveContext },
+    );
+
+    /* Should wrap self-reference in z.lazy() */
+    expect(result.content).toContain("z.lazy(() => requestTracerTrace)");
+    /* Should add explicit z.ZodType annotation */
+    expect(result.content).toContain(
+      "export const requestTracerTrace: z.ZodType =",
+    );
+    /* Should still export the type alias */
+    expect(result.content).toContain(
+      "export type requestTracerTrace = z.infer<typeof requestTracerTrace>;",
+    );
+  });
+
+  it("should use z.lazy() for circular self-referencing schemas", async () => {
+    const recursiveContext = createRecursiveContext();
+    recursiveContext.recursiveSchemas.add("workersKvAny");
+
+    /* Schema that references itself */
+    const kvSchema: SchemaObject = {
+      anyOf: [
+        { type: "string" },
+        { type: "number" },
+        { type: "boolean" },
+        {
+          type: "array",
+          items: { $ref: "#/components/schemas/workersKvAny" },
+        },
+        {
+          type: "object",
+          additionalProperties: {
+            $ref: "#/components/schemas/workersKvAny",
+          },
+        },
+      ],
+    };
+
+    const result = await generateSchemaFile(
+      "workersKvAny",
+      kvSchema,
+      undefined,
+      {
+        recursiveContext,
+      },
+    );
+
+    /* Should wrap self-references in z.lazy() */
+    expect(result.content).toContain("z.lazy(() => workersKvAny)");
+    /* Should add explicit z.ZodType annotation */
+    expect(result.content).toContain("export const workersKvAny: z.ZodType =");
+  });
+
+  it("should NOT add z.ZodType annotation for non-recursive schemas", async () => {
+    const recursiveContext = createRecursiveContext();
+
+    const simpleSchema: SchemaObject = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    };
+
+    const result = await generateSchemaFile(
+      "SimpleSchema",
+      simpleSchema,
+      undefined,
+      { recursiveContext },
+    );
+
+    /* Should NOT have type annotation */
+    expect(result.content).toContain("export const SimpleSchema =");
+    expect(result.content).not.toContain(": z.ZodType");
+  });
+
+  it("should NOT add z.ZodType annotation for schemas in recursive set without direct self-reference", async () => {
+    const recursiveContext = createRecursiveContext();
+    // Mark IndirectNode as recursive (part of a cycle) but its code won't reference itself
+    recursiveContext.recursiveSchemas.add("IndirectNode");
+
+    const schema: SchemaObject = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        related: { $ref: "#/components/schemas/OtherNode" },
+      },
+    };
+
+    const result = await generateSchemaFile("IndirectNode", schema, undefined, {
+      recursiveContext,
+    });
+
+    /* Should NOT have z.ZodType annotation since code doesn't reference IndirectNode */
+    expect(result.content).toContain("export const IndirectNode =");
+    expect(result.content).not.toContain(": z.ZodType");
   });
 });

--- a/packages/core-utils/tests/schema-generator/file-generators.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators.test.ts
@@ -325,7 +325,7 @@ describe("schema-generator file-generators", () => {
   });
 
   describe("recursive type annotation", () => {
-    it("should add z.ZodType annotation when schema code directly self-references", async () => {
+    it("should generate an explicit recursive type alias for direct self-references", async () => {
       const schema: SchemaObject = {
         properties: {
           children: {
@@ -350,10 +350,15 @@ describe("schema-generator file-generators", () => {
         recursiveContext,
       });
 
-      expect(result.content).toContain("export const TreeNode: z.ZodType =");
+      expect(result.content).toContain(
+        'export type TreeNode = { "children"?: Array<TreeNode> };',
+      );
+      expect(result.content).toContain(
+        "export const TreeNode: z.ZodType<TreeNode> =",
+      );
     });
 
-    it("should NOT add z.ZodType annotation when schema is in recursive set but code does not self-reference", async () => {
+    it("should NOT add an explicit recursive type alias when schema is in recursive set but does not self-reference", async () => {
       const schema: SchemaObject = {
         properties: {
           name: { type: "string" },
@@ -380,7 +385,10 @@ describe("schema-generator file-generators", () => {
       );
 
       expect(result.content).toContain("export const IndirectNode =");
-      expect(result.content).not.toContain(": z.ZodType");
+      expect(result.content).not.toContain(": z.ZodType<");
+      expect(result.content).toContain(
+        "export type IndirectNode = z.infer<typeof IndirectNode>;",
+      );
     });
   });
 

--- a/packages/core-utils/tests/schema-generator/file-generators.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators.test.ts
@@ -8,6 +8,7 @@ import {
   generateSchemaFile,
   generateGetterCode,
 } from "../../src/schema-generator/file-generators.js";
+import { createRecursiveContext } from "../../src/schema-generator/recursive-handlers.js";
 import { zodSchemaToCode } from "../../src/schema-generator/schema-converter.js";
 
 // Mock schema-converter
@@ -320,6 +321,66 @@ describe("schema-generator file-generators", () => {
       );
 
       expect(result.content).toContain("Response schema for GetUser404");
+    });
+  });
+
+  describe("recursive type annotation", () => {
+    it("should add z.ZodType annotation when schema code directly self-references", async () => {
+      const schema: SchemaObject = {
+        properties: {
+          children: {
+            type: "array",
+            items: { $ref: "#/components/schemas/TreeNode" },
+          },
+        },
+        type: "object",
+      };
+
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ children: z.lazy(() => z.array(TreeNode)) })",
+          imports: new Set(),
+        }),
+      );
+
+      const recursiveContext = createRecursiveContext();
+      recursiveContext.recursiveSchemas.add("TreeNode");
+
+      const result = await generateSchemaFile("TreeNode", schema, undefined, {
+        recursiveContext,
+      });
+
+      expect(result.content).toContain("export const TreeNode: z.ZodType =");
+    });
+
+    it("should NOT add z.ZodType annotation when schema is in recursive set but code does not self-reference", async () => {
+      const schema: SchemaObject = {
+        properties: {
+          name: { type: "string" },
+        },
+        type: "object",
+      };
+
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.object({ name: z.string() })",
+          imports: new Set(),
+        }),
+      );
+
+      /* Schema is part of an indirect cycle but its own code doesn't reference itself */
+      const recursiveContext = createRecursiveContext();
+      recursiveContext.recursiveSchemas.add("IndirectNode");
+
+      const result = await generateSchemaFile(
+        "IndirectNode",
+        schema,
+        undefined,
+        { recursiveContext },
+      );
+
+      expect(result.content).toContain("export const IndirectNode =");
+      expect(result.content).not.toContain(": z.ZodType");
     });
   });
 

--- a/packages/core-utils/tests/schema-generator/recursive-handlers.test.ts
+++ b/packages/core-utils/tests/schema-generator/recursive-handlers.test.ts
@@ -16,8 +16,6 @@ describe("recursive-handlers", () => {
 
       expect(context.recursiveSchemas).toBeInstanceOf(Set);
       expect(context.recursiveSchemas.size).toBe(0);
-      expect(context.recursiveProperties).toBeInstanceOf(Map);
-      expect(context.recursiveProperties.size).toBe(0);
       expect(context.referenceStack).toEqual([]);
     });
   });
@@ -112,18 +110,6 @@ describe("recursive-handlers", () => {
 
       context.recursiveSchemas.add("RecursiveSchema");
       expect(context.recursiveSchemas.has("RecursiveSchema")).toBe(true);
-    });
-
-    it("should track recursive properties within schemas", () => {
-      const context = createRecursiveContext();
-
-      expect(context.recursiveProperties.has("TreeNode")).toBe(false);
-
-      context.recursiveProperties.set("TreeNode", new Set(["children"]));
-      expect(context.recursiveProperties.has("TreeNode")).toBe(true);
-      expect(context.recursiveProperties.get("TreeNode")?.has("children")).toBe(
-        true,
-      );
     });
   });
 

--- a/packages/core-utils/tests/schema-generator/schema-references.test.ts
+++ b/packages/core-utils/tests/schema-generator/schema-references.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSchemaNameFromReference,
+  parseSchemaReference,
+} from "../../src/schema-generator/schema-references.js";
+
+describe("schema-references", () => {
+  it("should parse component schema references", () => {
+    const result = parseSchemaReference("#/components/schemas/data_center");
+
+    expect(result).toEqual({
+      identifierName: "dataCenter",
+      originalName: "data_center",
+    });
+  });
+
+  it("should parse short-form schema references", () => {
+    const result = parseSchemaReference("#/Category");
+
+    expect(result).toEqual({
+      identifierName: "Category",
+      originalName: "Category",
+    });
+  });
+
+  it("should ignore non-schema references", () => {
+    expect(parseSchemaReference("#/paths/users")).toBeUndefined();
+    expect(getSchemaNameFromReference("not-a-ref")).toBeUndefined();
+  });
+});

--- a/packages/test-core/tests/schema-generator/recursive-handlers.test.ts
+++ b/packages/test-core/tests/schema-generator/recursive-handlers.test.ts
@@ -15,8 +15,6 @@ describe("recursive-handlers", () => {
 
       expect(context.recursiveSchemas).toBeInstanceOf(Set);
       expect(context.recursiveSchemas.size).toBe(0);
-      expect(context.recursiveProperties).toBeInstanceOf(Map);
-      expect(context.recursiveProperties.size).toBe(0);
       expect(context.referenceStack).toEqual([]);
     });
   });
@@ -113,17 +111,6 @@ describe("recursive-handlers", () => {
       expect(context.recursiveSchemas.has("RecursiveSchema")).toBe(true);
     });
 
-    it("should track recursive properties within schemas", () => {
-      const context = createRecursiveContext();
-
-      expect(context.recursiveProperties.has("TreeNode")).toBe(false);
-
-      context.recursiveProperties.set("TreeNode", new Set(["children"]));
-      expect(context.recursiveProperties.has("TreeNode")).toBe(true);
-      expect(context.recursiveProperties.get("TreeNode")?.has("children")).toBe(
-        true,
-      );
-    });
   });
 
   describe("edge cases", () => {

--- a/packages/test-core/tests/schema-generator/recursive-handlers.test.ts
+++ b/packages/test-core/tests/schema-generator/recursive-handlers.test.ts
@@ -110,7 +110,6 @@ describe("recursive-handlers", () => {
       context.recursiveSchemas.add("RecursiveSchema");
       expect(context.recursiveSchemas.has("RecursiveSchema")).toBe(true);
     });
-
   });
 
   describe("edge cases", () => {


### PR DESCRIPTION
## Problem

6 TypeScript errors (3x TS7022 + 3x TS2448) in 3 generated schema files. Recursive schemas reference themselves in their own initializer without type annotations.

### Affected schemas:
- `requestTracerTrace` — self-references via `trace` property
- `workersKvAny` — self-references (circular)
- `workersObservabilityFilterNode` — self-references (circular)

## Fix

For non-object recursive schemas that can't use the getter-based approach:

1. Added `useLazyWrapping` flag to `RecursiveContext`
2. Wraps direct self-references in `z.lazy(() => ...)` when enabled
3. Adds explicit `: z.ZodType` annotation on recursive schema declarations
4. Enables lazy wrapping in `generateSchemaFile` for schemas in the recursive set

### Generated output (after fix):
```ts
export const requestTracerTrace: z.ZodType = z.array(z.object({
  trace: z.lazy(() => requestTracerTrace).optional()
}));
```

## Tests
- 3 new test cases added covering array self-reference, circular anyOf, and non-recursive schemas
- All 230 core-utils tests pass