### PR TITLE
fix: preserve colliding security headers

### DIFF
--- a/packages/client-generator/src/templates/security-templates.ts
+++ b/packages/client-generator/src/templates/security-templates.ts
@@ -4,6 +4,8 @@ import { toValidVariableName } from "../utils.js";
 
 /* Security code generation templates and rendering functions */
 
+const renderStringLiteral = (value: string): string => JSON.stringify(value);
+
 /**
  * Renders auth header validation code
  */
@@ -12,7 +14,7 @@ export function renderAuthHeaderValidation(authHeaders: string[]): string {
 
   const validationChecks = authHeaders.map((headerName) => {
     const varName = toValidVariableName(headerName);
-    return `if (!${varName}) throw new Error('Missing required auth header: ${headerName}');`;
+    return `if (!${varName}) throw new Error(${renderStringLiteral(`Missing required auth header: ${headerName}`)});`;
   });
 
   return validationChecks.join("\n  ");
@@ -56,18 +58,22 @@ export function renderSecurityHeaderHandling(
   /* Helper to generate security header handling code */
   const generateHeaderCode = (header: SecurityHeader): string => {
     const varName = getUniqueSecurityVariableName(header.headerName);
+    const headerNameLiteral = renderStringLiteral(header.headerName);
+    const missingHeaderMessageLiteral = renderStringLiteral(
+      `Missing required security header: ${header.headerName}`,
+    );
     const source = header.isOverride ? "params.headers" : "config.headers";
     const useOptionalChaining = !(header.isOverride && header.isRequired);
     const optionalChain = useOptionalChaining ? "?." : "";
-    const accessExpression = `${source}${optionalChain}['${header.headerName}']`;
+    const accessExpression = `${source}${optionalChain}[${headerNameLiteral}]`;
 
     if (header.isRequired) {
       return `const ${varName} = ${accessExpression};
-    if (${varName} === undefined) throw new Error('Missing required security header: ${header.headerName}');
-    finalHeaders['${header.headerName}'] = ${varName};`;
+    if (${varName} === undefined) throw new Error(${missingHeaderMessageLiteral});
+    finalHeaders[${headerNameLiteral}] = ${varName};`;
     } else {
       return `const ${varName} = ${accessExpression};
-    if (${varName} !== undefined) finalHeaders['${header.headerName}'] = ${varName};`;
+    if (${varName} !== undefined) finalHeaders[${headerNameLiteral}] = ${varName};`;
     }
   };
 
@@ -87,7 +93,7 @@ export function renderSecurityParameterExtraction(
     .filter((h) => !h.isOverride) // Only global security
     .map((header) => {
       const varName = toValidVariableName(header.headerName);
-      return `const ${varName} = config.headers?.['${header.headerName}'];`;
+      return `const ${varName} = config.headers?.[${renderStringLiteral(header.headerName)}];`;
     });
 
   return extractions.join("\n  ");

--- a/packages/client-generator/src/templates/security-templates.ts
+++ b/packages/client-generator/src/templates/security-templates.ts
@@ -28,32 +28,46 @@ export function renderSecurityHeaderHandling(
 ): string {
   if (operationSecurityHeaders.length === 0) return "";
 
-  /* Deduplicate by computed variable name to prevent TS2451 from colliding names */
+  /* Deduplicate exact duplicate headers while preserving distinct header names. */
   const uniqueHeaders = new Map<string, SecurityHeader>();
   for (const header of operationSecurityHeaders) {
-    const varName = toValidVariableName(header.headerName);
-    const existing = uniqueHeaders.get(varName);
+    const existing = uniqueHeaders.get(header.headerName);
     if (!existing || (header.isRequired && !existing.isRequired)) {
-      uniqueHeaders.set(varName, header);
+      uniqueHeaders.set(header.headerName, header);
     }
   }
   const deduplicatedHeaders = [...uniqueHeaders.values()];
+  const usedVariableNames = new Set<string>();
+
+  const getUniqueSecurityVariableName = (headerName: string): string => {
+    const baseName = `_sec_${toValidVariableName(headerName)}`;
+    let candidateName = baseName;
+    let suffix = 2;
+
+    while (usedVariableNames.has(candidateName)) {
+      candidateName = `${baseName}_${suffix}`;
+      suffix++;
+    }
+
+    usedVariableNames.add(candidateName);
+    return candidateName;
+  };
 
   /* Helper to generate security header handling code */
   const generateHeaderCode = (header: SecurityHeader): string => {
-    const varName = toValidVariableName(header.headerName);
+    const varName = getUniqueSecurityVariableName(header.headerName);
     const source = header.isOverride ? "params.headers" : "config.headers";
     const useOptionalChaining = !(header.isOverride && header.isRequired);
     const optionalChain = useOptionalChaining ? "?." : "";
     const accessExpression = `${source}${optionalChain}['${header.headerName}']`;
 
     if (header.isRequired) {
-      return `const _sec_${varName} = ${accessExpression};
-    if (_sec_${varName} === undefined) throw new Error('Missing required security header: ${header.headerName}');
-    finalHeaders['${header.headerName}'] = _sec_${varName};`;
+      return `const ${varName} = ${accessExpression};
+    if (${varName} === undefined) throw new Error('Missing required security header: ${header.headerName}');
+    finalHeaders['${header.headerName}'] = ${varName};`;
     } else {
-      return `const _sec_${varName} = ${accessExpression};
-    if (_sec_${varName} !== undefined) finalHeaders['${header.headerName}'] = _sec_${varName};`;
+      return `const ${varName} = ${accessExpression};
+    if (${varName} !== undefined) finalHeaders['${header.headerName}'] = ${varName};`;
     }
   };
 

--- a/packages/client-generator/tests/security-templates.test.ts
+++ b/packages/client-generator/tests/security-templates.test.ts
@@ -21,7 +21,7 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XAPIKey = params.headers['X-API-Key'];\n    if (_sec_XAPIKey === undefined) throw new Error('Missing required security header: X-API-Key');\n    finalHeaders['X-API-Key'] = _sec_XAPIKey;",
+        'const _sec_XAPIKey = params.headers["X-API-Key"];\n    if (_sec_XAPIKey === undefined) throw new Error("Missing required security header: X-API-Key");\n    finalHeaders["X-API-Key"] = _sec_XAPIKey;',
       );
     });
 
@@ -37,7 +37,7 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XAPIKey = params.headers?.['X-API-Key'];\n    if (_sec_XAPIKey !== undefined) finalHeaders['X-API-Key'] = _sec_XAPIKey;",
+        'const _sec_XAPIKey = params.headers?.["X-API-Key"];\n    if (_sec_XAPIKey !== undefined) finalHeaders["X-API-Key"] = _sec_XAPIKey;',
       );
     });
 
@@ -59,8 +59,8 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XAPIKey = params.headers['X-API-Key'];\n    if (_sec_XAPIKey === undefined) throw new Error('Missing required security header: X-API-Key');\n    finalHeaders['X-API-Key'] = _sec_XAPIKey;\n" +
-          "    const _sec_Authorization = params.headers?.['Authorization'];\n    if (_sec_Authorization !== undefined) finalHeaders['Authorization'] = _sec_Authorization;",
+        'const _sec_XAPIKey = params.headers["X-API-Key"];\n    if (_sec_XAPIKey === undefined) throw new Error("Missing required security header: X-API-Key");\n    finalHeaders["X-API-Key"] = _sec_XAPIKey;\n' +
+          '    const _sec_Authorization = params.headers?.["Authorization"];\n    if (_sec_Authorization !== undefined) finalHeaders["Authorization"] = _sec_Authorization;',
       );
     });
 
@@ -76,7 +76,7 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XCustomAuthToken = params.headers['X-Custom-Auth-Token'];\n    if (_sec_XCustomAuthToken === undefined) throw new Error('Missing required security header: X-Custom-Auth-Token');\n    finalHeaders['X-Custom-Auth-Token'] = _sec_XCustomAuthToken;",
+        'const _sec_XCustomAuthToken = params.headers["X-Custom-Auth-Token"];\n    if (_sec_XCustomAuthToken === undefined) throw new Error("Missing required security header: X-Custom-Auth-Token");\n    finalHeaders["X-Custom-Auth-Token"] = _sec_XCustomAuthToken;',
       );
     });
 
@@ -97,7 +97,7 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XSpecialHeader = params.headers['X-Special@Header'];\n    if (_sec_XSpecialHeader === undefined) throw new Error('Missing required security header: X-Special@Header');\n    finalHeaders['X-Special@Header'] = _sec_XSpecialHeader;",
+        'const _sec_XSpecialHeader = params.headers["X-Special@Header"];\n    if (_sec_XSpecialHeader === undefined) throw new Error("Missing required security header: X-Special@Header");\n    finalHeaders["X-Special@Header"] = _sec_XSpecialHeader;',
       );
     });
 
@@ -154,19 +154,19 @@ describe("client-generator security templates", () => {
       const result = renderSecurityHeaderHandling(headers);
 
       expect(result).toContain(
-        "const _sec_XAuthEmail = params.headers['X-Auth-Email'];",
+        'const _sec_XAuthEmail = params.headers["X-Auth-Email"];',
       );
       expect(result).toContain(
         "if (_sec_XAuthEmail === undefined) throw new Error",
       );
       expect(result).toContain(
-        "finalHeaders['X-Auth-Email'] = _sec_XAuthEmail;",
+        'finalHeaders["X-Auth-Email"] = _sec_XAuthEmail;',
       );
       expect(result).toContain(
-        "const _sec_XAuthEmail_2 = params.headers?.['X_Auth_Email'];",
+        'const _sec_XAuthEmail_2 = params.headers?.["X_Auth_Email"];',
       );
       expect(result).toContain(
-        "if (_sec_XAuthEmail_2 !== undefined) finalHeaders['X_Auth_Email'] = _sec_XAuthEmail_2;",
+        'if (_sec_XAuthEmail_2 !== undefined) finalHeaders["X_Auth_Email"] = _sec_XAuthEmail_2;',
       );
     });
 
@@ -229,6 +229,29 @@ describe("client-generator security templates", () => {
       ]);
       expect(new Set(variableNames).size).toBe(variableNames.length);
     });
+
+    it("should escape generated string literals for header names", () => {
+      const headers: SecurityHeader[] = [
+        {
+          headerName: 'X-"Quoted"\\Header\nName',
+          isOverride: true,
+          isRequired: true,
+          schemeName: "quoted",
+        },
+      ];
+
+      const result = renderSecurityHeaderHandling(headers);
+
+      expect(result).toContain(
+        'params.headers["X-\\"Quoted\\"\\\\Header\\nName"]',
+      );
+      expect(result).toContain(
+        'throw new Error("Missing required security header: X-\\"Quoted\\"\\\\Header\\nName")',
+      );
+      expect(result).toContain(
+        'finalHeaders["X-\\"Quoted\\"\\\\Header\\nName"] = _sec_XQuotedHeaderName;',
+      );
+    });
   });
 
   describe("renderAuthHeaderValidation", () => {
@@ -237,7 +260,7 @@ describe("client-generator security templates", () => {
 
       const result = renderAuthHeaderValidation(authHeaders);
       expect(result).toBe(
-        "if (!XAPIKey) throw new Error('Missing required auth header: X-API-Key');",
+        'if (!XAPIKey) throw new Error("Missing required auth header: X-API-Key");',
       );
     });
 
@@ -246,8 +269,8 @@ describe("client-generator security templates", () => {
 
       const result = renderAuthHeaderValidation(authHeaders);
       expect(result).toBe(
-        "if (!XAPIKey) throw new Error('Missing required auth header: X-API-Key');\n" +
-          "  if (!Authorization) throw new Error('Missing required auth header: Authorization');",
+        'if (!XAPIKey) throw new Error("Missing required auth header: X-API-Key");\n' +
+          '  if (!Authorization) throw new Error("Missing required auth header: Authorization");',
       );
     });
 
@@ -256,7 +279,7 @@ describe("client-generator security templates", () => {
 
       const result = renderAuthHeaderValidation(authHeaders);
       expect(result).toBe(
-        "if (!XCustomAuthToken) throw new Error('Missing required auth header: X-Custom-Auth-Token');",
+        'if (!XCustomAuthToken) throw new Error("Missing required auth header: X-Custom-Auth-Token");',
       );
     });
 
@@ -278,7 +301,7 @@ describe("client-generator security templates", () => {
       ];
 
       const result = renderSecurityParameterExtraction(headers);
-      expect(result).toBe("const XAPIKey = config.headers?.['X-API-Key'];");
+      expect(result).toBe('const XAPIKey = config.headers?.["X-API-Key"];');
     });
 
     it("should render extraction for multiple headers", () => {
@@ -299,8 +322,8 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityParameterExtraction(headers);
       expect(result).toBe(
-        "const XAPIKey = config.headers?.['X-API-Key'];\n" +
-          "  const Authorization = config.headers?.['Authorization'];",
+        'const XAPIKey = config.headers?.["X-API-Key"];\n' +
+          '  const Authorization = config.headers?.["Authorization"];',
       );
     });
 
@@ -316,7 +339,7 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityParameterExtraction(headers);
       expect(result).toBe(
-        "const XCustomAuthToken = config.headers?.['X-Custom-Auth-Token'];",
+        'const XCustomAuthToken = config.headers?.["X-Custom-Auth-Token"];',
       );
     });
 
@@ -337,7 +360,24 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityParameterExtraction(headers);
       expect(result).toBe(
-        "const XSpecialHeader = config.headers?.['X-Special@Header'];",
+        'const XSpecialHeader = config.headers?.["X-Special@Header"];',
+      );
+    });
+
+    it("should escape header names during extraction", () => {
+      const headers: SecurityHeader[] = [
+        {
+          headerName: 'X-"Quoted"\\Header\nName',
+          isOverride: false,
+          isRequired: true,
+          schemeName: "quoted",
+        },
+      ];
+
+      const result = renderSecurityParameterExtraction(headers);
+
+      expect(result).toBe(
+        'const XQuotedHeaderName = config.headers?.["X-\\"Quoted\\"\\\\Header\\nName"];',
       );
     });
   });

--- a/packages/client-generator/tests/security-templates.test.ts
+++ b/packages/client-generator/tests/security-templates.test.ts
@@ -135,7 +135,7 @@ describe("client-generator security templates", () => {
       );
     });
 
-    it("should deduplicate headers whose names collide after normalization", () => {
+    it("should preserve distinct headers whose names collide after normalization", () => {
       const headers: SecurityHeader[] = [
         {
           headerName: "X-Auth-Email",
@@ -153,13 +153,20 @@ describe("client-generator security templates", () => {
 
       const result = renderSecurityHeaderHandling(headers);
 
-      // Both header names normalize to XAuthEmail – only one const should be emitted
-      const emailOccurrences = result.split("const _sec_XAuthEmail").length - 1;
-      expect(emailOccurrences).toBe(1);
-
-      // The required variant should win
+      expect(result).toContain(
+        "const _sec_XAuthEmail = params.headers['X-Auth-Email'];",
+      );
       expect(result).toContain(
         "if (_sec_XAuthEmail === undefined) throw new Error",
+      );
+      expect(result).toContain(
+        "finalHeaders['X-Auth-Email'] = _sec_XAuthEmail;",
+      );
+      expect(result).toContain(
+        "const _sec_XAuthEmail_2 = params.headers?.['X_Auth_Email'];",
+      );
+      expect(result).toContain(
+        "if (_sec_XAuthEmail_2 !== undefined) finalHeaders['X_Auth_Email'] = _sec_XAuthEmail_2;",
       );
     });
 
@@ -186,6 +193,41 @@ describe("client-generator security templates", () => {
       expect(result).toContain(
         "if (_sec_XAuthEmail !== undefined) finalHeaders",
       );
+    });
+
+    it("should generate unique local variable names for colliding header names", () => {
+      const headers: SecurityHeader[] = [
+        {
+          headerName: "X-Auth-Email",
+          isOverride: true,
+          isRequired: true,
+          schemeName: "api_email",
+        },
+        {
+          headerName: "X_Auth_Email",
+          isOverride: true,
+          isRequired: false,
+          schemeName: "api_email_alt",
+        },
+        {
+          headerName: "X Auth Email",
+          isOverride: true,
+          isRequired: false,
+          schemeName: "api_email_space",
+        },
+      ];
+
+      const result = renderSecurityHeaderHandling(headers);
+      const variableNames = [...result.matchAll(/const (\S+) =/g)].map(
+        ([, variableName]) => variableName,
+      );
+
+      expect(variableNames).toEqual([
+        "_sec_XAuthEmail",
+        "_sec_XAuthEmail_2",
+        "_sec_XAuthEmail_3",
+      ]);
+      expect(new Set(variableNames).size).toBe(variableNames.length);
     });
   });
 

--- a/packages/client-generator/tests/security.test.ts
+++ b/packages/client-generator/tests/security.test.ts
@@ -358,7 +358,7 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XAPIKey = params.headers['X-API-Key'];\n    if (_sec_XAPIKey === undefined) throw new Error('Missing required security header: X-API-Key');\n    finalHeaders['X-API-Key'] = _sec_XAPIKey;",
+        'const _sec_XAPIKey = params.headers["X-API-Key"];\n    if (_sec_XAPIKey === undefined) throw new Error("Missing required security header: X-API-Key");\n    finalHeaders["X-API-Key"] = _sec_XAPIKey;',
       );
     });
 
@@ -374,7 +374,7 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XAPIKey = params.headers?.['X-API-Key'];\n    if (_sec_XAPIKey !== undefined) finalHeaders['X-API-Key'] = _sec_XAPIKey;",
+        'const _sec_XAPIKey = params.headers?.["X-API-Key"];\n    if (_sec_XAPIKey !== undefined) finalHeaders["X-API-Key"] = _sec_XAPIKey;',
       );
     });
 
@@ -396,8 +396,8 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XAPIKey = params.headers['X-API-Key'];\n    if (_sec_XAPIKey === undefined) throw new Error('Missing required security header: X-API-Key');\n    finalHeaders['X-API-Key'] = _sec_XAPIKey;\n" +
-          "    const _sec_Authorization = params.headers?.['Authorization'];\n    if (_sec_Authorization !== undefined) finalHeaders['Authorization'] = _sec_Authorization;",
+        'const _sec_XAPIKey = params.headers["X-API-Key"];\n    if (_sec_XAPIKey === undefined) throw new Error("Missing required security header: X-API-Key");\n    finalHeaders["X-API-Key"] = _sec_XAPIKey;\n' +
+          '    const _sec_Authorization = params.headers?.["Authorization"];\n    if (_sec_Authorization !== undefined) finalHeaders["Authorization"] = _sec_Authorization;',
       );
     });
 
@@ -413,7 +413,7 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XCustomAuthToken = params.headers['X-Custom-Auth-Token'];\n    if (_sec_XCustomAuthToken === undefined) throw new Error('Missing required security header: X-Custom-Auth-Token');\n    finalHeaders['X-Custom-Auth-Token'] = _sec_XCustomAuthToken;",
+        'const _sec_XCustomAuthToken = params.headers["X-Custom-Auth-Token"];\n    if (_sec_XCustomAuthToken === undefined) throw new Error("Missing required security header: X-Custom-Auth-Token");\n    finalHeaders["X-Custom-Auth-Token"] = _sec_XCustomAuthToken;',
       );
     });
 
@@ -434,7 +434,7 @@ describe("client-generator security", () => {
 
       const result = renderSecurityHeaderHandling(headers);
       expect(result).toBe(
-        "const _sec_XSpecialHeader = params.headers['X-Special@Header'];\n    if (_sec_XSpecialHeader === undefined) throw new Error('Missing required security header: X-Special@Header');\n    finalHeaders['X-Special@Header'] = _sec_XSpecialHeader;",
+        'const _sec_XSpecialHeader = params.headers["X-Special@Header"];\n    if (_sec_XSpecialHeader === undefined) throw new Error("Missing required security header: X-Special@Header");\n    finalHeaders["X-Special@Header"] = _sec_XSpecialHeader;',
       );
     });
   });


### PR DESCRIPTION
## Summary
- follow up merged #122 by only deduplicating exact security header names
- keep distinct headers like `X-Auth-Email` and `X_Auth_Email` in generated output
- generate unique `_sec_*` locals to avoid TS2451 redeclarations and cover the regression with unit tests

## Validation
- pnpm --filter @apical-ts/core-utils build
- pnpm --filter @apical-ts/client-generator build
- pnpm --filter @apical-ts/client-generator test
- pnpm --filter @apical-ts/client-generator typecheck
- pnpm lint
- pnpm format