### PR TITLE
Add normalizeRequestBody function and update request body handling

### DIFF
--- a/.changeset/early-baths-laugh.md
+++ b/.changeset/early-baths-laugh.md
@@ -1,0 +1,7 @@
+---
+"@apical-ts/client-generator": patch
+"@apical-ts/server-generator": patch
+"@apical-ts/core-utils": patch
+---
+
+Make OpenAPI spec parsing more sound

--- a/packages/client-generator/src/templates/config/response-parsing.template.ts
+++ b/packages/client-generator/src/templates/config/response-parsing.template.ts
@@ -3,7 +3,21 @@
 /* Render RequestBody alias used across generated clients */
 export function renderRequestBodyType(): string {
   return `/* Common request body union for generated clients */
-export type RequestBody = string | Blob | ArrayBuffer | FormData | undefined;`;
+export type RequestBody = string | Blob | ArrayBuffer | FormData | undefined;
+
+export function normalizeRequestBody(body: unknown): RequestBody {
+  if (body === undefined || typeof body === "string") {
+    return body;
+  }
+  if (
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    body instanceof FormData
+  ) {
+    return body;
+  }
+  return JSON.stringify(body);
+}`;
 }
 
 /*

--- a/packages/client-generator/src/templates/request-body-templates.ts
+++ b/packages/client-generator/src/templates/request-body-templates.ts
@@ -16,7 +16,7 @@ export const DEFAULT_CONTENT_TYPE_HANDLERS: ContentTypeHandlerConfig = {
     requiresFormData: false,
   },
   "application/octet-stream": {
-    bodyProcessing: "params.body",
+    bodyProcessing: "normalizeRequestBody(params.body)",
     contentTypeHeader: '"Content-Type": "application/octet-stream"',
     requiresFormData: false,
   },

--- a/packages/client-generator/tests/request-body-templates.test.ts
+++ b/packages/client-generator/tests/request-body-templates.test.ts
@@ -299,5 +299,15 @@ describe("Request Body Template Functions", () => {
       expect(result).toContain("FormData");
       expect(result).toContain("contentTypeHeader = {};");
     });
+
+    it("should normalize octet-stream bodies to RequestBody-compatible values", () => {
+      const result = renderContentTypeSwitch([
+        "application/octet-stream",
+        "multipart/form-data",
+      ]);
+
+      expect(result).toContain('case "application/octet-stream":');
+      expect(result).toContain("normalizeRequestBody(params.body)");
+    });
   });
 });

--- a/packages/core-utils/src/core-generator/file-writer.ts
+++ b/packages/core-utils/src/core-generator/file-writer.ts
@@ -109,6 +109,10 @@ function getConfigImports(functionCode?: string): {
     configValueImports.push("buildFormData");
   }
 
+  if (functionCode?.includes("normalizeRequestBody(")) {
+    configValueImports.push("normalizeRequestBody");
+  }
+
   if (functionCode?.includes("serializeQueryParam(")) {
     configValueImports.push("serializeQueryParam");
   }

--- a/packages/core-utils/src/schema-generator/recursive-type-renderer.ts
+++ b/packages/core-utils/src/schema-generator/recursive-type-renderer.ts
@@ -4,6 +4,7 @@ import { isReferenceObject } from "openapi3-ts/oas31";
 
 import { findReferencesInSchema } from "./recursive-handlers.js";
 import { getSchemaNameFromReference } from "./schema-references.js";
+import { analyzeTypeArray } from "./utils.js";
 
 export function renderRecursiveTypeAlias(
   schema: SchemaObject,
@@ -36,11 +37,39 @@ function renderSchemaType(schema: ReferenceObject | SchemaObject): string {
     return JSON.stringify(schema.const);
   }
 
+  if (Array.isArray(schema.type)) {
+    return renderMultiTypeSchema(schema);
+  }
+
   const compositionType = renderCompositionType(schema);
   const baseType = compositionType ?? renderSimpleSchemaType(schema);
-  const isNullable = "nullable" in schema && schema.nullable === true;
+  const isNullable = hasNullableFlag(schema);
 
   return isNullable ? `${baseType} | null` : baseType;
+}
+
+function renderMultiTypeSchema(schema: SchemaObject): string {
+  const schemaTypes = Array.isArray(schema.type) ? schema.type : [];
+  const { isNullable, nonNullTypes } = analyzeTypeArray(schemaTypes);
+  const baseTypes = [
+    ...new Set(
+      nonNullTypes.map((type) =>
+        renderSchemaTypeForSpecificType(
+          schema,
+          type as Exclude<SchemaObject["type"], readonly string[] | undefined>,
+        ),
+      ),
+    ),
+  ];
+
+  if (baseTypes.length === 0) {
+    return "null";
+  }
+
+  const baseType = baseTypes.join(" | ");
+  return isNullable || hasNullableFlag(schema)
+    ? `${baseType} | null`
+    : baseType;
 }
 
 function renderCompositionType(schema: SchemaObject): string | undefined {
@@ -81,6 +110,20 @@ function renderSimpleSchemaType(schema: SchemaObject): string {
   }
 
   return "unknown";
+}
+
+function renderSchemaTypeForSpecificType(
+  schema: SchemaObject,
+  type: Exclude<SchemaObject["type"], readonly string[] | undefined>,
+): string {
+  switch (type) {
+    case "array":
+      return `Array<${renderSchemaType(schema.items ?? {})}>`;
+    case "object":
+      return renderObjectSchemaType(schema);
+    default:
+      return renderPrimitiveType(type);
+  }
 }
 
 function renderObjectSchemaType(schema: SchemaObject): string {
@@ -134,4 +177,8 @@ function renderPrimitiveType(
     default:
       return "unknown";
   }
+}
+
+function hasNullableFlag(schema: SchemaObject): boolean {
+  return "nullable" in schema && schema.nullable === true;
 }

--- a/packages/core-utils/src/shared/parameter-schemas.ts
+++ b/packages/core-utils/src/shared/parameter-schemas.ts
@@ -87,6 +87,14 @@ export function generateParameterSchemas(
   const hasHeaders =
     parameterGroups.headerParams.length > 0 || securityHeaders.length > 0;
 
+  const normalizeParameterName = (
+    originalName: string,
+    parameterLocation: ParameterObject["in"],
+  ): string =>
+    lowercaseHeaderKeys && parameterLocation === "header"
+      ? originalName.toLowerCase()
+      : originalName;
+
   /* Helper to build property entry using zodSchemaToCode; fallback to z.string()
      For servers, applies parameter-specific transformations:
        - Preserve original OpenAPI key verbatim (quoted)
@@ -95,10 +103,7 @@ export function generateParameterSchemas(
   const buildProp = (originalName: string, param: ParameterObject): string => {
     const schema = param.schema as ReferenceObject | SchemaObject | undefined;
     const isRequired = param.required === true;
-    const name =
-      lowercaseHeaderKeys && param.in === "header"
-        ? originalName.toLowerCase()
-        : originalName;
+    const name = normalizeParameterName(originalName, param.in);
 
     let zodCode: string;
     if (schema) {
@@ -178,25 +183,30 @@ export function generateParameterSchemas(
   const hasCombinedHeaders = hasHeaders || hasSecurityOverrides;
 
   if (hasCombinedHeaders) {
-    const headerProps = parameterGroups.headerParams
-      .map((p) => buildProp(p.name, p))
-      .join(", ");
+    const headerProps = new Map<string, string>();
+
+    for (const headerParam of parameterGroups.headerParams) {
+      const normalizedName = normalizeParameterName(headerParam.name, "header");
+      headerProps.set(normalizedName, buildProp(headerParam.name, headerParam));
+    }
 
     /* Add security override headers to the schema (always required) */
-    const securityHeaderProps = securityOverrideHeaders
-      .map((sh) => {
-        const name = lowercaseHeaderKeys
-          ? sh.headerName.toLowerCase()
-          : sh.headerName;
-        // Security override headers are always required
-        const zodCode = "z.string()";
-        return `${JSON.stringify(name)}: ${zodCode}`;
-      })
-      .join(", ");
+    for (const securityHeader of securityOverrideHeaders) {
+      const normalizedName = normalizeParameterName(
+        securityHeader.headerName,
+        "header",
+      );
+      if (headerProps.has(normalizedName)) {
+        continue;
+      }
 
-    const allHeaderProps = [headerProps, securityHeaderProps]
-      .filter(Boolean)
-      .join(", ");
+      headerProps.set(
+        normalizedName,
+        `${JSON.stringify(normalizedName)}: z.string()`,
+      );
+    }
+
+    const allHeaderProps = [...headerProps.values()].join(", ");
 
     schemas.push(
       `const ${headersSchemaName} = ${headerObjectMethod}({ ${allHeaderProps} });`,

--- a/packages/core-utils/src/shared/security-utils.ts
+++ b/packages/core-utils/src/shared/security-utils.ts
@@ -87,6 +87,28 @@ export function analyzeSecurityScheme(
   };
 }
 
+function dedupeSecurityHeaders(headers: SecurityHeader[]): SecurityHeader[] {
+  const uniqueHeaders = new Map<string, SecurityHeader>();
+
+  for (const header of headers) {
+    const key = header.headerName.toLowerCase();
+    const existing = uniqueHeaders.get(key);
+
+    if (!existing) {
+      uniqueHeaders.set(key, header);
+      continue;
+    }
+
+    uniqueHeaders.set(key, {
+      ...existing,
+      isOverride: existing.isOverride || header.isOverride,
+      isRequired: existing.isRequired || header.isRequired,
+    });
+  }
+
+  return [...uniqueHeaders.values()];
+}
+
 /**
  * Determines auth header requirements for an operation
  */
@@ -144,7 +166,7 @@ export function getOperationSecuritySchemes(
       schemeName: s.schemeName,
     }));
 
-  return globalHeaders;
+  return dedupeSecurityHeaders(globalHeaders);
 }
 
 /**
@@ -196,6 +218,6 @@ export function processOperationSecurity(
   return {
     analyzedSchemes,
     hasOverride,
-    operationHeaders,
+    operationHeaders: dedupeSecurityHeaders(operationHeaders),
   };
 }

--- a/packages/core-utils/tests/schema-generator/file-generators.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators.test.ts
@@ -390,6 +390,50 @@ describe("schema-generator file-generators", () => {
         "export type IndirectNode = z.infer<typeof IndirectNode>;",
       );
     });
+
+    it("should preserve nullability and deduplicate primitive branches for recursive multi-type schemas", async () => {
+      const schema: SchemaObject = {
+        anyOf: [
+          {
+            type: ["object", "null"],
+            additionalProperties: true,
+          },
+          {
+            type: ["number", "integer"],
+          },
+          {
+            type: "array",
+            items: { $ref: "#/components/schemas/WorkersKvAny" },
+          },
+        ],
+      };
+
+      vi.mocked(zodSchemaToCode).mockReturnValue(
+        mockSchemaResult({
+          code: "z.union([z.object({}).catchall(z.unknown()).nullable(), z.number(), z.array(z.lazy(() => WorkersKvAny))])",
+          imports: new Set(),
+        }),
+      );
+
+      const recursiveContext = createRecursiveContext();
+      recursiveContext.recursiveSchemas.add("WorkersKvAny");
+
+      const result = await generateSchemaFile(
+        "WorkersKvAny",
+        schema,
+        undefined,
+        {
+          recursiveContext,
+        },
+      );
+
+      expect(result.content).toContain("export type WorkersKvAny =");
+      expect(result.content).toContain("| null");
+      expect(result.content).not.toContain("number | number");
+      expect(result.content).toContain(
+        "export const WorkersKvAny: z.ZodType<WorkersKvAny> =",
+      );
+    });
   });
 
   describe("circular reference type annotations", () => {

--- a/packages/core-utils/tests/shared/parameter-schemas.test.ts
+++ b/packages/core-utils/tests/shared/parameter-schemas.test.ts
@@ -74,4 +74,58 @@ describe("generateParameterSchemas", () => {
       '.describe("Schema desc").describe("Param desc")',
     );
   });
+
+  it("should deduplicate security headers and preserve explicit header schemas", () => {
+    const parameterGroups = {
+      queryParams: [],
+      headerParams: [
+        {
+          in: "header",
+          name: "X-Auth-Email",
+          required: true,
+          schema: { type: "string" },
+          description: "Explicit email header",
+        },
+      ],
+      pathParams: [],
+      cookieParams: [],
+    };
+
+    const result = generateParameterSchemas(
+      "getUsers",
+      parameterGroups as any,
+      {
+        securityHeaders: [
+          {
+            headerName: "X-Auth-Email",
+            isOverride: true,
+            isRequired: true,
+            schemeName: "emailAuth",
+          },
+          {
+            headerName: "X-Auth-Email",
+            isOverride: true,
+            isRequired: true,
+            schemeName: "emailAuthAlt",
+          },
+          {
+            headerName: "X-Auth-Key",
+            isOverride: true,
+            isRequired: true,
+            schemeName: "keyAuth",
+          },
+          {
+            headerName: "X-Auth-Key",
+            isOverride: true,
+            isRequired: true,
+            schemeName: "keyAuthAlt",
+          },
+        ],
+      },
+    );
+
+    expect((result.schemaCode.match(/"X-Auth-Email":/g) ?? []).length).toBe(1);
+    expect((result.schemaCode.match(/"X-Auth-Key":/g) ?? []).length).toBe(1);
+    expect(result.schemaCode).toContain('.describe("Explicit email header")');
+  });
 });

--- a/packages/server-generator/src/operation-wrapper-generator.ts
+++ b/packages/server-generator/src/operation-wrapper-generator.ts
@@ -6,8 +6,11 @@ import type {
 } from "openapi3-ts/oas31";
 
 import { sanitizeIdentifier } from "@apical-ts/core-utils";
-import { extractParameterGroups } from "@apical-ts/core-utils/shared";
-import { getOperationSecuritySchemes } from "@apical-ts/core-utils/shared";
+import {
+  extractParameterGroups,
+  generateContentTypeMaps,
+  getOperationSecuritySchemes,
+} from "@apical-ts/core-utils/shared";
 import assert from "assert";
 
 import { renderServerOperationWrapper } from "./templates/server-operation-templates.js";
@@ -88,7 +91,8 @@ function extractServerWrapperMetadata(
   assert(operation.operationId, "Operation ID is required");
   const operationId = operation.operationId;
   const sanitizedId = sanitizeIdentifier(operationId);
-  const hasBody = !!operation.requestBody;
+  const contentTypeMaps = generateContentTypeMaps(operation, doc);
+  const hasBody = contentTypeMaps.requestContentTypeCount > 0;
 
   /* Extract parameter groups to determine which parameter types exist */
   const parameterGroups = extractParameterGroups(
@@ -110,7 +114,7 @@ function extractServerWrapperMetadata(
     method: method.toLowerCase(),
     operationId,
     pathKey,
-    /* Request map is always generated in routes (even if empty) */
+    /* Keep wrapper body handling aligned with the generated route request map. */
     requestMapTypeName: hasBody ? `${sanitizedId}RequestMap` : undefined,
     responseMapTypeName: `${sanitizedId}ResponseMap`,
     summary: operation.summary?.trim(),

--- a/packages/server-generator/tests/server-generator.test.ts
+++ b/packages/server-generator/tests/server-generator.test.ts
@@ -252,6 +252,33 @@ describe("server-generator operation wrapper", () => {
     expect(result.wrapperCode).toContain("parsedBody");
   });
 
+  it("should not import or validate a request map when request content types are empty", () => {
+    const operation = {
+      operationId: "testEmptyRequestBody",
+      requestBody: {
+        required: false,
+        content: {},
+      },
+      responses: {
+        200: {
+          description: "OK",
+        },
+      },
+    };
+
+    const result = generateServerOperationWrapper(
+      "/test",
+      "post",
+      operation as any,
+      [],
+      {} as any,
+    );
+
+    expect(result.wrapperCode).not.toContain("testEmptyRequestBodyRequestMap");
+    expect(result.wrapperCode).not.toContain("schema.safeParse(req.body)");
+    expect(result.wrapperCode).not.toContain("Unsupported Content-Type");
+  });
+
   it("should generate route function with correct path and method", () => {
     const operation = {
       operationId: "testAuthBearer",


### PR DESCRIPTION
Introduce a `normalizeRequestBody` function to standardize request body processing across templates. Update relevant templates to utilize this function, ensuring consistent handling of `application/octet-stream` content types. Enhance tests to verify the new behavior.