### PR TITLE
Reuse shared operation metadata across client and route generation

### DIFF
--- a/apps/craft/src/generate.ts
+++ b/apps/craft/src/generate.ts
@@ -6,6 +6,7 @@ import type {
 import type { OpenAPIObject } from "openapi3-ts/oas31";
 
 import { generateOperations } from "@apical-ts/client-generator";
+import { extractAllOperationGenerationMetadata } from "@apical-ts/core-utils/shared";
 import {
   applyGeneratedOperationIds,
   convertToOpenAPI31,
@@ -148,12 +149,26 @@ async function generateAllOperations(
   profiler?: Profiler,
 ): Promise<void> {
   const operationPromises: Promise<void>[] = [];
+  let operationMetadata:
+    | ReturnType<typeof extractAllOperationGenerationMetadata>
+    | undefined;
+
+  if (generateRoutes || generateClient || generateServer) {
+    profiler?.start("operation-metadata");
+    operationMetadata = extractAllOperationGenerationMetadata(openApiDoc);
+    profiler?.end("operation-metadata");
+  }
 
   /* Generate routes if explicitly requested or if client/server is enabled */
   if (generateRoutes || generateClient || generateServer) {
     profiler?.start("routes");
     operationPromises.push(
-      generateRouteMetadata(openApiDoc, output, concurrency).finally(() => {
+      generateRouteMetadata(
+        openApiDoc,
+        output,
+        concurrency,
+        operationMetadata,
+      ).finally(() => {
         profiler?.end("routes");
       }),
     );
@@ -162,7 +177,12 @@ async function generateAllOperations(
   if (generateClient) {
     profiler?.start("client-operations");
     operationPromises.push(
-      generateOperations(openApiDoc, output, concurrency).finally(() => {
+      generateOperations(
+        openApiDoc,
+        output,
+        concurrency,
+        operationMetadata,
+      ).finally(() => {
         profiler?.end("client-operations");
       }),
     );

--- a/apps/craft/src/generate.ts
+++ b/apps/craft/src/generate.ts
@@ -148,31 +148,27 @@ async function generateAllOperations(
   generateServer: boolean,
   profiler?: Profiler,
 ): Promise<void> {
-  const operationPromises: Promise<void>[] = [];
-  let operationMetadata:
-    | ReturnType<typeof extractAllOperationGenerationMetadata>
-    | undefined;
-
-  if (generateRoutes || generateClient || generateServer) {
-    profiler?.start("operation-metadata");
-    operationMetadata = extractAllOperationGenerationMetadata(openApiDoc);
-    profiler?.end("operation-metadata");
+  if (!generateRoutes && !generateClient && !generateServer) {
+    return;
   }
+
+  const operationPromises: Promise<void>[] = [];
+  profiler?.start("operation-metadata");
+  const operationMetadata = extractAllOperationGenerationMetadata(openApiDoc);
+  profiler?.end("operation-metadata");
 
   /* Generate routes if explicitly requested or if client/server is enabled */
-  if (generateRoutes || generateClient || generateServer) {
-    profiler?.start("routes");
-    operationPromises.push(
-      generateRouteMetadata(
-        openApiDoc,
-        output,
-        concurrency,
-        operationMetadata,
-      ).finally(() => {
-        profiler?.end("routes");
-      }),
-    );
-  }
+  profiler?.start("routes");
+  operationPromises.push(
+    generateRouteMetadata(
+      openApiDoc,
+      output,
+      concurrency,
+      operationMetadata,
+    ).finally(() => {
+      profiler?.end("routes");
+    }),
+  );
 
   if (generateClient) {
     profiler?.start("client-operations");

--- a/apps/craft/tests/integrations/readonly-writeonly-integration.test.ts
+++ b/apps/craft/tests/integrations/readonly-writeonly-integration.test.ts
@@ -50,10 +50,18 @@ describe("ReadOnly/WriteOnly Integration Tests", () => {
        */
       const client = createUnauthenticatedClient(baseURL);
 
+      void ({
+        body: {
+          // @ts-expect-error readOnly properties are excluded from request bodies
+          id: "test-id",
+          username: "testuser",
+          email: "test@example.com",
+        },
+      } satisfies Parameters<typeof client.createUserReadOnly>[0]);
+
       /* Act - call with only non-readOnly properties */
       const response = await client.createUserReadOnly({
         body: {
-          id: "test-id",
           username: "testuser",
           email: "test@example.com",
         },
@@ -120,10 +128,20 @@ describe("ReadOnly/WriteOnly Integration Tests", () => {
        */
       const client = createUnauthenticatedClient(baseURL);
 
+      void ({
+        body: {
+          // @ts-expect-error readOnly properties are excluded from request bodies
+          id: "test-id",
+          username: "testuser",
+          email: "test@example.com",
+          password: "secret123",
+          secretToken: "token-abc-123",
+        },
+      } satisfies Parameters<typeof client.createUserBoth>[0]);
+
       /* Act - call with only request-valid properties */
       const response = await client.createUserBoth({
         body: {
-          id: "test-id",
           username: "testuser",
           email: "test@example.com",
           password: "secret123",
@@ -139,10 +157,19 @@ describe("ReadOnly/WriteOnly Integration Tests", () => {
       /* Arrange */
       const client = createUnauthenticatedClient(baseURL);
 
+      void ({
+        body: {
+          // @ts-expect-error readOnly properties are excluded from request bodies
+          id: "test-id",
+          username: "updateduser",
+          email: "updated@example.com",
+          password: "newpassword123",
+        },
+      } satisfies Parameters<typeof client.updateUserBoth>[0]);
+
       /* Act */
       const response = await client.updateUserBoth({
         body: {
-          id: "test-id",
           username: "updateduser",
           email: "updated@example.com",
           password: "newpassword123",

--- a/packages/client-generator/src/index.ts
+++ b/packages/client-generator/src/index.ts
@@ -1,9 +1,12 @@
-import type { OperationMetadata } from "@apical-ts/core-utils/shared";
+import type {
+  OperationGenerationMetadata,
+  OperationMetadata,
+} from "@apical-ts/core-utils/shared";
 import type { OpenAPIObject } from "openapi3-ts/oas31";
 
-import { extractAllOperations } from "@apical-ts/core-utils/shared";
 import { extractServerUrls } from "@apical-ts/core-utils/shared";
 import { extractAuthHeaders } from "@apical-ts/core-utils/shared";
+import { extractAllOperationGenerationMetadata } from "@apical-ts/core-utils/shared";
 import pLimit from "p-limit";
 
 import {
@@ -12,7 +15,7 @@ import {
   writeIndexFile,
   writeOperationFile,
 } from "./file-writer.js";
-import { generateOperationFunction } from "./operation-function-generator.js";
+import { generateOperationFunctionFromMetadata } from "./operation-function-generator.js";
 
 /**
  * Generates individual operation files and configuration
@@ -21,6 +24,7 @@ export async function generateOperations(
   doc: OpenAPIObject,
   outputDir: string,
   concurrency: number,
+  operationMetadata = extractAllOperationGenerationMetadata(doc),
 ): Promise<void> {
   const operationsDir = await createOperationsDirectory(outputDir);
 
@@ -29,7 +33,12 @@ export async function generateOperations(
   const serverUrls = extractServerUrls(doc);
 
   // Process all operations and write files
-  const operations = await processOperations(doc, operationsDir, concurrency);
+  const operations = await processOperations(
+    doc,
+    operationsDir,
+    concurrency,
+    operationMetadata,
+  );
 
   // Write configuration file
   await writeConfigFile(authHeaders, serverUrls, operationsDir);
@@ -45,29 +54,18 @@ async function processOperations(
   doc: OpenAPIObject,
   operationsDir: string,
   concurrency: number,
+  operationMetadata: OperationGenerationMetadata[],
 ): Promise<OperationMetadata[]> {
-  const operations = extractAllOperations(doc);
   const limit = pLimit(concurrency);
   const operationPromises: Promise<void>[] = [];
 
-  for (const {
-    method,
-    operation,
-    operationId,
-    pathKey,
-    pathLevelParameters,
-  } of operations) {
+  for (const metadata of operationMetadata) {
     const promise = limit(async () => {
-      const { functionCode, importManager } = generateOperationFunction(
-        pathKey,
-        method,
-        operation,
-        pathLevelParameters,
-        doc,
-      );
+      const { functionCode, importManager } =
+        generateOperationFunctionFromMetadata(metadata, doc);
 
       await writeOperationFile(
-        operationId,
+        metadata.operationId,
         functionCode,
         importManager,
         operationsDir,
@@ -77,7 +75,7 @@ async function processOperations(
   }
 
   await Promise.all(operationPromises);
-  return operations;
+  return operationMetadata;
 }
 
 export {

--- a/packages/client-generator/src/operation-function-generator.ts
+++ b/packages/client-generator/src/operation-function-generator.ts
@@ -5,16 +5,14 @@ import type {
   ReferenceObject,
 } from "openapi3-ts/oas31";
 
-import { ImportManager } from "@apical-ts/core-utils";
-import { sanitizeIdentifier } from "@apical-ts/core-utils";
-import { generateContentTypeMaps } from "@apical-ts/core-utils/shared";
-import { extractParameterGroups } from "@apical-ts/core-utils/shared";
+import { ImportManager, sanitizeIdentifier } from "@apical-ts/core-utils";
 import {
   extractAuthHeaders,
-  getOperationSecuritySchemes,
-  hasSecurityOverride,
+  extractOperationGenerationMetadata,
+  type OperationGenerationMetadata,
+  type ParameterGroups,
+  type SecurityHeader,
 } from "@apical-ts/core-utils/shared";
-import assert from "assert";
 import { isReferenceObject } from "openapi3-ts/oas31";
 
 import type { OperationMetadata } from "./templates/operation-templates.js";
@@ -36,6 +34,14 @@ interface GeneratedFunction {
   importManager: ImportManager;
 }
 
+interface BodyAndContentTypesConfig {
+  doc: OpenAPIObject;
+  functionName: string;
+  operation: OperationObject;
+  operationName: string;
+  sharedBodyInfo: OperationGenerationMetadata["bodyInfo"];
+}
+
 /**
  * extractOperationMetadata
  * Pure function that extracts and assembles all metadata needed for generating an operation function.
@@ -49,69 +55,128 @@ export function extractOperationMetadata(
   pathLevelParameters: (ParameterObject | ReferenceObject)[] = [],
   doc: OpenAPIObject,
 ): OperationMetadata {
-  assert(operation.operationId, "Operation ID is required");
-  const functionName: string = sanitizeIdentifier(operation.operationId);
-  const operationName =
-    functionName.charAt(0).toUpperCase() + functionName.slice(1);
+  const sharedMetadata = extractOperationGenerationMetadata({
+    doc,
+    method,
+    operation,
+    pathKey,
+    pathLevelParameters,
+  });
+
+  return createOperationMetadata(sharedMetadata, doc);
+}
+
+export function generateOperationFunctionFromMetadata(
+  sharedMetadata: OperationGenerationMetadata,
+  doc: OpenAPIObject,
+): GeneratedFunction {
+  const metadata = createOperationMetadata(sharedMetadata, doc);
+
+  /* Render using template functions */
+  const parameterDeclaration = buildParameterDeclaration({
+    destructuredParams: metadata.parameterStructures.destructuredParams,
+    paramsInterface: metadata.parameterStructures.paramsInterface,
+    shouldDefaultParams: metadata.shouldDefaultParams,
+  });
+
+  /* Compute generic parameters and adjust return type if response map present */
+  const { genericParams, updatedReturnType } = buildGenericParams({
+    contentTypeMaps: metadata.bodyInfo.contentTypeMaps,
+    initialReturnType: metadata.responseHandlers.returnType,
+    requestMapTypeName: metadata.bodyInfo.requestMapTypeName,
+    responseMapTypeName: metadata.bodyInfo.responseMapTypeName,
+    shouldGenerateRequestMap: metadata.bodyInfo.shouldGenerateRequestMap,
+    shouldGenerateResponseMap: metadata.bodyInfo.shouldGenerateResponseMap,
+  });
+
+  /* Emit request/response map type aliases (only when non-empty / applicable) */
+  const typeAliases = buildTypeAliasesFromRoute({
+    bodyTypeName: metadata.bodyInfo.bodyTypeInfo?.typeName ?? undefined,
+    contentTypeMaps: metadata.bodyInfo.contentTypeMaps,
+    hasBody: metadata.hasBody,
+    hasHeaderParams:
+      metadata.parameterGroups.headerParams.length > 0 ||
+      metadata.operationSecurityHeaders.length > 0,
+    hasPathParams: metadata.parameterGroups.pathParams.length > 0,
+    hasQueryParams: metadata.parameterGroups.queryParams.length > 0,
+    hasRequestMap: metadata.bodyInfo.shouldGenerateRequestMap,
+    hasResponseMap: metadata.bodyInfo.shouldGenerateResponseMap,
+    importManager: metadata.importManager,
+    isBodyOptional:
+      !metadata.hasBody || !metadata.bodyInfo.bodyTypeInfo?.isRequired,
+    isHeadersOptional: metadata.isHeadersOptional,
+    isQueryOptional: metadata.isQueryOptional,
+    operationId: sharedMetadata.operationId,
+    requestMapTypeName: metadata.bodyInfo.requestMapTypeName,
+    responseMapTypeName: metadata.bodyInfo.responseMapTypeName,
+    shouldGenerateRequestMap: metadata.bodyInfo.shouldGenerateRequestMap,
+    shouldGenerateResponseMap: metadata.bodyInfo.shouldGenerateResponseMap,
+  });
+
+  /* Render the complete function */
+  const functionStr = renderOperationFunction({
+    canOmitParams: metadata.shouldDefaultParams,
+    functionBodyCode: metadata.functionBodyCode,
+    functionName: metadata.functionName,
+    genericParams,
+    parameterDeclaration,
+    parameterInterface: metadata.parameterStructures.paramsInterface,
+    responseMapTypeName: metadata.bodyInfo.shouldGenerateResponseMap
+      ? metadata.bodyInfo.responseMapTypeName
+      : undefined,
+    summary: metadata.summary,
+    typeAliases,
+    updatedReturnType,
+  });
+
+  return {
+    functionCode: functionStr,
+    importManager: metadata.importManager,
+  };
+}
+
+function createOperationMetadata(
+  sharedMetadata: OperationGenerationMetadata,
+  doc: OpenAPIObject,
+): OperationMetadata {
+  const {
+    bodyInfo: sharedBodyInfo,
+    functionName,
+    method,
+    operation,
+    operationId,
+    operationName,
+    operationSecurityHeaders,
+    overridesSecurity,
+    parameterGroups,
+    parameterInfo,
+    pathKey,
+  } = sharedMetadata;
 
   const summary = operation.summary ? `/** ${operation.summary} */\n` : "";
   const importManager = new ImportManager();
-  // Create a temporary Set for legacy response functions
   const responseTypeImports = new Set<string>();
 
-  /* Extract parameters & security */
-  const parameterGroups = extractParameterGroups(
-    operation,
-    pathLevelParameters,
+  const bodyInfo = collectBodyAndContentTypes({
     doc,
-  );
-  const hasRequestBody = !!operation.requestBody;
-  const operationSecurityHeaders = getOperationSecuritySchemes(operation, doc);
-
-  /* Body & content type meta */
-  /* Collect body related type info + request/response content-type maps (if any) */
-  const bodyInfo = collectBodyAndContentTypes(
-    hasRequestBody,
-    operation,
     functionName,
-    importManager,
+    operation,
     operationName,
-    doc,
-  );
+    sharedBodyInfo,
+  });
+  const hasBody =
+    sharedBodyInfo.hasRequestBody && bodyInfo.requestContentTypes.length > 0;
 
-  /* Refine: body is only present when request body has actual content types */
-  const hasBody = hasRequestBody && bodyInfo.requestContentTypes.length > 0;
-
-  /* Build parameter shapes */
-  /* Build the "first parameter" surface: destructured runtime parameter object + its TS interface */
   const parameterStructures = buildParameterStructures(
     parameterGroups,
     hasBody,
     bodyInfo.bodyTypeInfo,
     operationSecurityHeaders,
     bodyInfo.shouldGenerateRequestMap,
-    bodyInfo.shouldGenerateResponseMap, // This controls generic params, keep as false for unknown mode
+    bodyInfo.shouldGenerateResponseMap,
     bodyInfo.requestMapTypeName,
     bodyInfo.responseMapTypeName,
-    operation.operationId,
-  );
-
-  /*
-   * Calculate if headers are optional for TypeScript types
-   * Headers are optional only if ALL explicit header params AND security headers are optional.
-   * If any header is required, the headers object must be provided in params OR config.
-   * Runtime code merges from both sources, but types enforce presence.
-   */
-  const hasRequiredSecurityHeader = operationSecurityHeaders.some(
-    (sh) => sh.isRequired,
-  );
-  const isHeadersOptional =
-    parameterGroups.headerParams.every((p) => p.required !== true) &&
-    !hasRequiredSecurityHeader;
-
-  /* Calculate if query is optional */
-  const isQueryOptional = parameterGroups.queryParams.every(
-    (p) => p.required !== true,
+    operationId,
   );
 
   const hasSurfaceParams =
@@ -125,19 +190,13 @@ export function extractOperationMetadata(
   const shouldDefaultParams =
     hasSurfaceParams &&
     parameterGroups.pathParams.length === 0 &&
-    isQueryOptional &&
-    isHeadersOptional &&
+    parameterInfo.isQueryOptional &&
+    parameterInfo.isHeadersOptional &&
     !isBodyRequired;
 
-  /* Parameter schemas removed: parameters are available through clientRoute.params from routes */
-
-  /* Responses & union return type */
-  /* Build response handlers + discriminated union return type (ApiResponse<code, data>) */
-  /* Pass camelCase runtime value name for response map access */
   const responseMapRuntimeName = bodyInfo.shouldExportResponseMap
-    ? sanitizeIdentifier(operation.operationId) + "ResponseMap"
+    ? `${functionName}ResponseMap`
     : undefined;
-
   const responseHandlers = generateResponseHandlers(
     operation,
     responseTypeImports,
@@ -146,13 +205,7 @@ export function extractOperationMetadata(
     doc,
   );
 
-  // Schema imports removed: schemas are available through route imports
-
-  /* Security overrides/auth headers */
-  const overridesSecurity = hasSecurityOverride(operation);
   const authHeaders = extractAuthHeaders(doc);
-
-  /* Generate default response handler if there is a default response */
   const defaultResponseHandler = responseHandlers.defaultResponseInfo
     ? renderDefaultResponseHandler(
         responseHandlers.defaultResponseInfo,
@@ -162,8 +215,6 @@ export function extractOperationMetadata(
       )
     : undefined;
 
-  /* Function internal body code */
-  /* Assemble the inner imperative body (headers, fetch call, switch over request content-type, parsing) */
   const functionBodyCode = generateFunctionBody({
     authHeaders,
     contentTypeMaps: bodyInfo.contentTypeMaps,
@@ -187,8 +238,8 @@ export function extractOperationMetadata(
     functionName,
     hasBody,
     importManager,
-    isHeadersOptional,
-    isQueryOptional,
+    isHeadersOptional: parameterInfo.isHeadersOptional,
+    isQueryOptional: parameterInfo.isQueryOptional,
     operationName,
     operationSecurityHeaders,
     overridesSecurity,
@@ -228,76 +279,15 @@ export function generateOperationFunction(
     );
   }
 
-  /* Extract all metadata using pure logic function */
-  const metadata = extractOperationMetadata(
-    pathKey,
+  const sharedMetadata = extractOperationGenerationMetadata({
+    doc,
     method,
     operation,
+    pathKey,
     pathLevelParameters,
-    doc,
-  );
-
-  /* Render using template functions */
-  const parameterDeclaration = buildParameterDeclaration({
-    destructuredParams: metadata.parameterStructures.destructuredParams,
-    paramsInterface: metadata.parameterStructures.paramsInterface,
-    shouldDefaultParams: metadata.shouldDefaultParams,
   });
 
-  /* Compute generic parameters and adjust return type if response map present */
-  const { genericParams, updatedReturnType } = buildGenericParams({
-    contentTypeMaps: metadata.bodyInfo.contentTypeMaps,
-    initialReturnType: metadata.responseHandlers.returnType,
-    requestMapTypeName: metadata.bodyInfo.requestMapTypeName,
-    responseMapTypeName: metadata.bodyInfo.responseMapTypeName,
-    shouldGenerateRequestMap: metadata.bodyInfo.shouldGenerateRequestMap,
-    shouldGenerateResponseMap: metadata.bodyInfo.shouldGenerateResponseMap,
-  });
-
-  /* Emit request/response map type aliases (only when non-empty / applicable) */
-  const typeAliases = buildTypeAliasesFromRoute({
-    bodyTypeName: metadata.bodyInfo.bodyTypeInfo?.typeName ?? undefined,
-    contentTypeMaps: metadata.bodyInfo.contentTypeMaps,
-    hasBody: metadata.hasBody,
-    hasHeaderParams:
-      metadata.parameterGroups.headerParams.length > 0 ||
-      metadata.operationSecurityHeaders.length > 0,
-    hasPathParams: metadata.parameterGroups.pathParams.length > 0,
-    hasQueryParams: metadata.parameterGroups.queryParams.length > 0,
-    hasRequestMap: metadata.bodyInfo.shouldGenerateRequestMap,
-    hasResponseMap: metadata.bodyInfo.shouldGenerateResponseMap,
-    importManager: metadata.importManager,
-    isBodyOptional:
-      !metadata.hasBody || !metadata.bodyInfo.bodyTypeInfo?.isRequired,
-    isHeadersOptional: metadata.isHeadersOptional,
-    isQueryOptional: metadata.isQueryOptional,
-    operationId: operation.operationId,
-    requestMapTypeName: metadata.bodyInfo.requestMapTypeName,
-    responseMapTypeName: metadata.bodyInfo.responseMapTypeName,
-    shouldGenerateRequestMap: metadata.bodyInfo.shouldGenerateRequestMap,
-    shouldGenerateResponseMap: metadata.bodyInfo.shouldGenerateResponseMap,
-  });
-
-  /* Render the complete function */
-  const functionStr = renderOperationFunction({
-    canOmitParams: metadata.shouldDefaultParams,
-    functionBodyCode: metadata.functionBodyCode,
-    functionName: metadata.functionName,
-    genericParams,
-    parameterDeclaration,
-    parameterInterface: metadata.parameterStructures.paramsInterface,
-    responseMapTypeName: metadata.bodyInfo.shouldGenerateResponseMap
-      ? metadata.bodyInfo.responseMapTypeName
-      : undefined,
-    summary: metadata.summary,
-    typeAliases,
-    updatedReturnType,
-  });
-
-  return {
-    functionCode: functionStr,
-    importManager: metadata.importManager,
-  };
+  return generateOperationFunctionFromMetadata(sharedMetadata, doc);
 }
 
 /* ---------------- Helper extraction functions (kept local to module) ---------------- */
@@ -308,10 +298,10 @@ export function generateOperationFunction(
  * The interface type name is derived from the operation ID and matches the type alias generated in routes.
  */
 function buildParameterStructures(
-  parameterGroups: ReturnType<typeof extractParameterGroups>,
+  parameterGroups: ParameterGroups,
   hasBody: boolean,
   bodyTypeInfo: ReturnType<typeof resolveRequestBodyType> | undefined,
-  operationSecurityHeaders: ReturnType<typeof getOperationSecuritySchemes>,
+  operationSecurityHeaders: SecurityHeader[],
   shouldGenerateRequestMap: boolean,
   shouldGenerateResponseMap: boolean,
   requestMapTypeName: string,
@@ -362,78 +352,38 @@ function buildParameterStructures(
  * shouldGenerateResponseMap: true when response map has entries (non-empty {}).
  * Returns an object with everything needed downstream (maps, defaults, flags, imports augmented).
  */
-function collectBodyAndContentTypes(
-  hasBody: boolean,
-  operation: OperationObject,
-  functionName: string,
-  importManager: ImportManager,
-  operationName: string,
-  doc: OpenAPIObject,
-) {
+function collectBodyAndContentTypes({
+  doc,
+  functionName,
+  operation,
+  operationName,
+  sharedBodyInfo,
+}: BodyAndContentTypesConfig) {
   let bodyTypeInfo: ReturnType<typeof resolveRequestBodyType> | undefined;
   let requestContentType: string | undefined;
 
   if (
-    hasBody &&
+    sharedBodyInfo.hasRequestBody &&
     operation.requestBody &&
     !isReferenceObject(operation.requestBody)
   ) {
-    const requestBody = operation.requestBody;
     bodyTypeInfo = resolveRequestBodyType(
-      requestBody,
+      operation.requestBody,
       functionName,
       doc.components?.schemas,
     );
     requestContentType = bodyTypeInfo.contentType;
-    /* Schema imports removed: available through route imports */
   }
-
-  const requestMapTypeName = `${operationName}RequestMap`;
-  const responseMapTypeName = `${operationName}ResponseMap`;
-
-  const contentTypeMaps = generateContentTypeMaps(operation, doc);
-  /* Schema imports removed: available through route imports */
-
-  let requestContentTypes: string[] = [];
-  if (
-    hasBody &&
-    operation.requestBody &&
-    !isReferenceObject(operation.requestBody)
-  ) {
-    const requestBody = operation.requestBody;
-    if (requestBody.content) {
-      requestContentTypes = Object.keys(requestBody.content);
-    }
-  }
-
-  // Request map only meaningful when there is a body and at least one content-type mapping generated.
-  const shouldGenerateRequestMap =
-    hasBody &&
-    !!contentTypeMaps.requestMapType &&
-    contentTypeMaps.requestMapType !== "{}";
-  // A response map of '{}' means the operation has no concrete response content-type mappings.
-  // In that case we must NOT generate response content-type generics or attempt indexed lookup.
-  // (Previously this produced: TResponseContentType extends keyof {} = "application/json" -> error)
-  // Generate response map generics when we actually have concrete mappings.
-  // We still operate in "unknown" validation mode (parsing occurs lazily or via parse())
-  // but we need the ability to negotiate content types via Accept header for integration tests
-  // (e.g., multi-content-types selecting vendor or xml responses).
-  const shouldGenerateResponseMap = !!(
-    contentTypeMaps.responseMapType && contentTypeMaps.responseMapType !== "{}"
-  );
-  const shouldExportResponseMap =
-    !!contentTypeMaps.responseMapType &&
-    contentTypeMaps.responseMapType !== "{}";
 
   return {
     bodyTypeInfo,
-    contentTypeMaps,
+    contentTypeMaps: sharedBodyInfo.contentTypeMaps,
     requestContentType,
-    requestContentTypes,
-    requestMapTypeName,
-    responseMapTypeName,
-    shouldExportResponseMap,
-    shouldGenerateRequestMap,
-    shouldGenerateResponseMap,
+    requestContentTypes: sharedBodyInfo.requestContentTypes,
+    requestMapTypeName: `${operationName}RequestMap`,
+    responseMapTypeName: `${operationName}ResponseMap`,
+    shouldExportResponseMap: sharedBodyInfo.shouldGenerateResponseMap,
+    shouldGenerateRequestMap: sharedBodyInfo.shouldGenerateRequestMap,
+    shouldGenerateResponseMap: sharedBodyInfo.shouldGenerateResponseMap,
   };
 }

--- a/packages/core-utils/src/shared/index.ts
+++ b/packages/core-utils/src/shared/index.ts
@@ -3,6 +3,7 @@ export * from "./generated-operation-files.js";
 export * from "./models/parameter-models.js";
 export * from "./models/request-body-models.js";
 export * from "./models/security-models.js";
+export * from "./operation-generation-metadata.js";
 export * from "./operation-extractor.js";
 export * from "./operation-utils.js";
 export * from "./parameter-schemas.js";

--- a/packages/core-utils/src/shared/operation-generation-metadata.ts
+++ b/packages/core-utils/src/shared/operation-generation-metadata.ts
@@ -1,0 +1,196 @@
+import type {
+  OpenAPIObject,
+  OperationObject,
+  ParameterObject,
+  ReferenceObject,
+} from "openapi3-ts/oas31";
+
+import assert from "assert";
+import { isReferenceObject } from "openapi3-ts/oas31";
+
+import { sanitizeIdentifier } from "../schema-generator/utils.js";
+
+import type { ContentTypeMaps } from "./content-type-maps.js";
+import type { ParameterGroups } from "./models/parameter-models.js";
+import type { SecurityHeader } from "./models/security-models.js";
+import {
+  extractAllOperations,
+  type OperationMetadata,
+} from "./operation-extractor.js";
+import { extractParameterGroups } from "./parameter-utils.js";
+import {
+  generateRequestBodyMap,
+  type RequestBodyMapResult,
+} from "./request-body-maps.js";
+import {
+  generateResponseMap,
+  type ResponseMapResult,
+} from "./response-maps.js";
+import {
+  getOperationSecuritySchemes,
+  hasSecurityOverride,
+} from "./security-utils.js";
+
+export interface OperationBodyGenerationMetadata {
+  contentTypeMaps: ContentTypeMaps;
+  hasRequestBody: boolean;
+  requestBodyMap: RequestBodyMapResult;
+  requestContentTypes: string[];
+  responseMap: ResponseMapResult;
+  shouldGenerateRequestMap: boolean;
+  shouldGenerateResponseMap: boolean;
+}
+
+export interface OperationParameterInfo {
+  hasHeaders: boolean;
+  hasPath: boolean;
+  hasQuery: boolean;
+  isHeadersOptional: boolean;
+  isQueryOptional: boolean;
+}
+
+export interface OperationGenerationMetadata extends OperationMetadata {
+  bodyInfo: OperationBodyGenerationMetadata;
+  functionName: string;
+  operationName: string;
+  operationSecurityHeaders: SecurityHeader[];
+  overridesSecurity: boolean;
+  parameterGroups: ParameterGroups;
+  parameterInfo: OperationParameterInfo;
+}
+
+interface OperationGenerationMetadataConfig {
+  doc: OpenAPIObject;
+  method: string;
+  operation: OperationObject;
+  pathKey: string;
+  pathLevelParameters?: (ParameterObject | ReferenceObject)[];
+}
+
+export function extractAllOperationGenerationMetadata(
+  doc: OpenAPIObject,
+): OperationGenerationMetadata[] {
+  return extractAllOperations(doc).map(
+    ({ method, operation, pathKey, pathLevelParameters }) =>
+      extractOperationGenerationMetadata({
+        doc,
+        method,
+        operation,
+        pathKey,
+        pathLevelParameters,
+      }),
+  );
+}
+
+export function extractOperationGenerationMetadata({
+  doc,
+  method,
+  operation,
+  pathKey,
+  pathLevelParameters = [],
+}: OperationGenerationMetadataConfig): OperationGenerationMetadata {
+  assert(operation.operationId, "Operation ID is required");
+
+  const operationId = operation.operationId;
+  const functionName = sanitizeIdentifier(operationId);
+  const operationName =
+    functionName.charAt(0).toUpperCase() + functionName.slice(1);
+  const resolvedSchemas = doc.components?.schemas;
+
+  const requestBodyMap = generateRequestBodyMap(
+    operation,
+    operationId,
+    new Set<string>(),
+    resolvedSchemas,
+  );
+  const responseMap = generateResponseMap(
+    operation,
+    operationId,
+    new Set<string>(),
+    doc,
+    {},
+    resolvedSchemas,
+  );
+
+  const parameterGroups = extractParameterGroups(
+    operation,
+    pathLevelParameters,
+    doc,
+  );
+  const operationSecurityHeaders = getOperationSecuritySchemes(operation, doc);
+  const hasRequiredSecurityHeader = operationSecurityHeaders.some(
+    (securityHeader) => securityHeader.isRequired,
+  );
+  const isHeadersOptional =
+    parameterGroups.headerParams.every(
+      (parameter) => parameter.required !== true,
+    ) && !hasRequiredSecurityHeader;
+  const isQueryOptional = parameterGroups.queryParams.every(
+    (parameter) => parameter.required !== true,
+  );
+  const hasRequestBody = operation.requestBody !== undefined;
+
+  return {
+    bodyInfo: {
+      contentTypeMaps: createContentTypeMaps(requestBodyMap, responseMap),
+      hasRequestBody,
+      requestBodyMap,
+      requestContentTypes: extractRequestContentTypes(operation),
+      responseMap,
+      shouldGenerateRequestMap:
+        hasRequestBody && requestBodyMap.requestMapType !== "{}",
+      shouldGenerateResponseMap: responseMap.responseMapType !== "{}",
+    },
+    functionName,
+    method,
+    operation,
+    operationId,
+    operationName,
+    operationSecurityHeaders,
+    overridesSecurity: hasSecurityOverride(operation),
+    parameterGroups,
+    parameterInfo: {
+      hasHeaders:
+        parameterGroups.headerParams.length > 0 ||
+        operationSecurityHeaders.length > 0,
+      hasPath: parameterGroups.pathParams.length > 0,
+      hasQuery: parameterGroups.queryParams.length > 0,
+      isHeadersOptional,
+      isQueryOptional,
+    },
+    pathKey,
+    pathLevelParameters,
+  };
+}
+
+function createContentTypeMaps(
+  requestBodyMap: RequestBodyMapResult,
+  responseMap: ResponseMapResult,
+): ContentTypeMaps {
+  const typeImports = new Set<string>();
+
+  for (const typeImport of requestBodyMap.typeImports) {
+    typeImports.add(typeImport);
+  }
+  for (const typeImport of responseMap.typeImports) {
+    typeImports.add(typeImport);
+  }
+
+  return {
+    defaultRequestContentType: requestBodyMap.defaultContentType,
+    defaultResponseContentType: responseMap.defaultContentType,
+    requestContentTypeCount: requestBodyMap.contentTypeCount,
+    requestMapType: requestBodyMap.requestMapType,
+    responseContentTypeCount: responseMap.contentTypeCount,
+    responseMapType: responseMap.responseMapType,
+    typeImports,
+  };
+}
+
+function extractRequestContentTypes(operation: OperationObject): string[] {
+  if (!operation.requestBody || isReferenceObject(operation.requestBody)) {
+    return [];
+  }
+
+  return Object.keys(operation.requestBody.content ?? {});
+}

--- a/packages/core-utils/tests/shared/operation-generation-metadata.test.ts
+++ b/packages/core-utils/tests/shared/operation-generation-metadata.test.ts
@@ -1,0 +1,236 @@
+import type { OpenAPIObject } from "openapi3-ts/oas31";
+import { describe, expect, it } from "vitest";
+
+import {
+  extractAllOperationGenerationMetadata,
+  extractOperationGenerationMetadata,
+} from "../../src/shared/operation-generation-metadata.js";
+
+const doc: OpenAPIObject = {
+  components: {
+    schemas: {
+      Widget: {
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+        },
+        required: ["id", "name"],
+        type: "object",
+      },
+      WidgetInput: {
+        properties: {
+          name: { type: "string" },
+        },
+        required: ["name"],
+        type: "object",
+      },
+    },
+    securitySchemes: {
+      ApiKeyAuth: {
+        in: "header",
+        name: "X-API-Key",
+        type: "apiKey",
+      },
+      BearerAuth: {
+        scheme: "bearer",
+        type: "http",
+      },
+    },
+  },
+  info: { title: "test", version: "1.0.0" },
+  openapi: "3.1.0",
+  paths: {
+    "/admin": {
+      get: {
+        operationId: "getAdmin",
+        responses: {
+          "204": { description: "No Content" },
+        },
+        security: [{ BearerAuth: [] }],
+      },
+    },
+    "/widgets/{widgetId}": {
+      get: {
+        operationId: "getWidget",
+        parameters: [
+          {
+            in: "query",
+            name: "includeDetails",
+            required: true,
+            schema: { type: "boolean" },
+          },
+        ],
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Widget" },
+              },
+            },
+            description: "OK",
+          },
+        },
+      },
+      parameters: [
+        {
+          in: "path",
+          name: "widgetId",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+      post: {
+        operationId: "createWidget",
+        parameters: [
+          {
+            in: "header",
+            name: "x-trace-id",
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/WidgetInput" },
+            },
+            "multipart/form-data": {
+              schema: {
+                properties: {
+                  file: { type: "string" },
+                },
+                type: "object",
+              },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          "201": {
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Widget" },
+              },
+            },
+            description: "Created",
+          },
+          "400": { description: "Bad Request" },
+        },
+      },
+    },
+  },
+  security: [{ ApiKeyAuth: [] }],
+};
+
+function getOperationInput(
+  pathKey: "/admin" | "/widgets/{widgetId}",
+  method: "get" | "post",
+) {
+  const pathItem = doc.paths?.[pathKey];
+
+  if (!pathItem) {
+    throw new Error(`Missing ${pathKey} path item`);
+  }
+
+  const operation = pathItem[method];
+
+  if (!operation) {
+    throw new Error(`Missing ${method.toUpperCase()} ${pathKey} operation`);
+  }
+
+  return {
+    operation,
+    pathLevelParameters: pathItem.parameters ?? [],
+  };
+}
+
+describe("operation generation metadata", () => {
+  it("extracts shared metadata and request or response map flags", () => {
+    const metadata = extractAllOperationGenerationMetadata(doc);
+
+    expect(metadata).toHaveLength(3);
+    expect(metadata.map((item) => item.operationId)).toEqual(
+      expect.arrayContaining(["getAdmin", "getWidget", "createWidget"]),
+    );
+
+    const createWidget = metadata.find(
+      (item) => item.operationId === "createWidget",
+    );
+    const getAdmin = metadata.find((item) => item.operationId === "getAdmin");
+
+    expect(createWidget).toBeDefined();
+    expect(createWidget?.bodyInfo.hasRequestBody).toBe(true);
+    expect(createWidget?.bodyInfo.requestContentTypes).toEqual([
+      "application/json",
+      "multipart/form-data",
+    ]);
+    expect(createWidget?.bodyInfo.shouldGenerateRequestMap).toBe(true);
+    expect(createWidget?.bodyInfo.requestBodyMap.shouldGenerateRequestMap).toBe(
+      true,
+    );
+    expect(createWidget?.bodyInfo.shouldGenerateResponseMap).toBe(true);
+    expect(createWidget?.bodyInfo.responseMap.shouldGenerateResponseMap).toBe(
+      true,
+    );
+
+    expect(getAdmin).toBeDefined();
+    expect(getAdmin?.bodyInfo.hasRequestBody).toBe(false);
+    expect(getAdmin?.bodyInfo.shouldGenerateRequestMap).toBe(false);
+    expect(getAdmin?.bodyInfo.shouldGenerateResponseMap).toBe(false);
+  });
+
+  it("tracks parameter optionality alongside global security headers", () => {
+    const { operation, pathLevelParameters } = getOperationInput(
+      "/widgets/{widgetId}",
+      "get",
+    );
+    const metadata = extractOperationGenerationMetadata({
+      doc,
+      method: "get",
+      operation,
+      pathKey: "/widgets/{widgetId}",
+      pathLevelParameters,
+    });
+
+    expect(metadata.parameterInfo).toEqual({
+      hasHeaders: true,
+      hasPath: true,
+      hasQuery: true,
+      isHeadersOptional: true,
+      isQueryOptional: false,
+    });
+    expect(metadata.operationSecurityHeaders).toEqual([
+      {
+        headerName: "X-API-Key",
+        isOverride: false,
+        isRequired: false,
+        schemeName: "ApiKeyAuth",
+      },
+    ]);
+  });
+
+  it("marks operation-level security headers as required overrides", () => {
+    const { operation, pathLevelParameters } = getOperationInput(
+      "/admin",
+      "get",
+    );
+    const metadata = extractOperationGenerationMetadata({
+      doc,
+      method: "get",
+      operation,
+      pathKey: "/admin",
+      pathLevelParameters,
+    });
+
+    expect(metadata.overridesSecurity).toBe(true);
+    expect(metadata.parameterInfo.hasHeaders).toBe(true);
+    expect(metadata.parameterInfo.isHeadersOptional).toBe(false);
+    expect(metadata.operationSecurityHeaders).toEqual([
+      {
+        headerName: "Authorization",
+        isOverride: true,
+        isRequired: true,
+        schemeName: "BearerAuth",
+      },
+    ]);
+  });
+});

--- a/packages/route-generator/src/index.ts
+++ b/packages/route-generator/src/index.ts
@@ -1,7 +1,8 @@
 import type { OpenAPIObject } from "openapi3-ts/oas31";
 
 import {
-  extractAllOperations,
+  extractAllOperationGenerationMetadata,
+  type OperationGenerationMetadata,
   type OperationMetadata,
 } from "@apical-ts/core-utils/shared";
 import pLimit from "p-limit";
@@ -11,7 +12,7 @@ import {
   writeRouteMetadataFile,
   writeRoutesIndexFile,
 } from "./file-writer.js";
-import { generateRouteMetadata } from "./route-metadata-generator.js";
+import { generateRouteMetadataFromMetadata } from "./route-metadata-generator.js";
 
 /**
  * Generates route metadata for all operations
@@ -20,10 +21,16 @@ export async function generateRoutes(
   doc: OpenAPIObject,
   outputDir: string,
   concurrency: number,
+  operationMetadata = extractAllOperationGenerationMetadata(doc),
 ): Promise<void> {
   const routesDir = await createRoutesDirectory(outputDir);
 
-  const operations = await processRoutes(doc, routesDir, concurrency);
+  const operations = await processRoutes(
+    doc,
+    routesDir,
+    concurrency,
+    operationMetadata,
+  );
 
   await writeRoutesIndexFile(operations, routesDir);
 }
@@ -35,29 +42,20 @@ async function processRoutes(
   doc: OpenAPIObject,
   routesDir: string,
   concurrency: number,
+  operationMetadata: OperationGenerationMetadata[],
 ): Promise<OperationMetadata[]> {
-  const operations = extractAllOperations(doc);
   const limit = pLimit(concurrency);
   const operationPromises: Promise<void>[] = [];
 
-  for (const {
-    method,
-    operation,
-    operationId,
-    pathKey,
-    pathLevelParameters,
-  } of operations) {
+  for (const metadata of operationMetadata) {
     const promise = limit(async () => {
-      const { importManager, routeCode } = generateRouteMetadata(
-        pathKey,
-        method,
-        operation,
-        pathLevelParameters,
+      const { importManager, routeCode } = generateRouteMetadataFromMetadata(
+        metadata,
         doc,
       );
 
       await writeRouteMetadataFile(
-        operationId,
+        metadata.operationId,
         routeCode,
         importManager,
         routesDir,
@@ -67,7 +65,7 @@ async function processRoutes(
   }
 
   await Promise.all(operationPromises);
-  return operations;
+  return operationMetadata;
 }
 
 export {

--- a/packages/route-generator/src/route-metadata-generator.ts
+++ b/packages/route-generator/src/route-metadata-generator.ts
@@ -6,13 +6,14 @@ import type {
 } from "openapi3-ts/oas31";
 
 import { ImportManager } from "@apical-ts/core-utils";
-import { sanitizeIdentifier } from "@apical-ts/core-utils";
-import { generateResponseMap } from "@apical-ts/core-utils/shared";
-import { generateResponseUnion } from "@apical-ts/core-utils/shared";
-import { generateServerRequestBodyMap } from "@apical-ts/core-utils/shared";
+import {
+  extractOperationGenerationMetadata,
+  generateResponseUnion,
+  type OperationGenerationMetadata,
+} from "@apical-ts/core-utils/shared";
 
 import {
-  extractRouteOperationMetadata,
+  extractRouteOperationMetadataFromMetadata,
   type RouteOperationMetadata as LightweightRouteMetadata,
 } from "./route-operation-extractor.js";
 import { renderRouteMetadata } from "./templates/route-metadata-templates.js";
@@ -30,11 +31,14 @@ export interface RouteOperationMetadata {
   bodyInfo: {
     contentTypeMaps: LightweightRouteMetadata["bodyInfo"]["contentTypeMaps"];
     hasBody: boolean;
+    requestBodyMap: OperationGenerationMetadata["bodyInfo"]["requestBodyMap"];
     requestMapTypeName: string;
+    responseMap: OperationGenerationMetadata["bodyInfo"]["responseMap"];
     responseMapTypeName: string;
-    serverRequestBodyMap: ReturnType<typeof generateServerRequestBodyMap>;
     shouldGenerateRequestMap: boolean;
+    shouldGenerateResponseMap: boolean;
   };
+  functionName: string;
   operation: OperationObject;
   operationId: string;
   parameterInfo: LightweightRouteMetadata["parameterInfo"];
@@ -55,15 +59,13 @@ export function buildRequestMap(
 export type ${mapName} = typeof ${mapName};`;
   }
 
-  const { serverRequestBodyMap } = metadata.bodyInfo;
-
-  /* Add imports for request schemas */
-  for (const typeImport of serverRequestBodyMap.typeImports) {
+  for (const typeImport of metadata.bodyInfo.requestBodyMap.typeImports) {
     importManager.addSchemaImport(typeImport);
   }
 
-  /* Convert the client generator format (with semicolons) to object literal format (with commas) */
-  const fixedMapType = serverRequestBodyMap.requestMapType.replace(/;/g, ",");
+  /* Convert the type-shape map into an object-literal friendly map */
+  const fixedMapType =
+    metadata.bodyInfo.requestBodyMap.requestMapType.replaceAll(";", ",");
 
   return `export const ${mapName} = ${fixedMapType} as const;
 export type ${mapName} = typeof ${mapName};`;
@@ -77,53 +79,31 @@ export function buildResponseMap(
   importManager: ImportManager,
   doc: OpenAPIObject,
 ): string {
-  /* Create a temporary Set to collect type imports */
-  const typeImports = new Set<string>();
-  // Route files already import schema response symbols (e.g. FooResponse).
-  // Use a distinct route-level union name to avoid TS2440 collisions between
-  // imported schema types and the response union exported by the route module.
-  const routeResponseTypeName = `${sanitizeIdentifier(metadata.operationId)}RouteResponse`;
-
-  /* Generate response union type using existing logic */
+  const responseTypeImports = new Set<string>();
+  const routeResponseTypeName = `${metadata.functionName}RouteResponse`;
   const unionResult = generateResponseUnion(
     metadata.operation,
     metadata.operationId,
-    typeImports,
+    responseTypeImports,
     doc,
     undefined,
     routeResponseTypeName,
   );
 
-  /* Generate response map using shared logic */
-  const responseMapResult = generateResponseMap(
-    metadata.operation,
-    metadata.operationId,
-    typeImports,
-    doc,
-    {},
-  );
-
-  /* Add type imports to ImportManager */
-  for (const typeImport of typeImports) {
+  for (const typeImport of metadata.bodyInfo.responseMap.typeImports) {
     importManager.addSchemaImport(typeImport);
   }
-  for (const typeImport of responseMapResult.typeImports) {
+  for (const typeImport of unionResult.typeImports) {
     importManager.addSchemaImport(typeImport);
   }
 
-  /* Generate response map constant and type */
-  const responseMapName = `${sanitizeIdentifier(metadata.operationId)}ResponseMap`;
-
-  let responseMapCode = "";
-  if (responseMapResult.shouldGenerateResponseMap) {
-    responseMapCode = `export const ${responseMapName} = ${responseMapResult.responseMapType} as const;
+  const responseMapName = metadata.bodyInfo.responseMapTypeName;
+  const responseMapCode = metadata.bodyInfo.shouldGenerateResponseMap
+    ? `export const ${responseMapName} = ${metadata.bodyInfo.responseMap.responseMapType} as const;
+export type ${responseMapName} = typeof ${responseMapName};`
+    : `export const ${responseMapName} = {} as const;
 export type ${responseMapName} = typeof ${responseMapName};`;
-  } else {
-    responseMapCode = `export const ${responseMapName} = {} as const;
-export type ${responseMapName} = typeof ${responseMapName};`;
-  }
 
-  /* Combine both the union type and the response map */
   return `${responseMapCode}\n\n${unionResult.unionTypeDefinition}`;
 }
 
@@ -137,36 +117,39 @@ export function generateRouteMetadata(
   pathLevelParameters: (ParameterObject | ReferenceObject)[] = [],
   doc: OpenAPIObject,
 ): GeneratedRouteMetadata {
-  const metadata = extractCompleteRouteMetadata(
-    pathKey,
+  const metadata = extractOperationGenerationMetadata({
+    doc,
     method,
     operation,
+    pathKey,
     pathLevelParameters,
-    doc,
-  );
+  });
 
+  return generateRouteMetadataFromMetadata(metadata, doc);
+}
+
+export function generateRouteMetadataFromMetadata(
+  metadata: OperationGenerationMetadata,
+  doc: OpenAPIObject,
+): GeneratedRouteMetadata {
+  const routeMetadata = extractCompleteRouteMetadata(metadata);
   const importManager = new ImportManager();
 
-  /* Build request map (always, even if empty) */
-  const requestMapCode = buildRequestMap(metadata, importManager);
-
-  /* Build response map */
-  const responseMapCode = buildResponseMap(metadata, importManager, doc);
-
-  /* Render the complete route metadata */
+  const requestMapCode = buildRequestMap(routeMetadata, importManager);
+  const responseMapCode = buildResponseMap(routeMetadata, importManager, doc);
   const routeCode = renderRouteMetadata({
-    hasHeaders: metadata.parameterInfo.hasHeaders,
-    hasPath: metadata.parameterInfo.hasPath,
-    hasQuery: metadata.parameterInfo.hasQuery,
-    isHeadersOptional: metadata.parameterInfo.isHeadersOptional,
-    isQueryOptional: metadata.parameterInfo.isQueryOptional,
-    method: method.toLowerCase(),
-    operationId: metadata.operationId,
-    pathKey,
+    hasHeaders: routeMetadata.parameterInfo.hasHeaders,
+    hasPath: routeMetadata.parameterInfo.hasPath,
+    hasQuery: routeMetadata.parameterInfo.hasQuery,
+    isHeadersOptional: routeMetadata.parameterInfo.isHeadersOptional,
+    isQueryOptional: routeMetadata.parameterInfo.isQueryOptional,
+    method: metadata.method.toLowerCase(),
+    operationId: routeMetadata.operationId,
+    pathKey: metadata.pathKey,
     requestMapCode,
-    requestMapTypeName: metadata.bodyInfo.requestMapTypeName,
+    requestMapTypeName: routeMetadata.bodyInfo.requestMapTypeName,
     responseMapCode,
-    responseMapTypeName: metadata.bodyInfo.responseMapTypeName,
+    responseMapTypeName: routeMetadata.bodyInfo.responseMapTypeName,
   });
 
   return {
@@ -179,46 +162,26 @@ export function generateRouteMetadata(
  * Extracts metadata needed for route generation (wrapper that adds server-specific data)
  */
 function extractCompleteRouteMetadata(
-  pathKey: string,
-  method: string,
-  operation: OperationObject,
-  pathLevelParameters: (ParameterObject | ReferenceObject)[] = [],
-  doc: OpenAPIObject,
+  metadata: OperationGenerationMetadata,
 ): RouteOperationMetadata {
-  const operationId = operation.operationId;
-  if (!operationId) {
-    throw new Error("Operation ID is required for route generation");
-  }
-
-  /* Use lightweight extractor instead of heavyweight client generator */
-  const lightweightMeta = extractRouteOperationMetadata(
-    pathKey,
-    method,
-    operation,
-    pathLevelParameters,
-    doc,
-  );
-
-  /* Generate server request body map (server-specific addition) */
-  const typeImports = new Set<string>();
-  const serverRequestBodyMap = generateServerRequestBodyMap(
-    operation,
-    operationId,
-    typeImports,
-  );
+  const lightweightMeta = extractRouteOperationMetadataFromMetadata(metadata);
 
   return {
     bodyInfo: {
       contentTypeMaps: lightweightMeta.bodyInfo.contentTypeMaps,
       hasBody: lightweightMeta.bodyInfo.hasBody,
+      requestBodyMap: metadata.bodyInfo.requestBodyMap,
       requestMapTypeName: lightweightMeta.bodyInfo.requestMapTypeName,
+      responseMap: metadata.bodyInfo.responseMap,
       responseMapTypeName: lightweightMeta.bodyInfo.responseMapTypeName,
-      serverRequestBodyMap,
       shouldGenerateRequestMap:
         lightweightMeta.bodyInfo.shouldGenerateRequestMap,
+      shouldGenerateResponseMap:
+        lightweightMeta.bodyInfo.shouldGenerateResponseMap,
     },
-    operation,
-    operationId,
+    functionName: metadata.functionName,
+    operation: metadata.operation,
+    operationId: metadata.operationId,
     parameterInfo: lightweightMeta.parameterInfo,
   };
 }

--- a/packages/route-generator/src/route-metadata-generator.ts
+++ b/packages/route-generator/src/route-metadata-generator.ts
@@ -24,9 +24,7 @@ export interface GeneratedRouteMetadata {
   routeCode: string;
 }
 
-/**
- * Extended route operation metadata for template generation (includes server request body map)
- */
+/* Extended route operation metadata for template generation */
 export interface RouteOperationMetadata {
   bodyInfo: {
     contentTypeMaps: LightweightRouteMetadata["bodyInfo"]["contentTypeMaps"];
@@ -158,9 +156,7 @@ export function generateRouteMetadataFromMetadata(
   };
 }
 
-/**
- * Extracts metadata needed for route generation (wrapper that adds server-specific data)
- */
+/* Extracts metadata needed for route generation */
 function extractCompleteRouteMetadata(
   metadata: OperationGenerationMetadata,
 ): RouteOperationMetadata {

--- a/packages/route-generator/src/route-operation-extractor.ts
+++ b/packages/route-generator/src/route-operation-extractor.ts
@@ -1,4 +1,7 @@
-import type { ContentTypeMaps } from "@apical-ts/core-utils/shared";
+import type {
+  ContentTypeMaps,
+  OperationGenerationMetadata,
+} from "@apical-ts/core-utils/shared";
 import type {
   OpenAPIObject,
   OperationObject,
@@ -6,10 +9,7 @@ import type {
   ReferenceObject,
 } from "openapi3-ts/oas31";
 
-import { sanitizeIdentifier } from "@apical-ts/core-utils";
-import { generateContentTypeMaps } from "@apical-ts/core-utils/shared";
-import { extractParameterGroups } from "@apical-ts/core-utils/shared";
-import { getOperationSecuritySchemes } from "@apical-ts/core-utils/shared";
+import { extractOperationGenerationMetadata } from "@apical-ts/core-utils/shared";
 
 /**
  * Route operation metadata for template generation
@@ -21,18 +21,13 @@ export interface RouteOperationMetadata {
     requestMapTypeName: string;
     responseMapTypeName: string;
     shouldGenerateRequestMap: boolean;
+    shouldGenerateResponseMap: boolean;
   };
   method: string;
   operation: OperationObject;
   operationId: string;
   /* Flags indicating which parameter types have actual parameters */
-  parameterInfo: {
-    hasHeaders: boolean;
-    hasPath: boolean;
-    hasQuery: boolean;
-    isHeadersOptional: boolean;
-    isQueryOptional: boolean;
-  };
+  parameterInfo: OperationGenerationMetadata["parameterInfo"];
   pathKey: string;
 }
 
@@ -49,61 +44,33 @@ export function extractRouteOperationMetadata(
   pathLevelParameters: (ParameterObject | ReferenceObject)[],
   doc: OpenAPIObject,
 ): RouteOperationMetadata {
-  const operationId = operation.operationId;
-  if (!operationId) {
-    throw new Error("Operation ID is required for route generation");
-  }
-
-  /* Extract content-type information using shared logic */
-  const contentTypeMaps = generateContentTypeMaps(operation, doc);
-  const hasBody = !!operation.requestBody;
-
-  /* Determine if maps should be generated based on content type counts */
-  const shouldGenerateRequestMap =
-    hasBody && contentTypeMaps.requestContentTypeCount > 0;
-
-  /* Extract parameter groups to determine which parameter types exist */
-  const parameterGroups = extractParameterGroups(
-    operation,
-    pathLevelParameters,
+  const sharedMetadata = extractOperationGenerationMetadata({
     doc,
-  );
-
-  /* Extract security headers to calculate header optionality */
-  const securityHeaders = getOperationSecuritySchemes(operation, doc);
-
-  /* Calculate optionality - same logic as in parameter-file-generator */
-  const isQueryOptional = parameterGroups.queryParams.every(
-    (p) => p.required !== true,
-  );
-  /*
-   * Headers are optional only if all header params AND security headers are optional.
-   * When required headers exist, they must be provided in params OR config.
-   */
-  const hasRequiredSecurityHeader = securityHeaders.some((sh) => sh.isRequired);
-  const isHeadersOptional =
-    parameterGroups.headerParams.every((p) => p.required !== true) &&
-    !hasRequiredSecurityHeader;
-
-  return {
-    bodyInfo: {
-      contentTypeMaps,
-      hasBody,
-      requestMapTypeName: `${sanitizeIdentifier(operationId)}RequestMap`,
-      responseMapTypeName: `${sanitizeIdentifier(operationId)}ResponseMap`,
-      shouldGenerateRequestMap,
-    },
     method,
     operation,
-    operationId,
-    parameterInfo: {
-      hasHeaders:
-        parameterGroups.headerParams.length > 0 || securityHeaders.length > 0,
-      hasPath: parameterGroups.pathParams.length > 0,
-      hasQuery: parameterGroups.queryParams.length > 0,
-      isHeadersOptional,
-      isQueryOptional,
-    },
     pathKey,
+    pathLevelParameters,
+  });
+
+  return extractRouteOperationMetadataFromMetadata(sharedMetadata);
+}
+
+export function extractRouteOperationMetadataFromMetadata(
+  metadata: OperationGenerationMetadata,
+): RouteOperationMetadata {
+  return {
+    bodyInfo: {
+      contentTypeMaps: metadata.bodyInfo.contentTypeMaps,
+      hasBody: metadata.bodyInfo.hasRequestBody,
+      requestMapTypeName: `${metadata.functionName}RequestMap`,
+      responseMapTypeName: `${metadata.functionName}ResponseMap`,
+      shouldGenerateRequestMap: metadata.bodyInfo.shouldGenerateRequestMap,
+      shouldGenerateResponseMap: metadata.bodyInfo.shouldGenerateResponseMap,
+    },
+    method: metadata.method,
+    operation: metadata.operation,
+    operationId: metadata.operationId,
+    parameterInfo: metadata.parameterInfo,
+    pathKey: metadata.pathKey,
   };
 }


### PR DESCRIPTION
## Summary
- extract shared operation generation metadata once in `core-utils`
- reuse that metadata across client and route generation instead of rebuilding it in each pipeline
- keep `routes/` and `client/` generation separate while sharing the expensive metadata work

## Measured savings
- routes 951.95 ms -> 863.47 ms
- client-operations 959.24 ms -> 871.60 ms
- targeted combined saving -125.87 ms

## Note
- `routes/` and `client/` remain separate