### PR TITLE
Optimize schema index generation by reusing in-memory metadata

### DIFF
--- a/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
+++ b/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
@@ -22,12 +22,20 @@ import type { ResolvedSchemas } from "../schema-generator/types.js";
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
 import type { ExtraPropsMode } from "../shared/types.js";
 import { isPlainSchemaObject } from "./openapi-utils.js";
-import { extractOperationParameters } from "./parameter-extractor.js";
+import {
+  extractOperationParameters,
+  type OperationParameterMetadata,
+} from "./parameter-extractor.js";
 import {
   extractRequestSchemas,
   extractResponseSchemas,
 } from "./schema-extractor.js";
-import { generateSchemaIndex } from "./schema-index-generator.js";
+import {
+  buildParameterSchemaIndexEntry,
+  buildSchemaFileIndexEntry,
+  generateSchemaIndex,
+  type SchemaIndexEntry,
+} from "./schema-index-generator.js";
 
 /**
  * Options for component schema promise creation
@@ -54,7 +62,13 @@ interface SchemaGenerationContext {
 type SchemaGeneratorFunction<T = SchemaObject> = (
   name: string,
   schema: T,
-) => Promise<{ content: string; fileName: string }>;
+) => Promise<GeneratedSchemaFile>;
+
+interface GeneratedSchemaFile {
+  content: string;
+  fileName: string;
+  variantFiles?: GeneratedSchemaFile[];
+}
 
 /**
  * Generates all schemas (component, request, response, and parameter schemas)
@@ -82,8 +96,14 @@ export async function generateSchemas(
     schemasDir,
   };
 
+  if (profiler) {
+    profiler.start("schemas:parameter-metadata");
+  }
+  const operationParameters = extractOperationParameters(openApiDoc);
+  profiler?.end("schemas:parameter-metadata");
+
   if (!profiler) {
-    const schemaGenerationPromises: Promise<void>[] = [
+    const schemaGenerationPromises: Promise<SchemaIndexEntry[]>[] = [
       // Generate schemas from components/schemas
       ...generateComponentSchemas(context),
       // Generate request schemas from operations
@@ -111,59 +131,75 @@ export async function generateSchemas(
           }),
       ),
       // Generate parameter schemas from operations
-      ...generateParameterSchemas(openApiDoc, context),
+      ...generateParameterSchemas(operationParameters, context),
     ];
 
-    await Promise.all(schemaGenerationPromises);
-
-    /* Generate the schema index barrel file */
-    const operationParameters = extractOperationParameters(openApiDoc);
-    await generateSchemaIndex(context.schemasDir, operationParameters);
+    const schemaIndexEntries = (
+      await Promise.all(schemaGenerationPromises)
+    ).flat();
+    await generateSchemaIndex(context.schemasDir, schemaIndexEntries);
   } else {
+    const schemaIndexEntries: SchemaIndexEntry[] = [];
+
     // Profiled path: run phases sequentially to get isolated timings
     profiler.start("schemas:components");
-    await Promise.all(generateComponentSchemas(context));
+    schemaIndexEntries.push(
+      ...(await Promise.all(generateComponentSchemas(context))).flat(),
+    );
     profiler.end("schemas:components");
 
     profiler.start("schemas:requests");
-    await Promise.all(
-      createSchemaGenerationPromises(
-        extractRequestSchemas(openApiDoc),
-        context,
-        (name, schema) =>
-          generateRequestSchemaFile(name, schema, {
-            extraProps: context.extraProps,
-            formatOverrides: context.formatOverrides,
-            resolvedSchemas: context.resolvedSchemas,
-            schemaDirectory: context.schemasDir,
-          }),
-      ),
+    schemaIndexEntries.push(
+      ...(
+        await Promise.all(
+          createSchemaGenerationPromises(
+            extractRequestSchemas(openApiDoc),
+            context,
+            (name, schema) =>
+              generateRequestSchemaFile(name, schema, {
+                extraProps: context.extraProps,
+                formatOverrides: context.formatOverrides,
+                resolvedSchemas: context.resolvedSchemas,
+                schemaDirectory: context.schemasDir,
+              }),
+          ),
+        )
+      ).flat(),
     );
     profiler.end("schemas:requests");
 
     profiler.start("schemas:responses");
-    await Promise.all(
-      createSchemaGenerationPromises(
-        extractResponseSchemas(openApiDoc),
-        context,
-        (name, schema) =>
-          generateResponseSchemaFile(name, schema, {
-            extraProps: context.extraProps,
-            formatOverrides: context.formatOverrides,
-            resolvedSchemas: context.resolvedSchemas,
-            schemaDirectory: context.schemasDir,
-          }),
-      ),
+    schemaIndexEntries.push(
+      ...(
+        await Promise.all(
+          createSchemaGenerationPromises(
+            extractResponseSchemas(openApiDoc),
+            context,
+            (name, schema) =>
+              generateResponseSchemaFile(name, schema, {
+                extraProps: context.extraProps,
+                formatOverrides: context.formatOverrides,
+                resolvedSchemas: context.resolvedSchemas,
+                schemaDirectory: context.schemasDir,
+              }),
+          ),
+        )
+      ).flat(),
     );
     profiler.end("schemas:responses");
 
     profiler.start("schemas:parameters");
-    await Promise.all(generateParameterSchemas(openApiDoc, context));
+    schemaIndexEntries.push(
+      ...(
+        await Promise.all(
+          generateParameterSchemas(operationParameters, context),
+        )
+      ).flat(),
+    );
     profiler.end("schemas:parameters");
 
     profiler.start("schemas:index");
-    const operationParameters = extractOperationParameters(openApiDoc);
-    await generateSchemaIndex(context.schemasDir, operationParameters);
+    await generateSchemaIndex(context.schemasDir, schemaIndexEntries);
     profiler.end("schemas:index");
   }
   /* eslint-disable-next-line no-console */
@@ -175,7 +211,7 @@ export async function generateSchemas(
  */
 function createComponentSchemaPromise(
   options: ComponentSchemaOptions,
-): Promise<void> {
+): Promise<SchemaIndexEntry[]> {
   const {
     context,
     description,
@@ -224,6 +260,8 @@ function createComponentSchemaPromise(
         await fs.writeFile(variantPath, variantFile.content);
       }
     }
+
+    return buildSchemaIndexEntries(schemaFile);
   });
 }
 
@@ -234,17 +272,17 @@ function createSchemaGenerationPromises<T = SchemaObject>(
   schemaMap: Map<string, T>,
   context: SchemaGenerationContext,
   generatorFn: SchemaGeneratorFunction<T>,
-): Promise<void>[] {
-  const promises: Promise<void>[] = [];
+): Promise<SchemaIndexEntry[]>[] {
+  const promises: Promise<SchemaIndexEntry[]>[] = [];
 
   for (const [name, schema] of schemaMap) {
     // Generate schema (used by both client and server)
-    const promise = context.limit(() =>
-      generatorFn(name, schema).then((schemaFile) => {
-        const filePath = path.join(context.schemasDir, schemaFile.fileName);
-        return fs.writeFile(filePath, schemaFile.content);
-      }),
-    );
+    const promise = context.limit(async () => {
+      const schemaFile = await generatorFn(name, schema);
+      const filePath = path.join(context.schemasDir, schemaFile.fileName);
+      await fs.writeFile(filePath, schemaFile.content);
+      return [buildSchemaFileIndexEntry(schemaFile.fileName)];
+    });
     promises.push(promise);
   }
 
@@ -256,8 +294,8 @@ function createSchemaGenerationPromises<T = SchemaObject>(
  */
 function generateComponentSchemas(
   context: SchemaGenerationContext,
-): Promise<void>[] {
-  const promises: Promise<void>[] = [];
+): Promise<SchemaIndexEntry[]>[] {
+  const promises: Promise<SchemaIndexEntry[]>[] = [];
 
   if (!context.openApiDoc.components?.schemas) {
     return promises;
@@ -298,8 +336,10 @@ function generateComponentSchemas(
       const sanitizedName = sanitizeIdentifier(name);
       const promise = context.limit(async () => {
         const content = generateFallbackSchemaContent(sanitizedName, schema);
-        const filePath = path.join(context.schemasDir, `${sanitizedName}.ts`);
+        const fileName = `${sanitizedName}.ts`;
+        const filePath = path.join(context.schemasDir, fileName);
         await fs.writeFile(filePath, content);
+        return [buildSchemaFileIndexEntry(fileName)];
       });
       promises.push(promise);
       continue;
@@ -328,18 +368,15 @@ function generateComponentSchemas(
  * Generates parameter schemas for all operations
  */
 function generateParameterSchemas(
-  openApiDoc: OpenAPIObject,
+  operationParameters: readonly OperationParameterMetadata[],
   context: SchemaGenerationContext,
-): Promise<void>[] {
-  const promises: Promise<void>[] = [];
-
-  /* Extract all operation parameters */
-  const operationParameters = extractOperationParameters(openApiDoc);
+): Promise<SchemaIndexEntry[]>[] {
+  const promises: Promise<SchemaIndexEntry[]>[] = [];
 
   /* Generate parameter schema files for each operation */
   for (const parameterMetadata of operationParameters) {
-    const promise = context.limit(() =>
-      writeParameterSchemaFile(
+    const promise = context.limit(async () => {
+      await writeParameterSchemaFile(
         context.schemasDir,
         parameterMetadata.operationId,
         parameterMetadata,
@@ -349,12 +386,27 @@ function generateParameterSchemas(
           formatOverrides: context.formatOverrides,
           lowercaseHeaderKeys: false,
         },
-      ),
-    );
+      );
+      return [buildParameterSchemaIndexEntry(parameterMetadata)];
+    });
     promises.push(promise);
   }
 
   return promises;
+}
+
+function buildSchemaIndexEntries(
+  schemaFile: GeneratedSchemaFile,
+): SchemaIndexEntry[] {
+  const entries = [buildSchemaFileIndexEntry(schemaFile.fileName)];
+
+  if (schemaFile.variantFiles) {
+    for (const variantFile of schemaFile.variantFiles) {
+      entries.push(...buildSchemaIndexEntries(variantFile));
+    }
+  }
+
+  return entries;
 }
 
 /* Generates a minimal fallback file for schemas that are not plain OpenAPI objects */

--- a/packages/core-utils/src/core-generator/schema-index-generator.ts
+++ b/packages/core-utils/src/core-generator/schema-index-generator.ts
@@ -5,97 +5,96 @@ import type { OperationParameterMetadata } from "../core-generator/parameter-ext
 
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
 
-/**
- * Generates the schema index barrel file that exports all schemas including parameter schemas
- */
-export async function generateSchemaIndex(
-  schemasDir: string,
-  operationParameters: OperationParameterMetadata[],
-): Promise<void> {
-  /* Read all .ts files in schemas directory */
-  const files = await fs.readdir(schemasDir);
-  const schemaFiles = files.filter(
-    (file) => file.endsWith(".ts") && file !== "index.ts",
-  );
+export interface SchemaIndexEntry {
+  exportNames: string[];
+  fileName: string;
+}
 
+export function buildSchemaFileIndexEntry(fileName: string): SchemaIndexEntry {
+  return {
+    exportNames: [path.basename(fileName, ".ts")],
+    fileName,
+  };
+}
+
+export function buildParameterSchemaIndexEntry(
+  parameterMetadata: OperationParameterMetadata,
+): SchemaIndexEntry {
+  const sanitizedId = sanitizeIdentifier(parameterMetadata.operationId);
+  const exportNames: string[] = [];
+
+  if (parameterMetadata.parameterGroups.queryParams.length > 0) {
+    exportNames.push(`${sanitizedId}QuerySchema`);
+  }
+  if (parameterMetadata.parameterGroups.pathParams.length > 0) {
+    exportNames.push(`${sanitizedId}PathSchema`);
+  }
+
+  const hasHeaders =
+    parameterMetadata.parameterGroups.headerParams.length > 0 ||
+    (parameterMetadata.securityHeaders?.length ?? 0) > 0;
+  if (hasHeaders) {
+    exportNames.push(`${sanitizedId}HeadersSchema`);
+  }
+
+  return {
+    exportNames,
+    fileName: `${sanitizedId}Parameters.ts`,
+  };
+}
+
+export function buildSchemaIndexContent(
+  entries: readonly SchemaIndexEntry[],
+): string {
   const imports: string[] = [];
-  const exports: string[] = [];
+  const exports = new Set<string>();
 
-  /* Add imports and exports for regular schema files */
-  for (const file of schemaFiles) {
-    const baseName = path.basename(file, ".ts");
+  const sortedEntries = [...entries]
+    .filter((entry) => entry.exportNames.length > 0)
+    .sort((left, right) => left.fileName.localeCompare(right.fileName));
 
-    /* Skip parameter files - they will be handled separately */
-    if (file.includes("Parameters.ts")) {
-      continue;
-    }
+  for (const entry of sortedEntries) {
+    imports.push(...buildImportLines(entry));
 
-    imports.push(`import { ${baseName} } from "./${baseName}.js";`);
-    exports.push(baseName);
-  }
-
-  /* Add imports and exports for parameter schemas */
-  for (const parameterMetadata of operationParameters) {
-    const sanitizedId = sanitizeIdentifier(parameterMetadata.operationId);
-    const parameterFileName = `${sanitizedId}Parameters`;
-
-    /* Check if the parameter file exists */
-    const parameterFilePath = path.join(schemasDir, `${parameterFileName}.ts`);
-    try {
-      await fs.access(parameterFilePath);
-
-      /* Read the parameter file to check which schemas actually exist */
-      const parameterFileContent = await fs.readFile(
-        parameterFilePath,
-        "utf-8",
-      );
-
-      /* Collect available schema exports from the file */
-      const availableExports: string[] = [];
-
-      /* Check for both client and server schema exports */
-      const querySchemaName = `${sanitizedId}QuerySchema`;
-      const pathSchemaName = `${sanitizedId}PathSchema`;
-      const headersSchemaName = `${sanitizedId}HeadersSchema`;
-
-      if (parameterFileContent.includes(`export { ${querySchemaName} }`)) {
-        availableExports.push(querySchemaName);
-      }
-      if (parameterFileContent.includes(`export { ${pathSchemaName} }`)) {
-        availableExports.push(pathSchemaName);
-      }
-      if (parameterFileContent.includes(`export { ${headersSchemaName} }`)) {
-        availableExports.push(headersSchemaName);
-      }
-
-      /* Only add imports if there are any exports */
-      if (availableExports.length > 0) {
-        imports.push(`import {`);
-        imports.push(...availableExports.map((exp) => `  ${exp},`));
-        imports.push(`} from "./${parameterFileName}.js";`);
-
-        /* Add to exports */
-        exports.push(...availableExports);
-      }
-    } catch {
-      /* Parameter file doesn't exist - skip */
+    for (const exportName of entry.exportNames) {
+      exports.add(exportName);
     }
   }
 
-  /* Sort exports for consistency */
-  exports.sort();
+  const sortedExports = [...exports].sort();
 
-  /* Generate the index file content */
-  const content = [
+  return [
     ...imports,
     "",
     "export {",
-    ...exports.map((exp) => `  ${exp},`),
+    ...sortedExports.map((exportName) => `  ${exportName},`),
     "};",
     "",
   ].join("\n");
+}
 
-  /* Write the index file */
+export async function generateSchemaIndex(
+  schemasDir: string,
+  entries: readonly SchemaIndexEntry[],
+): Promise<void> {
+  const content = buildSchemaIndexContent(entries);
   const indexPath = path.join(schemasDir, "index.ts");
   await fs.writeFile(indexPath, content, "utf-8");
+}
+
+function buildImportLines(entry: SchemaIndexEntry): string[] {
+  const fileBaseName = path.basename(entry.fileName, ".ts");
+
+  if (
+    entry.exportNames.length === 1 &&
+    !entry.fileName.includes("Parameters.ts")
+  ) {
+    return [`import { ${entry.exportNames[0]} } from "./${fileBaseName}.js";`];
+  }
+
+  return [
+    "import {",
+    ...entry.exportNames.map((exportName) => `  ${exportName},`),
+    `} from "./${fileBaseName}.js";`,
+  ];
 }

--- a/packages/core-utils/src/core-generator/schema-index-generator.ts
+++ b/packages/core-utils/src/core-generator/schema-index-generator.ts
@@ -49,11 +49,9 @@ export function buildSchemaIndexContent(
   const imports: string[] = [];
   const exports = new Set<string>();
 
-  const sortedEntries = [...entries]
-    .filter((entry) => entry.exportNames.length > 0)
-    .sort((left, right) => left.fileName.localeCompare(right.fileName));
+  const normalizedEntries = normalizeSchemaIndexEntries(entries);
 
-  for (const entry of sortedEntries) {
+  for (const entry of normalizedEntries) {
     imports.push(...buildImportLines(entry));
 
     for (const exportName of entry.exportNames) {
@@ -80,6 +78,33 @@ export async function generateSchemaIndex(
   const content = buildSchemaIndexContent(entries);
   const indexPath = path.join(schemasDir, "index.ts");
   await fs.writeFile(indexPath, content, "utf-8");
+}
+
+function normalizeSchemaIndexEntries(
+  entries: readonly SchemaIndexEntry[],
+): SchemaIndexEntry[] {
+  const exportsByFileName = new Map<string, Set<string>>();
+
+  for (const entry of entries) {
+    if (entry.exportNames.length === 0) {
+      continue;
+    }
+
+    const exportNames = exportsByFileName.get(entry.fileName) ?? new Set();
+
+    for (const exportName of entry.exportNames) {
+      exportNames.add(exportName);
+    }
+
+    exportsByFileName.set(entry.fileName, exportNames);
+  }
+
+  return [...exportsByFileName.entries()]
+    .map(([fileName, exportNames]) => ({
+      exportNames: [...exportNames],
+      fileName,
+    }))
+    .sort((left, right) => left.fileName.localeCompare(right.fileName));
 }
 
 function buildImportLines(entry: SchemaIndexEntry): string[] {

--- a/packages/core-utils/tests/core-generator/schema-index-generator.test.ts
+++ b/packages/core-utils/tests/core-generator/schema-index-generator.test.ts
@@ -1,0 +1,107 @@
+import type { ParameterObject } from "openapi3-ts/oas31";
+
+import { describe, expect, it } from "vitest";
+
+import type { OperationParameterMetadata } from "../../src/core-generator/parameter-extractor.js";
+import {
+  buildParameterSchemaIndexEntry,
+  buildSchemaFileIndexEntry,
+  buildSchemaIndexContent,
+} from "../../src/core-generator/schema-index-generator.js";
+import type { SecurityHeader } from "../../src/shared/models/security-models.js";
+
+function createOperationParameterMetadata(
+  overrides: Partial<OperationParameterMetadata> = {},
+): OperationParameterMetadata {
+  return {
+    operationId: "listPets",
+    parameterGroups: {
+      headerParams: [],
+      pathParams: [],
+      queryParams: [],
+    },
+    securityHeaders: [],
+    ...overrides,
+  };
+}
+
+describe("core-generator schema-index-generator", () => {
+  it("builds schema index content from known entries without rediscovering files", () => {
+    const content = buildSchemaIndexContent([
+      buildSchemaFileIndexEntry("Pet.ts"),
+      buildSchemaFileIndexEntry("PetRequest.ts"),
+      {
+        exportNames: ["listPetsQuerySchema", "listPetsHeadersSchema"],
+        fileName: "listPetsParameters.ts",
+      },
+      {
+        exportNames: [],
+        fileName: "emptyParameters.ts",
+      },
+    ]);
+
+    expect(content).toContain(`import { Pet } from "./Pet.js";`);
+    expect(content).toContain(`import { PetRequest } from "./PetRequest.js";`);
+    expect(content).toContain(
+      [
+        "import {",
+        "  listPetsQuerySchema,",
+        "  listPetsHeadersSchema,",
+        '} from "./listPetsParameters.js";',
+      ].join("\n"),
+    );
+    expect(content).not.toContain("emptyParameters");
+    expect(content).toContain(
+      [
+        "export {",
+        "  Pet,",
+        "  PetRequest,",
+        "  listPetsHeadersSchema,",
+        "  listPetsQuerySchema,",
+        "};",
+      ].join("\n"),
+    );
+  });
+
+  it("derives query and security header exports from parameter metadata", () => {
+    const queryParam = {
+      in: "query",
+      name: "limit",
+      required: false,
+      schema: { type: "integer" },
+    } satisfies ParameterObject;
+    const securityHeader: SecurityHeader = {
+      headerName: "x-api-key",
+      isOverride: true,
+      isRequired: true,
+      schemeName: "apiKey",
+    };
+
+    const entry = buildParameterSchemaIndexEntry(
+      createOperationParameterMetadata({
+        parameterGroups: {
+          headerParams: [],
+          pathParams: [],
+          queryParams: [queryParam],
+        },
+        securityHeaders: [securityHeader],
+      }),
+    );
+
+    expect(entry).toEqual({
+      exportNames: ["listPetsQuerySchema", "listPetsHeadersSchema"],
+      fileName: "listPetsParameters.ts",
+    });
+  });
+
+  it("skips parameter imports when no client parameter schemas exist", () => {
+    const entry = buildParameterSchemaIndexEntry(
+      createOperationParameterMetadata(),
+    );
+
+    expect(entry).toEqual({
+      exportNames: [],
+      fileName: "listPetsParameters.ts",
+    });
+  });
+});

--- a/packages/core-utils/tests/core-generator/schema-index-generator.test.ts
+++ b/packages/core-utils/tests/core-generator/schema-index-generator.test.ts
@@ -63,6 +63,37 @@ describe("core-generator schema-index-generator", () => {
     );
   });
 
+  it("deduplicates imports when multiple entries share a file name", () => {
+    const content = buildSchemaIndexContent([
+      buildSchemaFileIndexEntry("Pet.ts"),
+      buildSchemaFileIndexEntry("Pet.ts"),
+      {
+        exportNames: ["listPetsQuerySchema"],
+        fileName: "listPetsParameters.ts",
+      },
+      {
+        exportNames: ["listPetsHeadersSchema", "listPetsQuerySchema"],
+        fileName: "listPetsParameters.ts",
+      },
+    ]);
+
+    expect(content.match(/from "\.\/Pet\.js";/g)).toHaveLength(1);
+    expect(content.match(/from "\.\/listPetsParameters\.js";/g)).toHaveLength(
+      1,
+    );
+    expect(content).toContain("  listPetsHeadersSchema,");
+    expect(content).toContain("  listPetsQuerySchema,");
+    expect(content).toContain(
+      [
+        "export {",
+        "  Pet,",
+        "  listPetsHeadersSchema,",
+        "  listPetsQuerySchema,",
+        "};",
+      ].join("\n"),
+    );
+  });
+
   it("derives query and security header exports from parameter metadata", () => {
     const queryParam = {
       in: "query",


### PR DESCRIPTION
## Summary
- Reuse in-memory schema metadata while generating the schema index instead of re-reading emitted schema files.
- Collect schema index entries while generating component, request, response, parameter, fallback, and variant schema files.
- Add focused tests covering schema index content generation and parameter-schema export detection.

## Measured savings
- schemas:index 731.16 ms -> 35.51 ms (-95.1%)
- schemas:all -585.73 ms

## Notes
- routes/ and client/ remain separate.