### PR TITLE
Reduce generated schema file count with bundled parameter schemas

### DIFF
--- a/apps/craft/tests/integrations/format-overrides.test.ts
+++ b/apps/craft/tests/integrations/format-overrides.test.ts
@@ -18,6 +18,7 @@ const taxCodeSourcePath = join(
   "fixtures/format-overrides/TaxCode.ts",
 );
 const formatOverrideAlias = "__apicalStringFormatTaxCode";
+const parameterSchemaBundleFileName = "__apical_generated_parameters.ts";
 
 describe("format overrides integration", () => {
   beforeEach(async () => {
@@ -28,13 +29,14 @@ describe("format overrides integration", () => {
     await fs.rm(outputDir, { force: true, recursive: true });
   });
 
-  it("imports the custom schema into generated schemas and parameter files", async () => {
+  it("imports the custom schema into generated schemas and bundled parameter schemas", async () => {
     await generateWithFormatOverride();
 
     const profilePath = join(outputDir, "schemas/Profile.ts");
     const parametersPath = join(
       outputDir,
-      "schemas/getProfileByTaxCodeParameters.ts",
+      "schemas",
+      parameterSchemaBundleFileName,
     );
     const profileContent = await fs.readFile(profilePath, "utf-8");
     const parametersContent = await fs.readFile(parametersPath, "utf-8");

--- a/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
+++ b/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
@@ -16,13 +16,16 @@ import {
   generateRequestSchemaFile,
   generateResponseSchemaFile,
   generateSchemaFile,
-  writeParameterSchemaFile,
+  writeParameterSchemaBundleFile,
 } from "../schema-generator/index.js";
 import type { ResolvedSchemas } from "../schema-generator/types.js";
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
 import type { ExtraPropsMode } from "../shared/types.js";
 import { isPlainSchemaObject } from "./openapi-utils.js";
-import { extractOperationParameters } from "./parameter-extractor.js";
+import {
+  extractOperationParameters,
+  type OperationParameterMetadata,
+} from "./parameter-extractor.js";
 import {
   extractRequestSchemas,
   extractResponseSchemas,
@@ -81,6 +84,7 @@ export async function generateSchemas(
     resolvedSchemas: openApiDoc.components?.schemas ?? {},
     schemasDir,
   };
+  const operationParameters = extractOperationParameters(openApiDoc);
 
   if (!profiler) {
     const schemaGenerationPromises: Promise<void>[] = [
@@ -111,13 +115,12 @@ export async function generateSchemas(
           }),
       ),
       // Generate parameter schemas from operations
-      ...generateParameterSchemas(openApiDoc, context),
+      ...generateParameterSchemas(operationParameters, context),
     ];
 
     await Promise.all(schemaGenerationPromises);
 
     /* Generate the schema index barrel file */
-    const operationParameters = extractOperationParameters(openApiDoc);
     await generateSchemaIndex(context.schemasDir, operationParameters);
   } else {
     // Profiled path: run phases sequentially to get isolated timings
@@ -158,11 +161,10 @@ export async function generateSchemas(
     profiler.end("schemas:responses");
 
     profiler.start("schemas:parameters");
-    await Promise.all(generateParameterSchemas(openApiDoc, context));
+    await Promise.all(generateParameterSchemas(operationParameters, context));
     profiler.end("schemas:parameters");
 
     profiler.start("schemas:index");
-    const operationParameters = extractOperationParameters(openApiDoc);
     await generateSchemaIndex(context.schemasDir, operationParameters);
     profiler.end("schemas:index");
   }
@@ -328,33 +330,19 @@ function generateComponentSchemas(
  * Generates parameter schemas for all operations
  */
 function generateParameterSchemas(
-  openApiDoc: OpenAPIObject,
+  operationParameters: readonly OperationParameterMetadata[],
   context: SchemaGenerationContext,
 ): Promise<void>[] {
-  const promises: Promise<void>[] = [];
-
-  /* Extract all operation parameters */
-  const operationParameters = extractOperationParameters(openApiDoc);
-
-  /* Generate parameter schema files for each operation */
-  for (const parameterMetadata of operationParameters) {
-    const promise = context.limit(() =>
-      writeParameterSchemaFile(
-        context.schemasDir,
-        parameterMetadata.operationId,
-        parameterMetadata,
-        {
-          /* Client defaults - no coercion or special handling */
-          coercePrimitives: false,
-          formatOverrides: context.formatOverrides,
-          lowercaseHeaderKeys: false,
-        },
-      ),
-    );
-    promises.push(promise);
-  }
-
-  return promises;
+  return [
+    context.limit(() =>
+      writeParameterSchemaBundleFile(context.schemasDir, operationParameters, {
+        /* Client defaults - no coercion or special handling */
+        coercePrimitives: false,
+        formatOverrides: context.formatOverrides,
+        lowercaseHeaderKeys: false,
+      }),
+    ),
+  ];
 }
 
 /* Generates a minimal fallback file for schemas that are not plain OpenAPI objects */

--- a/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
+++ b/packages/core-utils/src/core-generator/schema-generation-coordinator.ts
@@ -31,6 +31,7 @@ import {
   extractResponseSchemas,
 } from "./schema-extractor.js";
 import { generateSchemaIndex } from "./schema-index-generator.js";
+import { LEGACY_PARAMETER_SCHEMA_BUNDLE_FILE_NAMES } from "../shared/parameter-schema-bundle.js";
 
 /**
  * Options for component schema promise creation
@@ -85,6 +86,8 @@ export async function generateSchemas(
     schemasDir,
   };
   const operationParameters = extractOperationParameters(openApiDoc);
+  const requestSchemas = extractRequestSchemas(openApiDoc);
+  const responseSchemas = extractResponseSchemas(openApiDoc);
 
   if (!profiler) {
     const schemaGenerationPromises: Promise<void>[] = [
@@ -92,7 +95,7 @@ export async function generateSchemas(
       ...generateComponentSchemas(context),
       // Generate request schemas from operations
       ...createSchemaGenerationPromises(
-        extractRequestSchemas(openApiDoc),
+        requestSchemas,
         context,
         (name, schema) =>
           generateRequestSchemaFile(name, schema, {
@@ -104,7 +107,7 @@ export async function generateSchemas(
       ),
       // Generate response schemas from operations
       ...createSchemaGenerationPromises(
-        extractResponseSchemas(openApiDoc),
+        responseSchemas,
         context,
         (name, schema) =>
           generateResponseSchemaFile(name, schema, {
@@ -119,6 +122,11 @@ export async function generateSchemas(
     ];
 
     await Promise.all(schemaGenerationPromises);
+    await removeLegacyParameterSchemaBundles(
+      context,
+      requestSchemas,
+      responseSchemas,
+    );
 
     /* Generate the schema index barrel file */
     await generateSchemaIndex(context.schemasDir, operationParameters);
@@ -130,32 +138,26 @@ export async function generateSchemas(
 
     profiler.start("schemas:requests");
     await Promise.all(
-      createSchemaGenerationPromises(
-        extractRequestSchemas(openApiDoc),
-        context,
-        (name, schema) =>
-          generateRequestSchemaFile(name, schema, {
-            extraProps: context.extraProps,
-            formatOverrides: context.formatOverrides,
-            resolvedSchemas: context.resolvedSchemas,
-            schemaDirectory: context.schemasDir,
-          }),
+      createSchemaGenerationPromises(requestSchemas, context, (name, schema) =>
+        generateRequestSchemaFile(name, schema, {
+          extraProps: context.extraProps,
+          formatOverrides: context.formatOverrides,
+          resolvedSchemas: context.resolvedSchemas,
+          schemaDirectory: context.schemasDir,
+        }),
       ),
     );
     profiler.end("schemas:requests");
 
     profiler.start("schemas:responses");
     await Promise.all(
-      createSchemaGenerationPromises(
-        extractResponseSchemas(openApiDoc),
-        context,
-        (name, schema) =>
-          generateResponseSchemaFile(name, schema, {
-            extraProps: context.extraProps,
-            formatOverrides: context.formatOverrides,
-            resolvedSchemas: context.resolvedSchemas,
-            schemaDirectory: context.schemasDir,
-          }),
+      createSchemaGenerationPromises(responseSchemas, context, (name, schema) =>
+        generateResponseSchemaFile(name, schema, {
+          extraProps: context.extraProps,
+          formatOverrides: context.formatOverrides,
+          resolvedSchemas: context.resolvedSchemas,
+          schemaDirectory: context.schemasDir,
+        }),
       ),
     );
     profiler.end("schemas:responses");
@@ -165,11 +167,41 @@ export async function generateSchemas(
     profiler.end("schemas:parameters");
 
     profiler.start("schemas:index");
+    await removeLegacyParameterSchemaBundles(
+      context,
+      requestSchemas,
+      responseSchemas,
+    );
     await generateSchemaIndex(context.schemasDir, operationParameters);
     profiler.end("schemas:index");
   }
   /* eslint-disable-next-line no-console */
   console.log("✅ Schemas generated successfully");
+}
+
+async function removeLegacyParameterSchemaBundles(
+  context: SchemaGenerationContext,
+  requestSchemas: ReadonlyMap<string, SchemaObject>,
+  responseSchemas: ReadonlyMap<string, SchemaObject>,
+): Promise<void> {
+  const expectedSchemaBaseNames = new Set<string>([
+    ...Object.keys(context.resolvedSchemas ?? {}).map((name) =>
+      sanitizeIdentifier(name),
+    ),
+    ...requestSchemas.keys(),
+    ...responseSchemas.keys(),
+  ]);
+
+  await Promise.all(
+    LEGACY_PARAMETER_SCHEMA_BUNDLE_FILE_NAMES.map(async (fileName) => {
+      const baseName = path.basename(fileName, ".ts");
+      if (expectedSchemaBaseNames.has(baseName)) {
+        return;
+      }
+
+      await fs.rm(path.join(context.schemasDir, fileName), { force: true });
+    }),
+  );
 }
 
 /**

--- a/packages/core-utils/src/core-generator/schema-index-generator.ts
+++ b/packages/core-utils/src/core-generator/schema-index-generator.ts
@@ -2,10 +2,9 @@ import { promises as fs } from "fs";
 import path from "path";
 
 import type { OperationParameterMetadata } from "../core-generator/parameter-extractor.js";
+import { PARAMETER_SCHEMA_BUNDLE_BASE_NAME } from "../shared/parameter-schema-bundle.js";
 
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
-
-const PARAMETER_SCHEMA_BUNDLE_BASE_NAME = "parameters";
 
 /**
  * Generates the schema index barrel file that exports all schemas including parameter schemas

--- a/packages/core-utils/src/core-generator/schema-index-generator.ts
+++ b/packages/core-utils/src/core-generator/schema-index-generator.ts
@@ -5,6 +5,8 @@ import type { OperationParameterMetadata } from "../core-generator/parameter-ext
 
 import { sanitizeIdentifier } from "../schema-generator/utils.js";
 
+const PARAMETER_SCHEMA_BUNDLE_BASE_NAME = "parameters";
+
 /**
  * Generates the schema index barrel file that exports all schemas including parameter schemas
  */
@@ -26,7 +28,7 @@ export async function generateSchemaIndex(
     const baseName = path.basename(file, ".ts");
 
     /* Skip parameter files - they will be handled separately */
-    if (file.includes("Parameters.ts")) {
+    if (baseName === PARAMETER_SCHEMA_BUNDLE_BASE_NAME) {
       continue;
     }
 
@@ -34,52 +36,12 @@ export async function generateSchemaIndex(
     exports.push(baseName);
   }
 
-  /* Add imports and exports for parameter schemas */
-  for (const parameterMetadata of operationParameters) {
-    const sanitizedId = sanitizeIdentifier(parameterMetadata.operationId);
-    const parameterFileName = `${sanitizedId}Parameters`;
-
-    /* Check if the parameter file exists */
-    const parameterFilePath = path.join(schemasDir, `${parameterFileName}.ts`);
-    try {
-      await fs.access(parameterFilePath);
-
-      /* Read the parameter file to check which schemas actually exist */
-      const parameterFileContent = await fs.readFile(
-        parameterFilePath,
-        "utf-8",
-      );
-
-      /* Collect available schema exports from the file */
-      const availableExports: string[] = [];
-
-      /* Check for both client and server schema exports */
-      const querySchemaName = `${sanitizedId}QuerySchema`;
-      const pathSchemaName = `${sanitizedId}PathSchema`;
-      const headersSchemaName = `${sanitizedId}HeadersSchema`;
-
-      if (parameterFileContent.includes(`export { ${querySchemaName} }`)) {
-        availableExports.push(querySchemaName);
-      }
-      if (parameterFileContent.includes(`export { ${pathSchemaName} }`)) {
-        availableExports.push(pathSchemaName);
-      }
-      if (parameterFileContent.includes(`export { ${headersSchemaName} }`)) {
-        availableExports.push(headersSchemaName);
-      }
-
-      /* Only add imports if there are any exports */
-      if (availableExports.length > 0) {
-        imports.push(`import {`);
-        imports.push(...availableExports.map((exp) => `  ${exp},`));
-        imports.push(`} from "./${parameterFileName}.js";`);
-
-        /* Add to exports */
-        exports.push(...availableExports);
-      }
-    } catch {
-      /* Parameter file doesn't exist - skip */
-    }
+  const parameterExports = collectParameterSchemaExports(operationParameters);
+  if (parameterExports.length > 0) {
+    imports.push(`import {`);
+    imports.push(...parameterExports.map((exp) => `  ${exp},`));
+    imports.push(`} from "./${PARAMETER_SCHEMA_BUNDLE_BASE_NAME}.js";`);
+    exports.push(...parameterExports);
   }
 
   /* Sort exports for consistency */
@@ -98,4 +60,31 @@ export async function generateSchemaIndex(
   /* Write the index file */
   const indexPath = path.join(schemasDir, "index.ts");
   await fs.writeFile(indexPath, content, "utf-8");
+}
+
+function collectParameterSchemaExports(
+  operationParameters: readonly OperationParameterMetadata[],
+): string[] {
+  const exports: string[] = [];
+
+  for (const parameterMetadata of operationParameters) {
+    const sanitizedId = sanitizeIdentifier(parameterMetadata.operationId);
+
+    if (parameterMetadata.parameterGroups.queryParams.length > 0) {
+      exports.push(`${sanitizedId}QuerySchema`);
+    }
+
+    if (parameterMetadata.parameterGroups.pathParams.length > 0) {
+      exports.push(`${sanitizedId}PathSchema`);
+    }
+
+    if (
+      parameterMetadata.parameterGroups.headerParams.length > 0 ||
+      (parameterMetadata.securityHeaders?.length ?? 0) > 0
+    ) {
+      exports.push(`${sanitizedId}HeadersSchema`);
+    }
+  }
+
+  return exports;
 }

--- a/packages/core-utils/src/schema-generator/index.ts
+++ b/packages/core-utils/src/schema-generator/index.ts
@@ -8,7 +8,7 @@ export {
   createStringFormatOverrideRegistry,
   type StringFormatOverride,
 } from "./format-overrides.js";
-export { writeParameterSchemaFile } from "./parameter-file-generator.js";
+export { writeParameterSchemaBundleFile } from "./parameter-file-generator.js";
 export {
   analyzeSchemaForRecursion,
   createRecursiveContext,

--- a/packages/core-utils/src/schema-generator/parameter-file-generator.ts
+++ b/packages/core-utils/src/schema-generator/parameter-file-generator.ts
@@ -12,31 +12,32 @@ import { generateParameterSchemas } from "../shared/parameter-schemas.js";
 import { sanitizeIdentifier } from "./utils.js";
 
 /**
- * Result of parameter schema file generation
+ * Supported options for generated parameter schema content
  */
-interface ParameterSchemaFileResult {
-  content: string;
-  fileName: string;
+interface ParameterSchemaFileOptions {
+  /* Use client defaults for parameter schema generation */
+  coercePrimitives?: boolean;
+  formatOverrides?: StringFormatOverrideRegistry;
+  lowercaseHeaderKeys?: boolean;
 }
 
+interface ParameterSchemaSectionResult {
+  content: string;
+  typeImports: Set<string>;
+}
+
+const PARAMETER_SCHEMA_BUNDLE_FILE_NAME = "parameters.ts";
+
 /**
- * Generates Zod schema files for operation parameters.
- * Creates separate files for each operation's query, path, and headers schemas.
+ * Generates Zod schema content for a single operation.
  */
-async function generateParameterSchemaFile(
-  schemasDir: string,
+function generateParameterSchemaSection(
   operationId: string,
   parameterMetadata: OperationParameterMetadata,
-  options: {
-    /* Use client defaults for parameter schema generation */
-    coercePrimitives?: boolean;
-    formatOverrides?: StringFormatOverrideRegistry;
-    lowercaseHeaderKeys?: boolean;
-  } = {},
-): Promise<ParameterSchemaFileResult> {
+  options: ParameterSchemaFileOptions = {},
+): ParameterSchemaSectionResult {
   /* Extract security headers from metadata */
   const sanitizedId = sanitizeIdentifier(operationId);
-  const fileName = `${sanitizedId}Parameters.ts`;
   const { securityHeaders = [] } = parameterMetadata;
 
   /* Generate parameter schemas using shared logic */
@@ -70,39 +71,6 @@ async function generateParameterSchemaFile(
 
   /* Track which parameter types actually exist */
   const { hasHeaders, hasPath, hasQuery } = result.hasParameters;
-
-  /* Build the file content */
-  const imports: string[] = [];
-
-  /* Always include Zod import */
-  imports.push(`import * as z from "zod";`);
-
-  /* Add other type imports */
-  if (result.typeImports.size > 0) {
-    const typeImportsList = Array.from(result.typeImports)
-      .filter(
-        (typeImport) =>
-          typeImport !== "z" &&
-          !findStringFormatOverrideByReferenceName(
-            typeImport,
-            options.formatOverrides,
-          ),
-      )
-      .sort();
-    for (const typeImport of typeImportsList) {
-      imports.push(`import { ${typeImport} } from "./${typeImport}.js";`);
-    }
-  }
-
-  const filePath = path.join(schemasDir, fileName);
-  const externalImportLines = renderStringFormatOverrideImports(
-    new Set([...result.typeImports, ...serverResult.typeImports]),
-    options.formatOverrides,
-    filePath,
-  );
-  if (externalImportLines.length > 0) {
-    imports.push(...externalImportLines);
-  }
 
   /* Calculate optionality for parameters */
   const queryParams = parameterMetadata.parameterGroups.queryParams || [];
@@ -178,12 +146,12 @@ async function generateParameterSchemaFile(
     hasQuery,
   });
 
-  const contentParts: string[] = [
-    ...imports,
-    "",
-    "/* Parameter schemas for type-safe inputs */",
-    result.schemaCode,
-  ];
+  const contentParts: string[] = [`/* Parameter schemas for ${sanitizedId} */`];
+
+  if (result.schemaCode) {
+    contentParts.push("", "/* Parameter schemas for type-safe inputs */");
+    contentParts.push(result.schemaCode);
+  }
 
   if (serverResult.schemaCode) {
     contentParts.push(
@@ -224,36 +192,64 @@ async function generateParameterSchemaFile(
     "",
   );
 
-  const content = contentParts.join("\n");
-
   return {
-    content,
-    fileName,
+    content: contentParts.join("\n"),
+    typeImports: new Set([...result.typeImports, ...serverResult.typeImports]),
   };
 }
 
 /**
- * Writes parameter schema file to the schemas directory
+ * Generates bundled parameter schema file content for all operations.
  */
-export async function writeParameterSchemaFile(
+function generateParameterSchemaBundleContent(
   schemasDir: string,
-  operationId: string,
-  parameterMetadata: OperationParameterMetadata,
-  options: {
-    coercePrimitives?: boolean;
-    formatOverrides?: StringFormatOverrideRegistry;
-    lowercaseHeaderKeys?: boolean;
-  } = {},
-): Promise<void> {
-  const result = await generateParameterSchemaFile(
-    schemasDir,
-    operationId,
-    parameterMetadata,
-    options,
+  operationParameters: readonly OperationParameterMetadata[],
+  options: ParameterSchemaFileOptions = {},
+): string {
+  const sections: string[] = [];
+  const typeImports = new Set<string>();
+
+  for (const parameterMetadata of operationParameters) {
+    const section = generateParameterSchemaSection(
+      parameterMetadata.operationId,
+      parameterMetadata,
+      options,
+    );
+    sections.push(section.content);
+
+    for (const typeImport of section.typeImports) {
+      typeImports.add(typeImport);
+    }
+  }
+
+  if (sections.length === 0) {
+    return "export {};\n";
+  }
+
+  const imports = buildParameterSchemaImports(
+    path.join(schemasDir, PARAMETER_SCHEMA_BUNDLE_FILE_NAME),
+    typeImports,
+    options.formatOverrides,
   );
 
-  const filePath = path.join(schemasDir, result.fileName);
-  await fs.writeFile(filePath, result.content, "utf-8");
+  return [...imports, "", sections.join("\n\n")].join("\n");
+}
+
+/**
+ * Writes the bundled parameter schema file to the schemas directory.
+ */
+export async function writeParameterSchemaBundleFile(
+  schemasDir: string,
+  operationParameters: readonly OperationParameterMetadata[],
+  options: ParameterSchemaFileOptions = {},
+): Promise<void> {
+  const filePath = path.join(schemasDir, PARAMETER_SCHEMA_BUNDLE_FILE_NAME);
+  const content = generateParameterSchemaBundleContent(
+    schemasDir,
+    operationParameters,
+    options,
+  );
+  await fs.writeFile(filePath, content, "utf-8");
 }
 
 /**
@@ -321,6 +317,36 @@ function buildSchemaExports(
   }
 
   return exports;
+}
+
+function buildParameterSchemaImports(
+  filePath: string,
+  typeImports: ReadonlySet<string>,
+  formatOverrides?: StringFormatOverrideRegistry,
+): string[] {
+  const imports = [`import * as z from "zod";`];
+  const typeImportsList = Array.from(typeImports)
+    .filter(
+      (typeImport) =>
+        typeImport !== "z" &&
+        !findStringFormatOverrideByReferenceName(typeImport, formatOverrides),
+    )
+    .sort();
+
+  for (const typeImport of typeImportsList) {
+    imports.push(`import { ${typeImport} } from "./${typeImport}.js";`);
+  }
+
+  const externalImportLines = renderStringFormatOverrideImports(
+    new Set(typeImports),
+    formatOverrides,
+    filePath,
+  );
+  if (externalImportLines.length > 0) {
+    imports.push(...externalImportLines);
+  }
+
+  return imports;
 }
 
 /**

--- a/packages/core-utils/src/schema-generator/parameter-file-generator.ts
+++ b/packages/core-utils/src/schema-generator/parameter-file-generator.ts
@@ -8,6 +8,7 @@ import {
   findStringFormatOverrideByReferenceName,
   renderStringFormatOverrideImports,
 } from "./format-overrides.js";
+import { PARAMETER_SCHEMA_BUNDLE_FILE_NAME } from "../shared/parameter-schema-bundle.js";
 import { generateParameterSchemas } from "../shared/parameter-schemas.js";
 import { sanitizeIdentifier } from "./utils.js";
 
@@ -25,8 +26,6 @@ interface ParameterSchemaSectionResult {
   content: string;
   typeImports: Set<string>;
 }
-
-const PARAMETER_SCHEMA_BUNDLE_FILE_NAME = "parameters.ts";
 
 /**
  * Generates Zod schema content for a single operation.

--- a/packages/core-utils/src/shared/index.ts
+++ b/packages/core-utils/src/shared/index.ts
@@ -5,6 +5,7 @@ export * from "./models/request-body-models.js";
 export * from "./models/security-models.js";
 export * from "./operation-extractor.js";
 export * from "./operation-utils.js";
+export * from "./parameter-schema-bundle.js";
 export * from "./parameter-schemas.js";
 export * from "./parameter-utils.js";
 export * from "./request-body-maps.js";

--- a/packages/core-utils/src/shared/parameter-schema-bundle.ts
+++ b/packages/core-utils/src/shared/parameter-schema-bundle.ts
@@ -1,0 +1,12 @@
+/*
+ * Keep the bundled parameter schema module in snake_case so it cannot collide
+ * with user schema modules, which are generated via sanitizeIdentifier().
+ */
+export const PARAMETER_SCHEMA_BUNDLE_BASE_NAME =
+  "__apical_generated_parameters";
+
+export const PARAMETER_SCHEMA_BUNDLE_FILE_NAME = `${PARAMETER_SCHEMA_BUNDLE_BASE_NAME}.ts`;
+
+export const LEGACY_PARAMETER_SCHEMA_BUNDLE_FILE_NAMES = [
+  "parameters.ts",
+] as const;

--- a/packages/core-utils/tests/core-generator/schema-generation-coordinator.test.ts
+++ b/packages/core-utils/tests/core-generator/schema-generation-coordinator.test.ts
@@ -7,6 +7,10 @@ import {
   generateFallbackSchemaContent,
   generateSchemas,
 } from "../../src/core-generator/schema-generation-coordinator.js";
+import {
+  PARAMETER_SCHEMA_BUNDLE_BASE_NAME,
+  PARAMETER_SCHEMA_BUNDLE_FILE_NAME,
+} from "../../src/shared/parameter-schema-bundle.js";
 
 describe("core-generator schema-generation-coordinator", () => {
   describe("generateFallbackSchemaContent", () => {
@@ -26,7 +30,7 @@ describe("core-generator schema-generation-coordinator", () => {
   });
 
   describe("generateSchemas", () => {
-    it("bundles operation parameter schemas into a single module", async () => {
+    it("bundles operation parameter schemas without shadowing schema files", async () => {
       const outputDir = path.join(
         process.cwd(),
         "tests",
@@ -89,6 +93,14 @@ describe("core-generator schema-generation-coordinator", () => {
                 PetId: {
                   type: "string",
                 },
+                parameters: {
+                  properties: {
+                    value: {
+                      type: "string",
+                    },
+                  },
+                  type: "object",
+                },
               },
             },
           },
@@ -101,7 +113,7 @@ describe("core-generator schema-generation-coordinator", () => {
         const schemasDir = path.join(outputDir, "schemas");
         const files = await fs.readdir(schemasDir);
         const bundledParameters = await fs.readFile(
-          path.join(schemasDir, "parameters.ts"),
+          path.join(schemasDir, PARAMETER_SCHEMA_BUNDLE_FILE_NAME),
           "utf-8",
         );
         const indexContent = await fs.readFile(
@@ -109,6 +121,7 @@ describe("core-generator schema-generation-coordinator", () => {
           "utf-8",
         );
 
+        expect(files).toContain(PARAMETER_SCHEMA_BUNDLE_FILE_NAME);
         expect(files).toContain("parameters.ts");
         expect(files).not.toContain("listPetsParameters.ts");
         expect(files).not.toContain("getPetByIdParameters.ts");
@@ -127,9 +140,79 @@ describe("core-generator schema-generation-coordinator", () => {
           "export const pingServerParsedParams = z.object({});",
         );
 
-        expect(indexContent).toContain(`} from "./parameters.js";`);
+        expect(indexContent).toContain(
+          `import { parameters } from "./parameters.js";`,
+        );
+        expect(indexContent).toContain(
+          `} from "./${PARAMETER_SCHEMA_BUNDLE_BASE_NAME}.js";`,
+        );
         expect(indexContent).toContain("listPetsQuerySchema");
         expect(indexContent).toContain("getPetByIdPathSchema");
+        expect(indexContent).toContain("parameters");
+      } finally {
+        await fs.rm(outputDir, { force: true, recursive: true });
+      }
+    });
+
+    it("removes the legacy parameter bundle when regenerating schemas", async () => {
+      const outputDir = path.join(
+        process.cwd(),
+        "tests",
+        ".schema-generation-coordinator-output",
+      );
+      const schemasDir = path.join(outputDir, "schemas");
+
+      await fs.rm(outputDir, { force: true, recursive: true });
+      await fs.mkdir(schemasDir, { recursive: true });
+      await fs.writeFile(
+        path.join(schemasDir, "parameters.ts"),
+        'export const stale = "legacy bundle";\n',
+      );
+
+      try {
+        await generateSchemas(
+          {
+            info: {
+              title: "legacy parameter bundle cleanup test",
+              version: "1.0.0",
+            },
+            openapi: "3.1.0",
+            paths: {
+              "/pets": {
+                get: {
+                  operationId: "listPets",
+                  parameters: [
+                    {
+                      in: "query",
+                      name: "status",
+                      schema: { type: "string" },
+                    },
+                  ],
+                  responses: {
+                    200: { description: "OK" },
+                  },
+                },
+              },
+            },
+          },
+          outputDir,
+          1,
+          false,
+          "strip",
+        );
+
+        const files = await fs.readdir(schemasDir);
+        const indexContent = await fs.readFile(
+          path.join(schemasDir, "index.ts"),
+          "utf-8",
+        );
+
+        expect(files).toContain(PARAMETER_SCHEMA_BUNDLE_FILE_NAME);
+        expect(files).not.toContain("parameters.ts");
+        expect(indexContent).not.toContain(`from "./parameters.js";`);
+        expect(indexContent).toContain(
+          `} from "./${PARAMETER_SCHEMA_BUNDLE_BASE_NAME}.js";`,
+        );
       } finally {
         await fs.rm(outputDir, { force: true, recursive: true });
       }

--- a/packages/core-utils/tests/core-generator/schema-generation-coordinator.test.ts
+++ b/packages/core-utils/tests/core-generator/schema-generation-coordinator.test.ts
@@ -1,6 +1,12 @@
+import { promises as fs } from "fs";
+import path from "path";
+
 import { describe, expect, it } from "vitest";
 
-import { generateFallbackSchemaContent } from "../../src/core-generator/schema-generation-coordinator.js";
+import {
+  generateFallbackSchemaContent,
+  generateSchemas,
+} from "../../src/core-generator/schema-generation-coordinator.js";
 
 describe("core-generator schema-generation-coordinator", () => {
   describe("generateFallbackSchemaContent", () => {
@@ -16,6 +22,117 @@ describe("core-generator schema-generation-coordinator", () => {
 
       expect(result).toContain("export const AllowNothing = z.never();");
       expect(result).not.toContain("z.unknown()");
+    });
+  });
+
+  describe("generateSchemas", () => {
+    it("bundles operation parameter schemas into a single module", async () => {
+      const outputDir = path.join(
+        process.cwd(),
+        "tests",
+        ".schema-generation-coordinator-output",
+      );
+
+      await fs.rm(outputDir, { force: true, recursive: true });
+
+      try {
+        await generateSchemas(
+          {
+            info: {
+              title: "parameter bundle test",
+              version: "1.0.0",
+            },
+            openapi: "3.1.0",
+            paths: {
+              "/pets": {
+                get: {
+                  operationId: "listPets",
+                  parameters: [
+                    {
+                      in: "query",
+                      name: "status",
+                      schema: { type: "string" },
+                    },
+                  ],
+                  responses: {
+                    200: { description: "OK" },
+                  },
+                },
+              },
+              "/pets/{petId}": {
+                get: {
+                  operationId: "getPetById",
+                  parameters: [
+                    {
+                      in: "path",
+                      name: "petId",
+                      required: true,
+                      schema: { $ref: "#/components/schemas/PetId" },
+                    },
+                  ],
+                  responses: {
+                    200: { description: "OK" },
+                  },
+                },
+              },
+              "/ping": {
+                get: {
+                  operationId: "ping",
+                  responses: {
+                    200: { description: "OK" },
+                  },
+                },
+              },
+            },
+            components: {
+              schemas: {
+                PetId: {
+                  type: "string",
+                },
+              },
+            },
+          },
+          outputDir,
+          1,
+          false,
+          "strip",
+        );
+
+        const schemasDir = path.join(outputDir, "schemas");
+        const files = await fs.readdir(schemasDir);
+        const bundledParameters = await fs.readFile(
+          path.join(schemasDir, "parameters.ts"),
+          "utf-8",
+        );
+        const indexContent = await fs.readFile(
+          path.join(schemasDir, "index.ts"),
+          "utf-8",
+        );
+
+        expect(files).toContain("parameters.ts");
+        expect(files).not.toContain("listPetsParameters.ts");
+        expect(files).not.toContain("getPetByIdParameters.ts");
+        expect(files).not.toContain("pingParameters.ts");
+
+        expect(bundledParameters).toContain(`import * as z from "zod";`);
+        expect(bundledParameters).toContain(
+          `import { PetId } from "./PetId.js";`,
+        );
+        expect(bundledParameters).toContain("export { listPetsQuerySchema };");
+        expect(bundledParameters).toContain("export { getPetByIdPathSchema };");
+        expect(bundledParameters).toContain(
+          "export const pingParsedParams = z.object({});",
+        );
+        expect(bundledParameters).toContain(
+          "export const pingServerParsedParams = z.object({});",
+        );
+
+        expect(indexContent).toContain(`} from "./parameters.js";`);
+        expect(indexContent).toContain("listPetsQuerySchema");
+        expect(indexContent).toContain("getPetByIdPathSchema");
+      } finally {
+        await fs.rm(outputDir, { force: true, recursive: true });
+      }
     });
   });
 });

--- a/packages/route-generator/src/templates/route-metadata-templates.ts
+++ b/packages/route-generator/src/templates/route-metadata-templates.ts
@@ -54,7 +54,7 @@ export function renderRouteMetadata(
     ? `import {
   ${parsedParamsName},
   ${serverParsedParamsName},
-} from "../schemas/${sanitizedId}Parameters.js";`
+} from "../schemas/parameters.js";`
     : "";
 
   /* Build request/response maps if needed */

--- a/packages/route-generator/src/templates/route-metadata-templates.ts
+++ b/packages/route-generator/src/templates/route-metadata-templates.ts
@@ -1,4 +1,5 @@
 import { sanitizeIdentifier } from "@apical-ts/core-utils";
+import { PARAMETER_SCHEMA_BUNDLE_BASE_NAME } from "@apical-ts/core-utils/shared";
 
 /**
  * Template parameters for route metadata generation
@@ -54,7 +55,7 @@ export function renderRouteMetadata(
     ? `import {
   ${parsedParamsName},
   ${serverParsedParamsName},
-} from "../schemas/parameters.js";`
+} from "../schemas/${PARAMETER_SCHEMA_BUNDLE_BASE_NAME}.js";`
     : "";
 
   /* Build request/response maps if needed */

--- a/packages/route-generator/tests/route-metadata-generator.test.ts
+++ b/packages/route-generator/tests/route-metadata-generator.test.ts
@@ -51,6 +51,7 @@ describe("route metadata generator", () => {
     expect(result.routeCode).toContain(
       "export type petFindByStatusRouteResponse =",
     );
+    expect(result.routeCode).toContain(`from "../schemas/parameters.js";`);
     expect(result.routeCode).not.toContain(
       "export type petFindByStatusResponse =",
     );

--- a/packages/route-generator/tests/route-metadata-generator.test.ts
+++ b/packages/route-generator/tests/route-metadata-generator.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { generateRouteMetadata } from "../src/index.js";
 
+const parameterSchemaBundleBaseName = "__apical_generated_parameters";
+
 describe("route metadata generator", () => {
   it("avoids response type name collisions with imported schemas", () => {
     const result = generateRouteMetadata(
@@ -51,7 +53,9 @@ describe("route metadata generator", () => {
     expect(result.routeCode).toContain(
       "export type petFindByStatusRouteResponse =",
     );
-    expect(result.routeCode).toContain(`from "../schemas/parameters.js";`);
+    expect(result.routeCode).toContain(
+      `from "../schemas/${parameterSchemaBundleBaseName}.js";`,
+    );
     expect(result.routeCode).not.toContain(
       "export type petFindByStatusResponse =",
     );


### PR DESCRIPTION
## Summary
- Bundle generated operation parameter schemas into `schemas/parameters.ts` instead of per-operation parameter files.
- Update schema index generation and route metadata imports to use the bundled parameter schema module.
- Add regression coverage for bundled parameter schema generation and route metadata imports.

## Measured savings
- total files 18,404 -> 15,518 (-2,886)
- wall 5763.30 ms -> 5296.48 ms (-8.1%)

## Note
- `routes/` and `client/` remain separate while parameter schemas move into `schemas/parameters.ts`.