### PR TITLE
fix(core-utils): handle nullable members in discriminated unions

### DIFF
--- a/packages/core-utils/src/schema-generator/discriminated-union.ts
+++ b/packages/core-utils/src/schema-generator/discriminated-union.ts
@@ -1,0 +1,258 @@
+import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
+
+import { isReferenceObject, isSchemaObject } from "openapi3-ts/oas31";
+
+import type { ResolvedSchemas } from "./types.js";
+import { isNullable } from "./utils.js";
+
+interface DiscriminatedUnionMember {
+  code: string;
+  schema: ReferenceObject | SchemaObject;
+}
+
+interface BuildDiscriminatedUnionCodeOptions {
+  discriminatorProperty: string;
+  members: DiscriminatedUnionMember[];
+  resolvedSchemas?: ResolvedSchemas;
+}
+
+export function buildDiscriminatedUnionCode(
+  options: BuildDiscriminatedUnionCodeOptions,
+): string {
+  const { discriminatorProperty, members, resolvedSchemas } = options;
+  const memberCodes = members.map((member) => member.code);
+  const nullableFlags = members.map((member) =>
+    isDiscriminatedUnionMemberNullable(member.schema, resolvedSchemas),
+  );
+
+  if (!nullableFlags.some(Boolean)) {
+    return renderDiscriminatedUnion(discriminatorProperty, memberCodes);
+  }
+
+  if (!nullableFlags.every(Boolean)) {
+    return renderPlainUnion(memberCodes);
+  }
+
+  const unwrappedMemberCodes: string[] = [];
+  for (const member of members) {
+    const unwrappedMemberCode = unwrapNullableDiscriminatedUnionMember(
+      member,
+      resolvedSchemas,
+    );
+    if (unwrappedMemberCode === null) {
+      return renderPlainUnion(memberCodes);
+    }
+    unwrappedMemberCodes.push(unwrappedMemberCode);
+  }
+
+  return `${renderDiscriminatedUnion(discriminatorProperty, unwrappedMemberCodes)}.nullable()`;
+}
+
+function renderDiscriminatedUnion(
+  discriminatorProperty: string,
+  memberCodes: string[],
+): string {
+  return `z.discriminatedUnion("${discriminatorProperty}", [${memberCodes.join(", ")}])`;
+}
+
+function renderPlainUnion(memberCodes: string[]): string {
+  return `z.union([${memberCodes.join(", ")}])`;
+}
+
+function unwrapNullableDiscriminatedUnionMember(
+  member: DiscriminatedUnionMember,
+  resolvedSchemas?: ResolvedSchemas,
+): null | string {
+  if (isReferenceObject(member.schema)) {
+    const resolvedSchema = resolveReferencedSchema(
+      member.schema,
+      resolvedSchemas,
+    );
+    if (!resolvedSchema || resolvedSchema.default !== undefined) {
+      return null;
+    }
+    return `${member.code}.unwrap()`;
+  }
+
+  if (member.schema.default !== undefined) {
+    return null;
+  }
+
+  return stripTopLevelNullableWrapper(member.code);
+}
+
+function isDiscriminatedUnionMemberNullable(
+  schema: ReferenceObject | SchemaObject,
+  resolvedSchemas?: ResolvedSchemas,
+): boolean {
+  if (isReferenceObject(schema)) {
+    const resolvedSchema = resolveReferencedSchema(schema, resolvedSchemas);
+    return resolvedSchema ? isSchemaNullable(resolvedSchema) : false;
+  }
+
+  return isSchemaNullable(schema);
+}
+
+function isSchemaNullable(schema: SchemaObject): boolean {
+  return isNullable(schema)
+    ? true
+    : Array.isArray(schema.type) && schema.type.includes("null");
+}
+
+function resolveReferencedSchema(
+  schema: ReferenceObject,
+  resolvedSchemas?: ResolvedSchemas,
+): null | SchemaObject {
+  if (!resolvedSchemas) {
+    return null;
+  }
+
+  const refName = extractSchemaNameFromRef(schema.$ref);
+  if (!refName) {
+    return null;
+  }
+
+  const resolvedSchema = resolvedSchemas[refName];
+  return resolvedSchema && isSchemaObject(resolvedSchema)
+    ? resolvedSchema
+    : null;
+}
+
+function stripTopLevelNullableWrapper(code: string): null | string {
+  const nullableWrapper = ".nullable()";
+  const nullableIndex = findTopLevelNullableWrapper(code, nullableWrapper);
+  if (nullableIndex === null) {
+    return null;
+  }
+
+  const codeBeforeNullable = stripEnclosingParens(code.slice(0, nullableIndex));
+  const codeAfterNullable = code.slice(nullableIndex + nullableWrapper.length);
+  return `${codeBeforeNullable}${codeAfterNullable}`;
+}
+
+function findTopLevelNullableWrapper(
+  code: string,
+  wrapper: string,
+): null | number {
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let parenDepth = 0;
+  let quote: '"' | "'" | "`" | undefined;
+  let escaped = false;
+  let matchIndex: null | number = null;
+
+  for (let i = 0; i < code.length; i++) {
+    const char = code[i];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") {
+      parenDepth++;
+      continue;
+    }
+    if (char === ")") {
+      parenDepth--;
+      continue;
+    }
+    if (char === "{") {
+      braceDepth++;
+      continue;
+    }
+    if (char === "}") {
+      braceDepth--;
+      continue;
+    }
+    if (char === "[") {
+      bracketDepth++;
+      continue;
+    }
+    if (char === "]") {
+      bracketDepth--;
+      continue;
+    }
+    if (
+      char === "." &&
+      bracketDepth === 0 &&
+      braceDepth === 0 &&
+      parenDepth === 0 &&
+      code.startsWith(wrapper, i)
+    ) {
+      matchIndex = i;
+      i += wrapper.length - 1;
+    }
+  }
+
+  return matchIndex;
+}
+
+function stripEnclosingParens(code: string): string {
+  if (!code.startsWith("(") || !code.endsWith(")")) {
+    return code;
+  }
+
+  let parenDepth = 0;
+  let quote: '"' | "'" | "`" | undefined;
+  let escaped = false;
+
+  for (let i = 0; i < code.length; i++) {
+    const char = code[i];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") {
+      parenDepth++;
+      continue;
+    }
+    if (char === ")") {
+      parenDepth--;
+      if (parenDepth === 0 && i < code.length - 1) {
+        return code;
+      }
+    }
+  }
+
+  return code.slice(1, -1);
+}
+
+function extractSchemaNameFromRef(ref: string | undefined): null | string {
+  if (!ref) {
+    return null;
+  }
+
+  const refMatch = ref.match(/\/([^/]+)$/);
+  return refMatch ? refMatch[1] : null;
+}

--- a/packages/core-utils/src/schema-generator/union-types.ts
+++ b/packages/core-utils/src/schema-generator/union-types.ts
@@ -10,6 +10,7 @@ import type {
 import type { ExtraPropsMode } from "../shared/types.js";
 import type { StringFormatOverrideRegistry } from "./format-overrides.js";
 import type { RecursiveContext } from "./recursive-handlers.js";
+import { buildDiscriminatedUnionCode } from "./discriminated-union.js";
 import { mergeImports, sanitizeIdentifier } from "./utils.js";
 
 /**
@@ -221,8 +222,14 @@ export function handleUnionSchema(
       return result;
     }
 
-    // Generate discriminated union - works for both anyOf and oneOf with discriminator
-    result.code = `z.discriminatedUnion("${discriminatorProperty}", [${schemasCodes.join(", ")}])`;
+    result.code = buildDiscriminatedUnionCode({
+      discriminatorProperty,
+      members: schemas.map((schema, index) => ({
+        code: schemasCodes[index],
+        schema,
+      })),
+      resolvedSchemas,
+    });
     return result;
   }
 

--- a/packages/core-utils/tests/zod-schema-to-code.test.ts
+++ b/packages/core-utils/tests/zod-schema-to-code.test.ts
@@ -641,6 +641,144 @@ describe("zodSchemaToCode", () => {
     expect(result.imports.has("Square")).toBe(true);
   });
 
+  it("should hoist nullable $ref members in discriminated unions", () => {
+    const schema: SchemaObject = {
+      discriminator: {
+        propertyName: "kind",
+      },
+      oneOf: [
+        { $ref: "#/components/schemas/Dog" },
+        { $ref: "#/components/schemas/Cat" },
+      ],
+    };
+    const result = zodSchemaToCode(schema, {
+      resolvedSchemas: {
+        Cat: {
+          properties: {
+            color: { type: "string" },
+            kind: { enum: ["cat"], type: "string" },
+          },
+          required: ["kind"],
+          type: ["object", "null"],
+        },
+        Dog: {
+          description: "A dog",
+          properties: {
+            bark: { type: "boolean" },
+            kind: { enum: ["dog"], type: "string" },
+          },
+          required: ["kind"],
+          type: ["object", "null"],
+        },
+      },
+    });
+
+    expect(result.code).toBe(
+      'z.discriminatedUnion("kind", [Dog.unwrap(), Cat.unwrap()]).nullable()',
+    );
+  });
+
+  it("should fall back to z.union when only some discriminated union members are nullable", () => {
+    const schema: SchemaObject = {
+      discriminator: {
+        propertyName: "type",
+      },
+      oneOf: [
+        { $ref: "#/components/schemas/NullableMember" },
+        { $ref: "#/components/schemas/NonNullableMember" },
+      ],
+    };
+    const result = zodSchemaToCode(schema, {
+      resolvedSchemas: {
+        NonNullableMember: {
+          properties: {
+            type: { enum: ["b"], type: "string" },
+          },
+          required: ["type"],
+          type: "object",
+        },
+        NullableMember: {
+          properties: {
+            type: { enum: ["a"], type: "string" },
+          },
+          required: ["type"],
+          type: ["object", "null"],
+        },
+      },
+    });
+
+    expect(result.code).toBe("z.union([NullableMember, NonNullableMember])");
+  });
+
+  it("should keep inline nullable discriminated union members with descriptions discriminable", () => {
+    const schema: SchemaObject = {
+      discriminator: {
+        propertyName: "type",
+      },
+      oneOf: [
+        {
+          description: "A circle shape",
+          properties: {
+            radius: { type: "number" },
+            type: { enum: ["circle"], type: "string" },
+          },
+          required: ["type", "radius"],
+          type: ["object", "null"],
+        },
+        {
+          description: "A square shape",
+          properties: {
+            size: { type: "number" },
+            type: { enum: ["square"], type: "string" },
+          },
+          required: ["type", "size"],
+          type: ["object", "null"],
+        },
+      ],
+    };
+    const result = zodSchemaToCode(schema);
+
+    expect(result.code).toContain('z.discriminatedUnion("type"');
+    expect(result.code).toContain(".nullable()");
+    expect(result.code).toContain('.describe("A circle shape")');
+    expect(result.code).toContain('.describe("A square shape")');
+    expect(result.code).not.toContain("z.union([");
+  });
+
+  it("should fall back to z.union for nullable $ref discriminated union members with defaults", () => {
+    const schema: SchemaObject = {
+      discriminator: {
+        propertyName: "kind",
+      },
+      oneOf: [
+        { $ref: "#/components/schemas/Dog" },
+        { $ref: "#/components/schemas/Cat" },
+      ],
+    };
+    const result = zodSchemaToCode(schema, {
+      resolvedSchemas: {
+        Cat: {
+          default: { kind: "cat" },
+          properties: {
+            kind: { enum: ["cat"], type: "string" },
+          },
+          required: ["kind"],
+          type: ["object", "null"],
+        },
+        Dog: {
+          default: { kind: "dog" },
+          properties: {
+            kind: { enum: ["dog"], type: "string" },
+          },
+          required: ["kind"],
+          type: ["object", "null"],
+        },
+      },
+    });
+
+    expect(result.code).toBe("z.union([Dog, Cat])");
+  });
+
   it("should use superRefine for oneOf when no discriminator is present", () => {
     const schema: SchemaObject = {
       oneOf: [{ type: "string" }, { type: "number" }],


### PR DESCRIPTION
## Problem
In Zod v4, `z.discriminatedUnion()` requires all members to implement `$ZodTypeDiscriminable`. When member schemas are wrapped with `.nullable()`, they break this contract, causing TS2322 errors.

## Fix
Detects nullable members in discriminated unions and either:
- **All nullable**: unwraps members and hoists `.nullable()` to outer union
- **Some nullable**: falls back to `z.union()`

## Tests
4 new test cases for nullable $ref (3.0 + 3.1), mixed, and inline members.