### PR TITLE
Refactor documentation for contract-first API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ schemas.
 pnpm start generate -i ./openapi.yaml -o ./generated --client --server
 ```
 
+## Contract-first integrations
+
+Apical TS can generate different layers from the same OpenAPI contract,
+depending on how much framework glue you want to write yourself and how much you
+want to derive later.
+
+| Output     | Best for                                              | Example                      |
+| ---------- | ----------------------------------------------------- | ---------------------------- |
+| `--server` | explicit, wrapper-based server integrations           | `examples/express`           |
+| `--routes` | metadata-driven generators and dynamic adapters       | `examples/hono`              |
+| `--client` | typed frontend/API consumers and secondary generators | `examples/react-query-hooks` |
+
+`--client` and `--server` also emit `routes/`, so the same contract can feed
+mock handlers, frontend hooks, or custom framework adapters without re-modeling
+paths, params, or responses for each integration. See the examples in
+[`examples/`](./examples/), especially `express`, `hono`, `msw-mock-server`, and
+`react-query-hooks`.
+
 ### Overriding OpenAPI string formats
 
 Use `--format` to replace a `type: string` + `format` mapping with your own Zod

--- a/apps/website/docs/schema-generation/framework-integrations.md
+++ b/apps/website/docs/schema-generation/framework-integrations.md
@@ -1,114 +1,119 @@
 # Framework Integrations
 
-Apical TS generates fully-typed Zod schemas and operation-based clients that can
-be easily adapted to any JavaScript/TypeScript framework. The generated route
-schemas provide runtime validation and type safety, making it straightforward to
-integrate with your preferred libraries.
+Apical TS works best as a **contract-first** generator: you describe the API
+once in OpenAPI, then let every integration consume the generated artifacts
+instead of re-declaring paths, params, and response shapes for each framework.
 
-## Key Benefits
+The main reusable outputs are:
 
-- **Framework Agnostic**: Use the same generated schemas across different
-  frameworks
-- **Type Safety**: Full TypeScript support with inferred types from OpenAPI
-  specs
-- **Runtime Validation**: Zod schemas ensure data integrity at runtime
-- **Operation-Based**: Each API operation is a separate, composable function
+- **`generated/routes/*`**: route metadata plus request/response schemas
+- **`generated/server/*`**: typed request-validation wrappers for explicit
+  server integrations
+- **`generated/client/*`**: typed operation functions for frontend and SDK usage
+
+## Static vs Dynamic Route Usage
+
+Different integrations reuse the same contract in different ways:
+
+| Style                               | Generated input                                                       | Example                                                                                                                                                                  | What you write                                                                |
+| ----------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| Static, wrapper-based               | `--server` (`server/` + `routes/`)                                    | [Express](https://github.com/gunzip/apical-ts/tree/main/examples/express/)                                                                                               | explicit framework route registration and business handlers                   |
+| Dynamic, metadata-driven            | `--routes` (or the `routes/` emitted alongside `--client`/`--server`) | [Hono](https://github.com/gunzip/apical-ts/tree/main/examples/hono/)                                                                                                     | a second generator or adapter that derives framework glue from route metadata |
+| Dynamic, contract-derived consumers | `--client` or `--server`, plus `routes/`                              | [React Query](https://github.com/gunzip/apical-ts/tree/main/examples/react-query-hooks/), [MSW](https://github.com/gunzip/apical-ts/tree/main/examples/msw-mock-server/) | hooks, mock handlers, and utilities generated from the same operations        |
+
+The important part is that the OpenAPI contract stays the single source of truth
+no matter which style you choose.
 
 ## Example Integrations
 
-We provide complete working examples for four popular frameworks in the
+We provide complete working examples in the
 [`examples/`](https://github.com/gunzip/apical-ts/tree/main/examples/) folder:
 
-### React Query Hooks
+### Express: explicit wrapper-based integration
 
 The
-[React Query integration](https://github.com/gunzip/apical-ts/tree/main/examples/react-query-hooks/)
-generates typed React Query hooks directly from your OpenAPI specification.
+[Express example](https://github.com/gunzip/apical-ts/tree/main/examples/express/)
+shows the more static style: generate `--server`, then register each route in
+Express with the generated wrapper.
 
-**Features:**
+**What it demonstrates**
 
-- `useX` query hooks for GET/HEAD operations
-- `useXMutation` hooks for POST/PUT/PATCH/DELETE operations
-- Automatic type inference from generated client operations
-- Error handling and loading states built-in
+- request/response validation from generated wrappers
+- explicit route registration with framework-specific adapters
+- custom business logic without redefining the API contract
 
 ```typescript
-// Generated hook usage
-const { data, isLoading, error } = useFindPetsByStatus({
-  query: { status: "available" },
-});
+createExpressAdapter(getPetByIdRoute(), getPetByIdHandler)(app);
 ```
 
-### Express Server Wrappers
+### Hono: route-metadata-driven generation
 
-The
-[Express integration](https://github.com/gunzip/apical-ts/tree/main/examples/express/)
-demonstrates how to create type-safe Express servers using generated route
-wrappers.
+The [Hono example](https://github.com/gunzip/apical-ts/tree/main/examples/hono/)
+shows the more dynamic style: generate `--routes`, then run a second generator
+that turns route metadata into a Hono registration layer.
 
-**Features:**
+**What it demonstrates**
 
-- Automatic request/response validation
-- Type-safe route handlers
-- Mock server support with realistic data generation
-- Full OpenAPI compliance
+- route-metadata-driven code generation
+- automatic request validation for path, query, headers, and body
+- zero manual remodelling of endpoints when switching from Express to Hono
 
 ```typescript
-// Generated route wrapper
-createExpressAdapter(findPetsByStatusRoute(), findPetsByStatusHandler)(app);
-```
-
-### Hono Mock Server
-
-The
-[Hono integration](https://github.com/gunzip/apical-ts/tree/main/examples/hono/)
-shows how to start from Apical TS `--routes` output and generate a Hono-specific
-registration layer for a runnable mock server.
-
-**Features:**
-
-- Route-metadata-driven Hono registration
-- Automatic request validation for path, query, headers, and body
-- Auto-generated mock responses using zocker
-
-```typescript
-// Register all generated Hono routes
 registerGeneratedRoutes(app);
 ```
 
-### MSW Mock Server
+### React Query: hooks derived from generated operations
 
 The
-[MSW integration](https://github.com/gunzip/apical-ts/tree/main/examples/msw-mock-server/)
-shows how to create fully functional mock APIs using Mock Service Worker.
+[React Query example](https://github.com/gunzip/apical-ts/tree/main/examples/react-query-hooks/)
+shows how the same contract can feed frontend hooks. Apical generates the client
+and routes once, then a secondary generator emits `useX` and `useXMutation`
+hooks from those artifacts.
 
-**Features:**
+**What it demonstrates**
 
-- HTTP request interception
-- Auto-generated mock data using zocker
-- Request validation against OpenAPI schemas
-- Support for all response status codes
+- `useX` hooks for GET/HEAD operations
+- `useXMutation` hooks for write operations
+- type inference from generated client operations and route methods
 
 ```typescript
-// MSW handler from generated route
-const handlers = [createMswHandler(findPetsByStatusRoute)];
+const { data, isLoading, error } = useFindPetsByStatus({
+  query: { status: ["available"] },
+});
+```
+
+### MSW: mock handlers derived from generated wrappers
+
+The
+[MSW example](https://github.com/gunzip/apical-ts/tree/main/examples/msw-mock-server/)
+shows a dynamic mock integration. It iterates the generated operations, creates
+one MSW handler per route, and still reuses the generated wrapper validation and
+response maps.
+
+**What it demonstrates**
+
+- dynamic handler registration from generated operations
+- request validation aligned with the OpenAPI contract
+- mock payload generation from response schemas via `zocker`
+
+```typescript
+const handlers = Object.values(routes).map((routeFn) => {
+  const routeInfo = routeFn();
+  return createMswHandler(routeInfo, createMockHandler(routeInfo));
+});
 ```
 
 ## Adapting to Other Frameworks
 
-The generated Zod schemas and operation functions are designed to be
-framework-agnostic. Here's how you can adapt them:
+Once you have generated `routes/`, `server/`, or `client/`, every other
+integration follows the same pattern:
 
-1. **Use the generated schemas** for validation in your framework's middleware
-2. **Compose the operation functions** with your framework's request/response
-   handling
-3. **Leverage the type definitions** for full TypeScript support
+1. Import the generated contract artifacts
+2. Derive framework-specific adapters, handlers, or hooks from those artifacts
+3. Keep framework code thin and avoid redefining API models by hand
 
-Each integration follows a similar adapter pattern:
-
-- Import the generated route schemas and operations
-- Create framework-specific adapters that handle requests/responses
-- Apply validation and type safety at the framework layer
+That is the main advantage of the contract-first flow: you can swap or add
+integrations without remodeling the API every time.
 
 ## Getting Started
 
@@ -118,8 +123,7 @@ To explore these integrations:
 2. Navigate to the desired example: `cd examples/[framework]`
 3. Install dependencies: `pnpm install`
 4. Generate the code: `pnpm run generate`
-5. Run the example using the command documented in that example's README (for
-   Hono/MSW: `pnpm dev`).
+5. Run the example using the command documented in that example's README
 
-The examples include comprehensive documentation and working code you can adapt
-for your own projects.
+Each example README now documents which generated artifacts it consumes and how
+to extend that integration without breaking the contract-first workflow.

--- a/apps/website/docs/server-routes-wrappers-generation.md
+++ b/apps/website/docs/server-routes-wrappers-generation.md
@@ -1,13 +1,19 @@
 # Using Generated Server Routes Wrappers
 
-The generator can also produce a fully-typed server handler wrapper for your
-OpenAPI operations. This enables you to build type-safe HTTP servers (e.g., with
-Express, Fastify, or custom frameworks) that validate requests at runtime using
-Zod schemas and can return only responses of the expected types.
+Apical TS supports two contract-first server integration styles:
 
-## How to Generate a Server Route Wrapper
+1. **Wrapper-based integrations** via `--server`
+2. **Metadata-driven integrations** via `--routes`
 
-To generate server-side code, use the CLI with the `--server` flag:
+This page focuses on the first style. It is the approach used in
+`examples/express`: Apical generates typed wrappers, and you explicitly bind
+them to your framework routes. If you want to derive a framework layer from
+route metadata instead of wiring routes one by one, see the Hono example and the
+`--routes` flow.
+
+## How to Generate Server Wrappers
+
+To generate server-side wrappers, use the CLI with the `--server` flag:
 
 ```bash
 npx @apical-ts/craft generate \
@@ -16,98 +22,90 @@ npx @apical-ts/craft generate \
   -o generated
 ```
 
-This will create a `server/` directory in your output folder, containing:
+This creates:
 
-- **`server/index.ts`**: Exports the server handler wrappers and types
-- **`server/<operationId>.ts`**: Individual operation handler wrappers
+- **`routes/`**: route metadata shared by every generated integration
+- **`server/index.ts`**: exports the server handler wrappers and types
+- **`server/<operationId>.ts`**: individual operation handler wrappers
+
+## When to Use `--server` vs `--routes`
+
+- Use **`--server`** when you want Apical to validate requests and type your
+  handler inputs/outputs, while you keep explicit control over framework route
+  registration. This is the more static style shown in `examples/express`.
+- Use **`--routes`** when you want metadata only and plan to generate a second
+  framework layer from it. This is the more dynamic style shown in
+  `examples/hono`.
+- You can mix both approaches because `--server` also generates `routes/`. The
+  same contract can therefore power Express handlers, Hono generators, MSW mock
+  handlers, or React Query hook generators without remodeling the API surface.
 
 ## Runtime Dependencies
 
 The generated server code requires `zod` as a runtime dependency for request and
-response validation. After generation, install it in your output directory:
-
-```bash
-cd generated
-npm install
-```
+response validation. After generation, install dependencies in your project or
+output directory as needed.
 
 ## Using the Wrapped Handler
 
-The generated route wrapper is a function that takes a request handler and
-returns an async function that can be used with any web framework. This allows
-you to ensure type safety and runtime validation for your request parameters
-(path, query, headers) and response data.
+The generated route wrapper takes a typed handler and returns an async function
+that you can connect to any web framework. Your framework adapter is responsible
+for:
 
-You are responsible for extracting parameters from the framework request and
-passing them to the wrapper, then handling the result (status, contentType,
-data) in your route handler. The `status` field is now always a string (e.g.
-`'200'`, `'404'`, `'4XX'`, `'5XX'`), allowing you to handle both specific and
-range status codes type-safely. This allows you to integrate with any web
-framework and customize error handling as needed.
+1. Extracting `query`, `path`, `headers`, `body`, and `contentType`
+2. Passing that data to the wrapper
+3. Translating the wrapper result back into the framework response
 
-Example usage with Express and a helper for parameter extraction:
+This is what keeps the framework layer thin: the contract stays in the generated
+files, while your adapter only moves data in and out of them.
+
+Example usage with Express:
 
 ```ts
-// ../../examples/express/server-examples/express-server-example.ts#L62-L91
-
-/* Implementation of getPetById handler */
 const getPetByIdHandler: getPetByIdHandler = async (params) => {
   if (!params.isValid) {
-    /* Handle validation errors */
-    console.error("Validation error in getPetById:", params);
-    return {
-      status: "400",
-    };
+    return { status: "400" };
   }
 
   const { petId } = params.value.path;
-  console.log(`Getting pet by ID: ${petId}`);
-
-  /* Find pet by ID */
-  const pet = mockPets.find((p) => p.id === petId);
+  const pet = mockPets.find((candidate) => candidate.id === petId);
 
   if (!pet) {
-    return {
-      status: "404",
-    };
+    return { status: "404" };
   }
 
-  // Response is typed here
   return {
     status: "200",
     contentType: "application/json",
     data: pet,
   };
 };
-/* Setup routes using the helper function */
+
 createExpressAdapter(getPetByIdRoute(), getPetByIdHandler)(app);
 ```
 
-- The wrapper receives a single params object containing validated query, path,
-  headers, body, etc. or error details if validation fails
-- You control the HTTP response based on the wrapper's result
-- All responses are type checked: you cannot return a response shape which is
-  not valid according to the OpenAPI schema.
-
-See the `apps/examples` directory in the repository for more usage examples.
+The wrapper receives a single params object containing validated query, path,
+headers, and body data, or structured validation errors when parsing fails. All
+responses are type checked against the OpenAPI contract.
 
 ### Handler Function Signature
 
-The handler you provide to the wrapper receives a single argument:
+The handler you provide to the wrapper receives one of:
 
-- For valid requests:
-  `{ isValid: true, value: { query, path, headers, body, ... } }`
-- For validation errors:
-  `{ isValid: false, kind: "query-error" | "body-error" | ... , error: ZodError }`
+- `{ isValid: true, value: { query, path, headers, body, ... } }`
+- `{ isValid: false, kind: "query-error" | "body-error" | ..., error: ZodError }`
 
-It must return an object with `{ status, contentType, data }`.
+It must return a typed object shaped like `{ status, contentType, data }`.
 
-## Features
+## Why This Is the "Static" Route Style
 
-- Request validation (body, query, params) using generated Zod schemas
-- Response validation before sending (if you use the generated types)
-- Automatic error details for validation failures
-- Type-safe handler context
+With `--server`, you still choose how routes are mounted in the framework. That
+is useful when you want:
 
-You can use the generated types and schemas for further custom validation or
-integration with other frameworks.
+- full control over middleware ordering and framework features
+- custom business logic per endpoint
+- incremental adoption in an existing server
+
+If, instead, you want the contract to drive route registration itself, start
+from `--routes` and generate a framework-specific layer from the route metadata,
+as shown in `examples/hono`.

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -80,7 +80,7 @@ function HomepageHeader() {
     <header className={styles.heroBanner}>
       <div className={clsx("container", styles.heroLayout)}>
         <div className={styles.heroBody}>
-          <div className={styles.eyebrow}>{siteConfig.title}</div>
+          {/* <div className={styles.eyebrow}>{siteConfig.title}</div> */}
           <Heading as="h1" className={styles.heroTitle}>
             {siteConfig.tagline}
           </Heading>

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -1,404 +1,98 @@
-# Express OpenAPI Server Wrapper Examples
+# Express Contract-First Server Example
 
-These examples demonstrate how to use the generated OpenAPI server wrappers with
-Express.js, showcasing complete integrations that include both server-side
-wrappers and client-side type-safe API calls. Two server implementations are
-provided:
+This example shows the **static, wrapper-based** integration style. Apical TS
+generates the contract artifacts once, then Express explicitly wires each route
+to the generated wrappers. You keep full control over middleware and business
+logic without re-declaring paths, params, or response types by hand.
 
-- **Express Server Example**: Full implementation with custom business logic
-- **Mock Server Example**: Automatic mock server using zocker for data
-  generation
+## Contract-first flow
 
-## Overview
+1. `examples.yaml` is the source of truth.
+2. `pnpm run generate` runs Apical with `--server --client`.
+3. Apical emits:
+   - `generated/routes/*`: route metadata shared across integrations
+   - `generated/server/*`: typed wrappers and handler signatures for Express
+   - `generated/client/*`: typed client operations for the client example
+   - `generated/schemas/*`: runtime validation schemas
+4. `server-examples/express-adapter.ts` adapts Express `Request` / `Response`
+   objects to the generated wrappers.
+5. `server-examples/express-server-example.ts` registers each route explicitly.
 
-These examples use the
-[Swagger Petstore OpenAPI specification](https://raw.githubusercontent.com/swagger-api/swagger-petstore/refs/heads/master/src/main/resources/openapi.yaml)
-to generate:
+## Static vs dynamic route usage
 
-- **Server wrappers**: Type-safe request handlers with automatic validation
-- **Client functions**: Type-safe API client functions
-- **Zod schemas**: Runtime validation schemas for all data types
+- **Express in this folder** is the static style: you decide how every route is
+  mounted with `createExpressAdapter(...)` or manual wrapper calls.
+- **Hono in `../hono`** is the dynamic style: a second generator reads the
+  generated route metadata and emits a full Hono registration layer.
+- Both approaches reuse the same contract, so switching frameworks does not
+  require remodeling the API.
 
-The examples show how to bridge the generated server wrappers with Express.js
-using an adapter pattern, and how to call the resulting API using the generated
-client.
+## Quick start
 
-## Prerequisites
+1. Install dependencies from the monorepo root:
 
-- Node.js 20.18.2+ (check your version with `node --version`)
-- pnpm 10.14.0+ (install with `npm install -g pnpm@10.14.0`)
+   ```bash
+   pnpm install
+   ```
 
-## Quick Start
+2. Generate the contract artifacts:
 
-### 1. Generate Server and Client Code
+   ```bash
+   cd examples/express
+   pnpm run generate
+   ```
 
-First, generate the TypeScript code from the OpenAPI specification:
+3. Run the Express server:
 
-```bash
-# From the examples directory
-pnpm generate:examples
-```
+   ```bash
+   pnpx tsx server-examples/express-server-example.ts
+   ```
 
-This task will:
+4. In another terminal, exercise the generated client:
 
-- Clean any existing generated code
-- Run the TypeScript OpenAPI generator with both `--server` and `--client` flags
-- Create the `generated/` directory with schemas, server wrappers, and client
-  functions
+   ```bash
+   pnpx tsx client-examples/client-example.ts
+   ```
 
-### 2. Choose Your Server Implementation
-
-#### Option A: Full Express Server with Custom Logic
-
-Run the Express server that uses the generated server wrappers with custom
-business logic:
-
-```bash
-# From the examples directory
-pnpx tsx server-examples/express-server-example.ts
-```
-
-#### Option B: Mock Server with Auto-Generated Data
-
-Run the mock Express server that automatically generates responses using zocker:
+For the mock-only variant, run:
 
 ```bash
-# From the examples directory
 pnpx tsx server-examples/mock-server-example.ts
 ```
 
-Both servers will start on `http://localhost:3000` and display available
-endpoints:
+## Project layout
 
-```
-🚀 Express server running on http://localhost:3000
-📊 Available endpoints:
-  GET /pet/findByStatus?status=available
-  GET /pet/{petId} (e.g., /pet/1)
-  GET /store/inventory
-  GET /health
-```
+- `examples.yaml`: the API contract used by this example
+- `generated/server/*`: wrapper-based server integration
+- `generated/routes/*`: reusable route metadata
+- `server-examples/express-adapter.ts`: Express-specific request/response bridge
+- `server-examples/express-server-example.ts`: custom business logic plus
+  explicit route registration
+- `client-examples/*`: typed client consumers of the same contract
 
-The mock server will additionally show:
+## Example prompt
 
-```
-📊 All OpenAPI operations are mocked with zocker-generated data for all status codes in responseMap
-🔍 Validation errors include detailed error messages
-```
+Use a prompt like this when you want an LLM to extend the Express integration
+without re-modeling the API:
 
-### 3. Test with the Generated Client
+```text
+You are working in examples/express.
 
-In a new terminal, run the client example to test the API:
+Use `examples.yaml`, `generated/routes/*`, and `generated/server/*` as the only
+source of truth for the API surface. Do not redefine paths, methods, params, or
+response payloads by hand.
 
-```bash
-# From the examples directory
-pnpx tsx client-examples/client-example.ts
-```
-
-This will demonstrate:
-
-- Finding pets by status with query parameters
-- Getting a specific pet by ID with path parameters
-- Retrieving store inventory
-- Handling typed operation errors (e.g. network, validation, missing schema)
-
-### 4. Manual Testing
-
-You can also test the API manually using curl:
-
-```bash
-# Find available pets
-curl "http://localhost:3000/pet/findByStatus?status=available"
-
-# Get pet by ID
-curl "http://localhost:3000/pet/1"
-
-# Get store inventory
-curl "http://localhost:3000/store/inventory"
-
-# Health check
-curl "http://localhost:3000/health"
+Update the Express integration so that:
+- each route is registered from generated metadata
+- each handler is wrapped with the generated Apical server wrapper
+- business logic stays in `server-examples/*`
+- response objects keep the generated status/contentType/data unions
+- existing adapters are reused instead of creating ad-hoc DTOs or duplicate
+  schema definitions
 ```
 
-## Key Components Explained
+## Why this example matters
 
-### 1. Express Adapter (`server-examples/express-adapter.ts`)
-
-The adapter module provides utilities to bridge generated server wrappers with
-Express:
-
-- **`extractRequestParams(req)`**: Converts Express `Request` objects into the
-  format expected by generated wrappers
-- **`sendWrapperResponse(res, result)`**: Sends wrapper results as Express
-  responses
-- **`createExpressAdapter()`**: Higher-order function for setting up routes
-
-```typescript
-// Example usage
-const params = extractRequestParams(req);
-const wrappedHandler = getPetByIdWrapper(getPetByIdHandler);
-const result = await wrappedHandler(params);
-sendWrapperResponse(res, result);
-```
-
-### 2. Server Implementation (`server-examples/express-server-example.ts`)
-
-Shows two approaches for setting up routes:
-
-**Manual approach:**
-
-```typescript
-app.get("/pet/findByStatus", async (req, res) => {
-  const params = extractRequestParams(req);
-  const wrappedHandler = findPetsByStatusWrapper(findPetsByStatusHandler);
-  const result = await wrappedHandler(params);
-  sendWrapperResponse(res, result);
-});
-```
-
-**Helper function approach:**
-
-```typescript
-setupRoute(getPetByIdWrapper, getPetByIdRoute(), getPetByIdHandler);
-```
-
-### 3. Mock Server Implementation (`server-examples/mock-server-example.ts`)
-
-Demonstrates automatic mock data generation using zocker:
-
-**Key features:**
-
-- **Automatic mock generation**: Uses zocker to generate realistic mock data for
-  all response schemas
-- **Status code coverage**: Mocks responses for all status codes defined in the
-  OpenAPI specification
-- **Validation error handling**: Provides detailed error messages for invalid
-  requests
-- **Generic handler factory**: `createMockHandler()` automatically creates
-  handlers for any operation
-
-**Mock handler pattern:**
-
-```typescript
-const createMockHandler = (routeInfo) => {
-  const handler = async (params) => {
-    if (!params.isValid) {
-      // Generate mock validation error response
-      const schema = routeInfo.responseMap["400"]["application/json"];
-      const mockData = zocker(schema).setSeed(123).generate();
-      return {
-        status: 400,
-        contentType: "application/json",
-        data: { ...mockData, message: prettifyValidationError(params) },
-      };
-    }
-
-    // Generate mock success response
-    const statusResponseMap = routeInfo.responseMap["200"];
-    const schema = statusResponseMap["application/json"];
-    const data = zocker(schema).setSeed(123).generate();
-    return { status: 200, contentType: "application/json", data };
-  };
-  return handler;
-};
-```
-
-**Automatic route registration:**
-
-```typescript
-Object.values(routes).forEach((routeFn) => {
-  registerRoute(routeFn());
-});
-```
-
-### 3. Request Parameter Extraction
-
-The `extractRequestParams` function handles parameter transformation:
-
-- **Query parameters**: Extracted from `req.query`
-- **Path parameters**: Extracted from `req.params`
-- **Headers**: Extracted from `req.headers`
-- **Body**: Passed through from `req.body`
-- **Content-Type**: Extracted from request headers
-
-Parameter names are transformed from kebab-case to camelCase to match the
-generated schemas.
-
-### 4. Handler Implementation Pattern
-
-Generated server wrappers expect handlers that follow this pattern:
-
-```typescript
-const handler: getPetByIdHandler = async (params) => {
-  if (!params.isValid) {
-    // Handle validation errors
-    return { status: 400 };
-  }
-
-  // Access validated parameters
-  const { petId } = params.value.path;
-
-  // Business logic here
-  const pet = findPetById(petId);
-
-  if (!pet) {
-    return { status: 404 };
-  }
-
-  return {
-    status: 200,
-    contentType: "application/json",
-    data: pet,
-  };
-};
-```
-
-### 5. Client Usage (`client-examples/client-example.ts`)
-
-The generated client provides type-safe functions with built-in validation:
-
-```typescript
-// Configure client for local server
-const localConfig = {
-  ...globalConfig,
-  baseURL: "http://localhost:3000",
-};
-
-// Call API with type safety
-const response = await findPetsByStatus(
-  { query: { status: "available" } },
-  localConfig,
-);
-
-if (response.status === "200") {
-  const data = response.parse();
-  if (isParsed(data)) {
-    console.log("Pets:", data.parsed);
-  } else if (data.kind === "parse-error") {
-    console.error("Validation failed:", data.error);
-  }
-} else {
-  console.error("Operation failed:", response.kind, response.error);
-}
-```
-
-### Error Handling with `neverthrow`
-
-See
-[`neverthrow-error-handling.ts`](./client-examples/neverthrow-error-handling.ts)
-for an example of how to use `neverthrow` to handle errors from the generated
-client.
-
-## Generated Code Structure
-
-### Server Wrappers (`generated/server/`)
-
-Each operation generates:
-
-- **Handler type**: `operationNameHandler` - Function signature for your
-  business logic
-- **Wrapper function**: `operationNameWrapper` - Validation and parameter
-  extraction
-- **Route function**: `route()` - Returns path and HTTP method information
-- **Response types**: Discriminated unions for all possible responses
-
-### Client Functions (`generated/client/`)
-
-Each operation generates:
-
-- **Client function**: Type-safe function for making API calls
-- **Parameter types**: Input validation schemas
-- **Response types**: Discriminated unions matching server responses
-- **Parse helpers**: Runtime validation for response data
-
-### Schemas (`generated/schemas/`)
-
-- **Zod schemas**: Runtime validation schemas for all data types
-- **TypeScript types**: Inferred types from Zod schemas
-- **Import/export structure**: Proper module organization
-
-## Benefits of This Approach
-
-1. **Type Safety**: Full TypeScript coverage from API definition to
-   implementation
-2. **Runtime Validation**: Opt‑in (`parse()` method) or automatic
-   (`forceValidation: true` in config) response validation
-3. **Error Handling**: Structured, non‑throwing error objects with discriminated
-   unions
-4. **Framework Agnostic**: Server wrappers can work with any Node.js framework
-5. **Consistent APIs**: Generated client matches server implementation exactly
-6. **Development Experience**: IntelliSense, auto-completion, and compile-time
-   checks
-7. **Mock Server Support**: Automatic mock data generation for rapid prototyping
-   and testing
-8. **Comprehensive Coverage**: Mock server supports all status codes and
-   response schemas from the OpenAPI specification
-
-## Customization
-
-### Choosing Between Server Implementations
-
-- **Use Express Server Example** (`express-server-example.ts`) when:
-  - You need custom business logic implementation
-  - You want full control over response data
-  - You're building a production API
-  - You need to integrate with databases or external services
-
-- **Use Mock Server Example** (`mock-server-example.ts`) when:
-  - You need rapid prototyping and testing
-  - You want to explore API behavior without implementing business logic
-  - You're developing client applications and need realistic test data
-  - You want to validate OpenAPI specifications with comprehensive response
-    coverage
-
-### Adding New Operations
-
-1. Update the OpenAPI specification (`examples.yaml`)
-2. Regenerate code: `pnpm generate:examples`
-3. Implement the handler in your Express server (for custom logic)
-4. Use the generated client to call the new endpoint
-
-### Custom Error Handling
-
-```typescript
-const handler: operationHandler = async (params) => {
-  if (params.kind === "query-error") {
-    // Handle query parameter validation errors
-    console.error("Query validation failed:", params.error);
-    return {
-      status: 400,
-      contentType: "application/json",
-      data: { error: "Invalid query parameters" },
-    };
-  }
-
-  if (params.kind === "path-error") {
-    // Handle path parameter validation errors
-    return {
-      status: 400,
-      contentType: "application/json",
-      data: { error: "Invalid path parameters" },
-    };
-  }
-
-  // Handle success case
-  // ...
-};
-```
-
-## Troubleshooting
-
-### Generation Issues
-
-- **File not found**: Ensure you're running the generation task
-  `pnpm generate:examples`
-- **Network issues**: Check your internet connection for downloading the OpenAPI
-  spec
-
-### Runtime Issues
-
-- **Module not found**: Ensure generated code exists by running the generation
-  task `pnpm generate:examples`
-- **Type errors**: Regenerate code after OpenAPI specification changes
-- **Connection refused**: Make sure the Express server is running before running
-  the client
+This is the best reference when you want **maximum framework control** while
+still keeping the contract generated once. If you want the contract to drive
+route registration more directly, compare it with the Hono example.

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -72,23 +72,30 @@ pnpx tsx server-examples/mock-server-example.ts
 
 ## Example prompt
 
-Use a prompt like this when you want an LLM to extend the Express integration
-without re-modeling the API:
+Use a prompt like this when you want an LLM to create Express handlers from
+scratch starting from the OpenAPI contract only:
 
 ```text
-You are working in examples/express.
+Goal: build type safe Express handlers that uses generated server wrappers
+from OpenAPI contract in `examples.yaml`.
 
-Use `examples.yaml`, `generated/routes/*`, and `generated/server/*` as the only
-source of truth for the API surface. Do not redefine paths, methods, params, or
-response payloads by hand.
+Process:
+1. Run `nps @apical-ts/craft generate -i examples.yaml -o generated --server --client`.
+2. Treat the generated files as the contract artifacts:
+   - `generated/server/*` for wrappers, handler types, and typed response unions
+   - `generated/routes/*` for path and method metadata
+3. Write `express-adapter.ts` so it:
+   - extracts query, path, headers, body, and content type from Express requests
+   - passes them to the generated wrapper
+   - translates wrapper results back into Express responses
+4. Write `express-server.ts` so it:
+   - registers the routes explicitly in Express
+   - keeps business logic inside typed handlers
+   - wraps each handler with the generated server wrapper
 
-Update the Express integration so that:
-- each route is registered from generated metadata
-- each handler is wrapped with the generated Apical server wrapper
-- business logic stays in `server-examples/*`
-- response objects keep the generated status/contentType/data unions
-- existing adapters are reused instead of creating ad-hoc DTOs or duplicate
-  schema definitions
+Rules:
+- do not hand-write endpoint definitions, DTOs, or validation schemas
+- paths, methods, params, and response shapes must come from @apical-ts/craft output
 ```
 
 ## Why this example matters

--- a/examples/hono/README.md
+++ b/examples/hono/README.md
@@ -1,62 +1,79 @@
-# Hono Mock Server Example
+# Hono Route-Metadata Example
 
-This example shows how to build a **Hono** server starting from Apical TS
-`--routes` output, then generate Hono-ready route registration files from that
-metadata.
+This example shows the **dynamic, metadata-driven** integration style. Apical TS
+first generates route metadata, then a second generator turns that metadata into
+a runnable Hono layer. The API contract stays the same; only the framework
+integration changes.
 
-## What this example demonstrates
+## Contract-first flow
 
-- route-metadata generation with `craft generate --routes`
-- a second generator step that creates `generated/hono/*`
-- automatic mock responses using `zocker`
-- request validation for path, query, headers, and request bodies via
-  `@hono/zod-validator`
+1. This example intentionally reuses `../express/examples.yaml`.
+2. `pnpm run generate:apical` runs Apical with `--routes`.
+3. Apical emits `generated/routes/*` plus the shared schemas.
+4. `pnpm run generate:hono` reads those route files and produces
+   `generated/hono/*`.
+5. `server-examples/mock-server-example.ts` mounts the generated Hono routes.
+
+## Why this is the dynamic style
+
+- **Express** wires each route explicitly with generated wrappers.
+- **Hono in this folder** derives the framework layer from generated route
+  metadata instead of registering routes one by one.
+- The contract is still modeled once, so moving from Express to Hono does not
+  require reshaping handlers, payloads, or status unions by hand.
 
 ## Quick start
 
-Install dependencies from the monorepo root:
+1. Install dependencies from the monorepo root:
 
-```bash
-pnpm install
-```
+   ```bash
+   pnpm install
+   ```
 
-Generate Apical TS routes and the Hono-specific registration layer:
+2. Generate route metadata and the Hono layer:
 
-```bash
-cd examples/hono
-pnpm run generate
-```
+   ```bash
+   cd examples/hono
+   pnpm run generate
+   ```
 
-Run the mock server:
+3. Run the mock server:
 
-```bash
-pnpm run dev
-```
+   ```bash
+   pnpm run dev
+   ```
 
 The server runs on `http://localhost:3002`.
 
 ## Project layout
 
-- `scripts/generate-hono-server.ts`: reads `generated/routes/*` and emits
-  `generated/hono/*`
-- `scripts/hono-generator/*`: modular generators for route registration, inline
-  operation handlers, usecases, runtime helpers, and file writing
-- `generated/hono/operations/*`: route registration modules with
-  `@hono/zod-validator` middleware and inline HTTP handling
-- `generated/hono/usecases/*`: zocker-backed mock business logic
-- `generated/package.json`: includes the runtime dependencies required by the
-  generated Hono layer
-- `generated/hono/runtime.ts`: generated runtime helpers for validation error
-  formatting and mocked responses
+- `generated/routes/*`: route metadata generated directly by Apical
+- `scripts/generate-hono-server.ts`: entry point for the secondary generator
+- `scripts/hono-generator/*`: Hono-specific code generation utilities
+- `generated/hono/operations/*`: generated Hono route modules
+- `generated/hono/usecases/*`: generated mock use cases backed by `zocker`
+- `generated/hono/register-routes.ts`: generated route registration entry point
 - `server-examples/mock-server-example.ts`: runnable Hono server
 
-## Why it reuses `examples/express/examples.yaml`
+## Example prompt
 
-This example intentionally reuses the same OpenAPI document as
-`examples/express`, so it is easy to compare:
+Use a prompt like this when you want an LLM to generate or extend the Hono
+integration from Apical route metadata:
 
-- the Express wrapper-based integration
-- the Hono route-metadata-driven integration
+```text
+You are working in examples/hono.
+
+Read `generated/routes/*` and use those files as the only source of truth for
+the API. Do not rewrite the OpenAPI surface manually.
+
+Generate or update the Hono integration so that:
+- path, method, params, requestMap, and responseMap come from generated route
+  metadata
+- output is written under `generated/hono/*`
+- request validation uses `@hono/zod-validator`
+- one generated Hono module exists per operation
+- mock responses come from generated schemas instead of hand-written models
+```
 
 ## Testing
 
@@ -65,4 +82,4 @@ pnpm run test
 ```
 
 The test suite regenerates the Hono layer before running so the example stays
-consistent with the OpenAPI source.
+aligned with the contract.

--- a/examples/hono/README.md
+++ b/examples/hono/README.md
@@ -57,22 +57,31 @@ The server runs on `http://localhost:3002`.
 
 ## Example prompt
 
-Use a prompt like this when you want an LLM to generate or extend the Hono
-integration from Apical route metadata:
+Use a prompt like this when you want an LLM to recreate Hono handlers from
+scratch starting from the OpenAPI contract only:
 
 ```text
-You are working in examples/hono.
+Goal: build type safe Hono handlers by first generating route metadata with @apical-ts/craft and
+then writing a generator that emits the Hono integration.
 
-Read `generated/routes/*` and use those files as the only source of truth for
-the API. Do not rewrite the OpenAPI surface manually.
+Process:
+1. Run `npx @apical-ts/craft generate --routes -i examples.yaml -o generated`.
+2. Inspect `generated/routes/*` and use them as the only source of truth for
+   `operationId`, `path`, `method`, `params`, `requestMap`, and `responseMap`.
+3. Implement the generator entrypoint in `scripts/generate-hono-server.ts`.
+4. Implement the generator modules under `scripts/hono-generator/*` so they read
+   generated route metadata and emit `generated/hono/*`.
+5. The generator should produce:
+   - one generated Hono operation module per route
+   - a register-routes module
+   - shared runtime helpers
+6. Add a runnable Hono server that imports the generated registration layer.
 
-Generate or update the Hono integration so that:
-- path, method, params, requestMap, and responseMap come from generated route
-  metadata
-- output is written under `generated/hono/*`
-- request validation uses `@hono/zod-validator`
-- one generated Hono module exists per operation
-- mock responses come from generated schemas instead of hand-written models
+Rules:
+- do not hand-write `generated/hono/*`
+- do not redefine endpoints or payload types outside @apical-ts/craft output
+- request validation must be driven by generated schemas and metadata
+- use `@hono/zod-validator` where request validation is needed
 ```
 
 ## Testing

--- a/examples/msw-mock-server/README.md
+++ b/examples/msw-mock-server/README.md
@@ -58,22 +58,36 @@ All three approaches start from the same contract and generated artifacts.
 
 ## Example prompt
 
-Use a prompt like this when you want an LLM to extend the MSW integration from
-generated Apical artifacts:
+Use a prompt like this when you want an LLM to recreate MSW handlers from
+scratch starting from the OpenAPI contract only:
 
 ```text
-You are working in examples/msw-mock-server.
+Goal: build MSW mock handlers from
+@apical-ts/craft artifacts instead of hand-writing one handler per endpoint.
 
-Use `generated/server/*`, `generated/routes/*`, and `generated/schemas/*` as
-the only API contract. Do not redefine endpoints or payload shapes manually.
+Process:
+1. Run `npx @apical-ts/craft generate -i examples.yaml -o generated --server --client`.
+2. Treat the generated files as the integration inputs:
+   - `generated/server/*` for wrappers and response maps
+   - `generated/routes/*` for path and method metadata
+   - `generated/schemas/*` for schema-driven mock data
+3. Implement `msw-adapter.ts` so it:
+   - converts MSW requests into the params expected by the generated wrappers
+   - converts wrapper results back into MSW responses
+4. Implement `mock-server-example.ts` as a handler
+   generator/factory that:
+   - iterates the generated operations
+   - creates one MSW handler per route at runtime
+   - validates requests through the generated wrappers
+   - selects response schemas from `responseMap`
+   - generates payloads with `zocker`
+5. Export the resulting handlers so they can be used with both
+   `setupServer(...)` and `setupWorker(...)`.
 
-Generate or update the MSW integration so that:
-- one handler is created per generated operation
-- method and path come from generated route info
-- request validation goes through the generated Apical wrapper
-- response schemas are selected from `responseMap`
-- mock payloads are generated from the schemas with `zocker`
-- the result works with both `setupServer(...)` and `setupWorker(...)`
+Rules:
+- do not hand-write endpoint-specific handler lists
+- do not redefine paths, params, or response payloads outside @apical-ts/craft output
+- the custom code should only be the MSW adapter and runtime handler factory
 ```
 
 ## Usage in tests

--- a/examples/msw-mock-server/README.md
+++ b/examples/msw-mock-server/README.md
@@ -1,71 +1,82 @@
-# MSW Mock Server Example
+# MSW Contract-First Mock Server Example
 
-This example demonstrates how to use **Mock Service Worker (MSW)** with the
-generated OpenAPI server wrappers and schemas to create a fully functional mock
-API server.
+This example shows how to turn Apical-generated artifacts into a **dynamic mock
+integration** with Mock Service Worker. Like the Express example, it reuses the
+generated server wrappers for validation. Unlike Express, it registers handlers
+dynamically by iterating the generated operations.
 
-## Features
+## Contract-first flow
 
-- 🎭 **MSW-based mocking**: Intercepts HTTP requests using MSW
-- 🔄 **Auto-generated mock data**: Uses `zocker` to generate realistic mock
-  responses
-- ✅ **Request validation**: Validates all incoming requests against OpenAPI
-  schemas
-- 🎯 **Type-safe handlers**: Fully typed request/response handling
-- 🔍 **Detailed error messages**: Pretty validation error reporting
-- 📊 **Multi-status support**: Mocks all response status codes defined in
-  OpenAPI spec
+1. `examples.yaml` is the source of truth.
+2. `pnpm run generate` runs Apical with `--server --client`.
+3. Apical emits:
+   - `generated/routes/*`: shared route metadata
+   - `generated/server/*`: typed wrappers and route info for mock handlers
+   - `generated/client/*`: typed client operations
+   - `generated/schemas/*`: runtime schemas reused by mocks
+4. `server-examples/msw-adapter.ts` adapts generated wrapper results to MSW.
+5. `server-examples/mock-server-example.ts` loops over the generated operations
+   and creates one MSW handler per route.
 
-## Installation
+## Where this sits on the static/dynamic spectrum
 
-```bash
-pnpm install
+- **Express**: explicit route registration, one framework binding at a time
+- **MSW in this folder**: dynamic handler registration over generated wrappers
+- **Hono**: second generator that emits a framework layer from route metadata
+
+All three approaches start from the same contract and generated artifacts.
+
+## Quick start
+
+1. Install dependencies from the monorepo root:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Generate the contract artifacts:
+
+   ```bash
+   cd examples/msw-mock-server
+   pnpm run generate
+   ```
+
+3. Run the MSW example:
+
+   ```bash
+   pnpm run dev
+   ```
+
+## Project layout
+
+- `examples.yaml`: the API contract
+- `generated/server/*`: generated wrappers reused by MSW handlers
+- `generated/routes/*`: shared route metadata
+- `server-examples/msw-adapter.ts`: MSW-specific adapter
+- `server-examples/mock-server-example.ts`: dynamic handler registration and
+  `zocker`-based responses
+
+## Example prompt
+
+Use a prompt like this when you want an LLM to extend the MSW integration from
+generated Apical artifacts:
+
+```text
+You are working in examples/msw-mock-server.
+
+Use `generated/server/*`, `generated/routes/*`, and `generated/schemas/*` as
+the only API contract. Do not redefine endpoints or payload shapes manually.
+
+Generate or update the MSW integration so that:
+- one handler is created per generated operation
+- method and path come from generated route info
+- request validation goes through the generated Apical wrapper
+- response schemas are selected from `responseMap`
+- mock payloads are generated from the schemas with `zocker`
+- the result works with both `setupServer(...)` and `setupWorker(...)`
 ```
 
-## Generate Client/Server Code
-
-```bash
-pnpm generate
-```
-
-This generates TypeScript client, server wrappers, and Zod schemas from
-`examples.yaml`.
-
-## Run the Mock Server
-
-```bash
-pnpm dev
-```
-
-The server will start and log all registered handlers.
-
-## How It Works
-
-### MSW Adapter
-
-The `msw-adapter.ts` module provides a bridge between the generated OpenAPI
-server wrappers and MSW's handler API:
-
-- **`createMswHandler`**: Converts generated route info into MSW request
-  handlers
-- **Parameter extraction**: Maps MSW request objects to the wrapper's expected
-  format
-- **Response formatting**: Converts wrapper responses to MSW's response format
-
-### Mock Server Example
-
-The `mock-server-example.ts` demonstrates:
-
-1. **Handler registration**: Automatically registers all generated operations as
-   MSW handlers
-2. **Mock data generation**: Uses `zocker` with response schemas to generate
-   realistic data
-3. **Validation handling**: Returns appropriate 400 errors with detailed
-   messages for invalid requests
-4. **Status code selection**: Intelligently picks the best status code to mock
-   (prefers 2xx)
-
-## Usage in Tests
+## Usage in tests
 
 ```typescript
 import { setupServer } from "msw/node";
@@ -76,17 +87,9 @@ const server = setupServer(...handlers);
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
-
-test("fetches pets", async () => {
-  const response = await fetch("http://localhost:3001/pets");
-  const pets = await response.json();
-  expect(Array.isArray(pets)).toBe(true);
-});
 ```
 
-## Usage in Browser
-
-Create a browser setup file:
+## Usage in the browser
 
 ```typescript
 import { setupWorker } from "msw/browser";
@@ -99,125 +102,10 @@ export async function startMocking() {
 }
 ```
 
-Then in your app:
+See `server-examples/browser-setup.ts` for the complete browser bootstrap.
 
-```typescript
-import { startMocking } from "./browser-setup.js";
+## Testing
 
-if (import.meta.env.DEV) {
-  await startMocking();
-}
+```bash
+pnpm run test
 ```
-
-See [browser-setup.ts](./server-examples/browser-setup.ts) for a complete
-example.
-
-## Customization
-
-You can customize the mock responses by:
-
-1. **Modifying the `createMockHandler` logic** in
-   [mock-server-example.ts](./server-examples/mock-server-example.ts)
-2. **Adding custom response data** instead of using `zocker`
-3. **Implementing specific business logic** for certain operations
-4. **Customizing the base URL** by passing it to `createHandlers(baseUrl)`
-
-### Example: Custom Handler
-
-```typescript
-import { createMswHandler } from "./msw-adapter.js";
-import { routes } from "../generated/server/index.js";
-
-const customHandler = async (params: any) => {
-  if (!params.isValid) {
-    return {
-      status: "400",
-      contentType: "application/json",
-      data: { error: "Validation failed" },
-    };
-  }
-
-  /* Custom business logic */
-  const petId = params.value.path.petId;
-
-  return {
-    status: "200",
-    contentType: "application/json",
-    data: {
-      id: petId,
-      name: "Custom Pet Name",
-      status: "available",
-    },
-  };
-};
-
-const routeInfo = routes.getPetById();
-const handler = createMswHandler(
-  routeInfo,
-  customHandler,
-  "http://localhost:3001",
-);
-```
-
-## Advanced Usage
-
-### Response Delay Simulation
-
-```typescript
-import { delay } from "msw";
-
-const handler: any = async (params: any) => {
-  /* Simulate network delay */
-  await delay(1000);
-
-  /* Return mock response */
-  return {
-    status: "200",
-    contentType: "application/json",
-    data: mockData,
-  };
-};
-```
-
-### Dynamic Response Based on Request
-
-```typescript
-const handler: any = async (params: any) => {
-  const status = params.value.query?.status;
-
-  /* Return different data based on query parameter */
-  if (status?.includes("available")) {
-    return {
-      status: "200",
-      contentType: "application/json",
-      data: [
-        /* Available pets */
-      ],
-    };
-  }
-
-  return {
-    status: "200",
-    contentType: "application/json",
-    data: [
-      /* Other pets */
-    ],
-  };
-};
-```
-
-## Comparison with Express Example
-
-This MSW example is equivalent to the
-[Express mock server example](../express/server-examples/mock-server-example.ts)
-but offers these advantages:
-
-- ✅ Works in both Node.js and browser environments
-- ✅ No server port binding required
-- ✅ Ideal for testing without network overhead
-- ✅ Can intercept requests from any HTTP client
-- ✅ Perfect for frontend development and testing
-
-## License
-
-MIT

--- a/examples/react-query-hooks/README.md
+++ b/examples/react-query-hooks/README.md
@@ -58,21 +58,32 @@ See `example/Usage.tsx` for a minimal consumption example.
 
 ## Example prompt
 
-Use a prompt like this when you want an LLM to generate hooks from Apical
-artifacts without redesigning the API:
+Use a prompt like this when you want an LLM to recreate react-query hooks from
+scratch starting from the OpenAPI contract only:
 
 ```text
-You are working in examples/react-query-hooks.
+Goal: build a generator that produces React Query hooks from @apical-ts/craft output.
 
-Use `generated/client/index.ts` and `generated/routes/index.ts` as the only API
-contract. Do not restate endpoints, payload types, or HTTP methods manually.
+Process:
+1. Run `npx @apical-ts/craft generate --client -i swagger.json -o generated`.
+2. Treat the generated files as the inputs to the hook generator:
+   - `generated/client/*` for operation functions and their types
+   - `generated/routes/*` for operation metadata and HTTP methods
+3. Implement `scripts/generate-hooks.ts` as the generator entrypoint.
+4. Make the generator read the @apical-ts/craft outputs and emit
+   `generated/react-query-hooks/*`.
+5. The generator must:
+   - map GET and HEAD operations to `useX` query hooks
+   - map POST, PUT, PATCH, and DELETE operations to `useXMutation` hooks
+   - derive hook names from generated operation names
+   - derive parameter and result types from the generated client functions
+6. Generate an `index.ts` file and a small example component that imports the
+   emitted hooks.
 
-Generate or update React Query hooks so that:
-- GET and HEAD operations become `useX` hooks
-- POST, PUT, PATCH, and DELETE operations become `useXMutation` hooks
-- hook names come from generated operation names
-- parameter and result types come from the generated client functions
-- output is written under `generated/react-query-hooks/*`
+Rules:
+- do not hand-write files under `generated/react-query-hooks/*`
+- do not duplicate endpoint definitions or payload types
+- the custom code belongs in the hook generator and usage example only
 ```
 
 ## Example usage

--- a/examples/react-query-hooks/README.md
+++ b/examples/react-query-hooks/README.md
@@ -1,31 +1,87 @@
-This package generates a typed API client and React Query hooks from an OpenAPI
-spec using Apical TS generators.
+# React Query Hooks from Generated Client and Routes
 
-Quick start:
+This example shows a **contract-derived frontend integration**. Apical TS
+generates the client operations once, then a second generator turns those
+operations and route metadata into React Query hooks. No endpoint modeling is
+duplicated in the frontend layer.
 
-1. Install dependencies at repo root:
+## Contract-first flow
 
-```bash
-pnpm install
+1. `swagger.json` is the source contract.
+2. `pnpm run generate:client` generates:
+   - `generated/client/*`: typed operation functions
+   - `generated/routes/*`: route metadata, including HTTP methods
+   - `generated/schemas/*`: shared Zod schemas
+3. `pnpm run generate:hooks` reads the generated client and routes and emits
+   `generated/react-query-hooks/*`.
+4. `example/Usage.tsx` consumes the generated hooks.
+
+## Why this is dynamic reuse
+
+- Hook names are derived from generated operation names.
+- `GET` / `HEAD` operations become `useX` query hooks.
+- Write operations become `useXMutation` hooks.
+- The frontend never needs its own copy of route names, payload types, or
+  response unions.
+
+## Quick start
+
+1. Install dependencies from the monorepo root:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Generate the client and hooks:
+
+   ```bash
+   cd examples/react-query-hooks
+   pnpm run generate
+   ```
+
+3. Build the example package:
+
+   ```bash
+   pnpm run build
+   ```
+
+See `example/Usage.tsx` for a minimal consumption example.
+
+## Project layout
+
+- `swagger.json`: the API contract
+- `generated/client/*`: generated operation functions
+- `generated/routes/*`: generated route metadata
+- `scripts/generate-hooks.ts`: secondary generator that emits React Query hooks
+- `generated/react-query-hooks/*`: generated hooks
+- `example/Usage.tsx`: example component using the generated hooks
+
+## Example prompt
+
+Use a prompt like this when you want an LLM to generate hooks from Apical
+artifacts without redesigning the API:
+
+```text
+You are working in examples/react-query-hooks.
+
+Use `generated/client/index.ts` and `generated/routes/index.ts` as the only API
+contract. Do not restate endpoints, payload types, or HTTP methods manually.
+
+Generate or update React Query hooks so that:
+- GET and HEAD operations become `useX` hooks
+- POST, PUT, PATCH, and DELETE operations become `useXMutation` hooks
+- hook names come from generated operation names
+- parameter and result types come from the generated client functions
+- output is written under `generated/react-query-hooks/*`
 ```
 
-2. Generate client + hooks:
+## Example usage
 
-```bash
-pnpm run generate
+```tsx
+const { data, isLoading, error } = useFindPetsByStatus({
+  query: { status: ["available"] },
+});
 ```
 
-3. You can also run only the client or only the hooks generator from top-level:
-
-```bash
-pnpm --filter @apical-ts/react-query-hooks --workspace run generate
-```
-
-4. Example React usage is at `./example/Usage.tsx`.
-
-Notes:
-
-- The hooks generator emits typed hooks that derive input and return types from
-  the generated client operations.
-- It emits `useX` query hooks for GET/HEAD operations and `useXMutation`
-  mutation hooks for other methods.
+This is the same contract-first idea as the Hono and MSW examples, applied to a
+frontend adapter instead of a server framework.


### PR DESCRIPTION
Enhance documentation and examples to clarify the contract-first approach for various integrations, including Express, Hono, MSW, and React Query. Update example prompts to improve understanding of LLM integration. Clean up the homepage for a more streamlined appearance.