### PR TITLE
fix(client-generator): do not reference RequestMap for bodyless operations

### DIFF
--- a/packages/client-generator/src/operation-function-generator.ts
+++ b/packages/client-generator/src/operation-function-generator.ts
@@ -65,19 +65,22 @@ export function extractOperationMetadata(
     pathLevelParameters,
     doc,
   );
-  const hasBody = !!operation.requestBody;
+  const hasRequestBody = !!operation.requestBody;
   const operationSecurityHeaders = getOperationSecuritySchemes(operation, doc);
 
   /* Body & content type meta */
   /* Collect body related type info + request/response content-type maps (if any) */
   const bodyInfo = collectBodyAndContentTypes(
-    hasBody,
+    hasRequestBody,
     operation,
     functionName,
     importManager,
     operationName,
     doc,
   );
+
+  /* Refine: body is only present when request body has actual content types */
+  const hasBody = hasRequestBody && bodyInfo.requestContentTypes.length > 0;
 
   /* Build parameter shapes */
   /* Build the "first parameter" surface: destructured runtime parameter object + its TS interface */

--- a/packages/client-generator/src/templates/operation-templates.ts
+++ b/packages/client-generator/src/templates/operation-templates.ts
@@ -294,9 +294,11 @@ function buildAdditionalProperties(config: {
   /* Add body if present */
   if (config.hasBody) {
     const bodyOptional = config.isBodyOptional ? "?" : "";
-    let bodyType = config.bodyTypeName || "any";
-    if (config.requestMapTypeName) {
+    let bodyType: string;
+    if (config.hasRequestMap && config.requestMapTypeName) {
       bodyType = `import('zod').infer<${config.requestMapTypeName}[TRequestContentType]>`;
+    } else {
+      bodyType = config.bodyTypeName || "unknown";
     }
     props.push(`body${bodyOptional}: ${bodyType}`);
   }


### PR DESCRIPTION
## Problem

Operations without a request body (like DELETE) that have `requestBody` defined but with no content types still generated code referencing `TRequestContentType` and `RequestMap`, causing 217 TS2304 and 5 TS2552 errors in generated client files.

## Fix

**Level A** (`operation-function-generator.ts`): Made `hasBody` more restrictive — only `true` when request body has actual content types (`requestContentTypes.length > 0`).

**Level B** (`operation-templates.ts`): Added `config.hasRequestMap` guard in `buildAdditionalProperties` so the body type falls back to `bodyTypeName || "unknown"` instead of referencing `RequestMap[TRequestContentType]` when the map is empty.

## Testing

All 310 client-generator tests pass. Lint and format clean.