### PR TITLE
Improve homepage UX and generated-output guidance

### DIFF
--- a/apps/website/docs/cli-usage.md
+++ b/apps/website/docs/cli-usage.md
@@ -182,15 +182,10 @@ handle runtime validation.
 ## Formatting Generated Code
 
 For performance reasons, the CLI does not format the generated TypeScript files
-by default. To format them you may use [Biome](https://biomejs.dev/) running the
-following command in the output directory:
+by default. To format them you may use
+[oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) running the following
+command in the output directory:
 
 ```bash
-npx @biomejs/biome format --write .
-```
-
-Alternatively, you can use any other slower code formatter of your choice, e.g.
-
-```bash
-npx prettier --log-level=silent --write .
+npx oxfmt
 ```

--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -5,9 +5,10 @@ import type * as Preset from "@docusaurus/preset-classic";
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const siteTitle = "@apical-ts/craft";
-const siteTagline = "From OpenAPI to your TypeScript stack.";
+const siteTagline =
+  "Generate exact Zod schemas, typed clients, and server wrappers from OpenAPI.";
 const siteDescription =
-  "Generate Zod v4 schemas, typed clients, and server wrappers from one OpenAPI specification.";
+  "Turn one OpenAPI specification into exact Zod v4 schemas, route metadata, typed clients, and server wrappers for TypeScript.";
 const siteUrl = "https://gunzip.github.io";
 const siteBaseUrl = "/apical-ts/";
 const siteBasePath = `${siteUrl}${siteBaseUrl}`;

--- a/apps/website/src/pages/index.module.css
+++ b/apps/website/src/pages/index.module.css
@@ -376,6 +376,7 @@
 .outputModalBackdrop {
   align-items: center;
   background: rgba(3, 8, 16, 0.72);
+  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   display: flex;
   inset: 0;
@@ -427,6 +428,15 @@
   padding: 0.6rem 1.15rem 0;
 }
 
+.outputModalActions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: flex-end;
+}
+
+.outputModalNav,
 .outputModalClose {
   align-items: center;
   background: rgba(12, 20, 33, 0.55);
@@ -437,6 +447,7 @@
   display: inline-flex;
   font-size: 0.9rem;
   font-weight: 600;
+  gap: 0.35rem;
   min-height: 40px;
   padding: 0 0.95rem;
   transition:
@@ -445,12 +456,14 @@
     transform 0.2s ease;
 }
 
+.outputModalNav:hover,
 .outputModalClose:hover {
   background: rgba(15, 26, 42, 0.8);
   border-color: rgba(166, 204, 255, 0.32);
   transform: translateY(-1px);
 }
 
+.outputModalNav:focus-visible,
 .outputModalClose:focus-visible {
   border-color: rgba(166, 204, 255, 0.42);
   outline: 2px solid rgba(166, 204, 255, 0.28);
@@ -636,6 +649,12 @@
     flex-direction: column;
   }
 
+  .outputModalActions {
+    justify-content: stretch;
+    width: 100%;
+  }
+
+  .outputModalNav,
   .outputModalClose {
     justify-content: center;
     width: 100%;
@@ -659,6 +678,7 @@
   .previewFrame,
   .outputCard,
   .outputButton,
+  .outputModalNav,
   .outputModalClose,
   .heroActions :global(.button).primaryAction {
     transition: none;

--- a/apps/website/src/pages/index.module.css
+++ b/apps/website/src/pages/index.module.css
@@ -84,7 +84,7 @@
 }
 
 .heroBanner {
-  padding: clamp(3.5rem, 7vw, 3.75rem) 0 2.75rem;
+  padding: clamp(3.25rem, 7vw, 5rem) 0 3rem;
   position: relative;
 }
 
@@ -104,25 +104,26 @@
 }
 
 .heroLayout {
-  align-items: center;
+  align-items: start;
   display: grid;
   gap: clamp(2rem, 5vw, 4.5rem);
-  grid-template-columns: minmax(0, 1.24fr) minmax(320px, 0.76fr);
+  grid-template-columns: minmax(0, 1.18fr) minmax(320px, 0.82fr);
   position: relative;
   z-index: 1;
 }
 
 .heroBody {
-  max-width: 43rem;
+  max-width: 41rem;
 }
 
 .eyebrow,
 .sectionEyebrow,
 .previewPill,
 .featureIndex,
-.resourceMeta,
 .proofLabel,
-.integrationLead {
+.resourceMeta,
+.integrationLabel,
+.workflowStep {
   color: var(--page-soft);
   font-size: 0.75rem;
   font-weight: 700;
@@ -144,85 +145,24 @@
 }
 
 .heroTitle {
-  font-size: clamp(2.35rem, 5.1vw, 3.95rem);
+  font-size: clamp(2.35rem, 4.6vw, 3.75rem);
   line-height: 0.96;
-  max-width: 15ch;
 }
 
 .heroSummary {
-  color: var(--page-muted);
-  font-size: 1.08rem;
-  line-height: 1.78;
-  margin: 1.25rem 0 0;
+  color: var(--page-text);
+  font-size: 1.12rem;
+  line-height: 1.68;
+  margin: 1.2rem 0 0;
   max-width: 36rem;
 }
 
 .heroDetail {
-  color: var(--page-text);
-  font-size: 0.98rem;
-  line-height: 1.75;
-  margin: 0.9rem 0 0;
+  color: var(--page-muted);
+  font-size: 1rem;
+  line-height: 1.72;
+  margin: 1rem 0 0;
   max-width: 36rem;
-}
-
-.integrationStrip {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem 0.9rem;
-  margin-top: 1.15rem;
-}
-
-.integrationList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.integrationItem {
-  align-items: center;
-  background: var(--page-surface);
-  border: 1px solid var(--page-border);
-  border-radius: 999px;
-  color: var(--page-text);
-  display: inline-flex;
-  gap: 0.45rem;
-  padding: 0.62rem 0.84rem;
-  text-decoration: none;
-  transition:
-    background-color 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.2s ease;
-}
-
-.integrationItem:hover {
-  background: var(--page-surface-strong);
-  border-color: var(--page-border-strong);
-  color: var(--page-text);
-  text-decoration: none;
-  transform: translateY(-1px);
-}
-
-.integrationName {
-  color: var(--page-text);
-  font-size: 0.92rem;
-  font-weight: 700;
-}
-
-.integrationDivider {
-  color: var(--page-soft);
-  font-size: 0.78rem;
-}
-
-.integrationLabel {
-  color: var(--page-soft);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
 }
 
 .heroActions {
@@ -230,7 +170,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.85rem;
-  margin-top: 1.75rem;
+  margin-top: 1.45rem;
 }
 
 .heroActions :global(.button).primaryAction {
@@ -258,8 +198,8 @@
   padding: 0 1.2rem;
   text-decoration: none;
   transition:
-    border-color 0.2s ease,
     background-color 0.2s ease,
+    border-color 0.2s ease,
     transform 0.2s ease;
 }
 
@@ -273,28 +213,28 @@
 
 .proofGrid {
   display: grid;
-  gap: 0.9rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.95rem;
+  grid-template-columns: repeat(auto-fit, minmax(185px, 1fr));
   list-style: none;
-  margin: 1.4rem 0 0;
+  margin: 1.55rem 0 0;
   padding: 0;
 }
 
 .proofItem {
   background: var(--page-surface);
   border: 1px solid var(--page-border);
-  border-radius: 18px;
+  border-radius: 20px;
   min-height: 100%;
-  padding: 1rem 1rem 1.05rem;
+  padding: 1rem 1.05rem 1.1rem;
 }
 
 .proofValue {
   color: var(--page-text);
   display: block;
-  font-size: 0.96rem;
+  font-size: 0.97rem;
   font-weight: 600;
-  line-height: 1.55;
-  margin-top: 0.4rem;
+  line-height: 1.58;
+  margin-top: 0.45rem;
 }
 
 .heroPreview {
@@ -305,6 +245,8 @@
 .previewFrame,
 .outputCard,
 .featureCard,
+.workflowCard,
+.integrationCard,
 .resourceCard {
   border: 1px solid var(--page-border);
   border-radius: 24px;
@@ -321,14 +263,10 @@
   overflow: hidden;
 }
 
-.featureCard,
-.resourceCard {
-  background: var(--page-surface);
-}
-
 .previewHeader {
   align-items: center;
   display: flex;
+  gap: 0.75rem;
   justify-content: space-between;
   padding: 1.1rem 1.25rem 0;
 }
@@ -362,8 +300,165 @@
   color: #eff5ff !important;
 }
 
-.outputCard {
-  min-height: 100%;
+.outputBody {
+  display: grid;
+  gap: 1rem;
+  padding: 0.9rem 1.25rem 1.35rem;
+}
+
+.outputSummary {
+  color: #eff5ff;
+  font-size: 1rem;
+  line-height: 1.68;
+  margin: 0;
+}
+
+.outputList {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.outputButton {
+  align-items: flex-start;
+  background: rgba(12, 20, 33, 0.55);
+  border: 1px solid rgba(166, 204, 255, 0.16);
+  border-radius: 18px;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.75rem 0.85rem;
+  text-align: left;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
+  width: 100%;
+}
+
+.outputButton:hover {
+  background: rgba(15, 26, 42, 0.8);
+  border-color: rgba(166, 204, 255, 0.32);
+  transform: translateY(-1px);
+}
+
+.outputButton:focus-visible {
+  border-color: rgba(166, 204, 255, 0.42);
+  outline: 2px solid rgba(166, 204, 255, 0.28);
+  outline-offset: 2px;
+}
+
+.outputButtonActive {
+  background: rgba(19, 35, 56, 0.95);
+  border-color: rgba(166, 204, 255, 0.36);
+}
+
+.outputTitle {
+  color: #ffffff;
+  display: block;
+  font-size: 0.96rem;
+  font-weight: 700;
+}
+
+.outputPath {
+  color: var(--code-panel-muted);
+  display: block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.outputModalBackdrop {
+  align-items: center;
+  background: rgba(3, 8, 16, 0.72);
+  backdrop-filter: blur(8px);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1.5rem;
+  position: fixed;
+  z-index: 30;
+}
+
+.outputModal {
+  background: var(--code-panel-bg);
+  border: 1px solid var(--code-panel-border);
+  border-radius: 24px;
+  box-shadow: 0 36px 90px -42px rgba(0, 0, 0, 0.85);
+  max-height: min(80vh, 760px);
+  max-width: 760px;
+  overflow: auto;
+  width: min(100%, 760px);
+}
+
+.outputModalHeader {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1.1rem 1.15rem 0;
+}
+
+.outputModalTitle {
+  color: #ffffff;
+  display: block;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.outputModalMeta {
+  color: var(--code-panel-muted);
+  display: block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  margin-top: 0.15rem;
+}
+
+.outputModalLead {
+  color: var(--code-panel-muted);
+  font-size: 0.94rem;
+  line-height: 1.58;
+  margin: 0;
+  padding: 0.6rem 1.15rem 0;
+}
+
+.outputModalClose {
+  align-items: center;
+  background: rgba(12, 20, 33, 0.55);
+  border: 1px solid rgba(166, 204, 255, 0.16);
+  border-radius: 999px;
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.9rem;
+  font-weight: 600;
+  min-height: 40px;
+  padding: 0 0.95rem;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.outputModalClose:hover {
+  background: rgba(15, 26, 42, 0.8);
+  border-color: rgba(166, 204, 255, 0.32);
+  transform: translateY(-1px);
+}
+
+.outputModalClose:focus-visible {
+  border-color: rgba(166, 204, 255, 0.42);
+  outline: 2px solid rgba(166, 204, 255, 0.28);
+  outline-offset: 2px;
+}
+
+.outputModalCode {
+  padding-top: 0.7rem !important;
 }
 
 .mainContent {
@@ -373,11 +468,7 @@
 }
 
 .section {
-  padding-top: 1rem;
-}
-
-.section + .section {
-  padding-top: 0.5rem;
+  padding-top: clamp(2rem, 5vw, 3rem);
 }
 
 .sectionStack {
@@ -387,91 +478,52 @@
 }
 
 .sectionIntro {
-  max-width: 42rem;
+  max-width: 46rem;
 }
 
 .sectionTitle {
-  font-size: clamp(2.1rem, 5vw, 3.3rem);
+  font-size: clamp(2.15rem, 5vw, 3.35rem);
 }
 
 .sectionLead {
   color: var(--page-muted);
-  font-size: 1.02rem;
+  font-size: 1.04rem;
   line-height: 1.75;
-  margin: 0.9rem 0 0;
+  margin: 0.95rem 0 0;
 }
 
 .featureGrid,
+.workflowGrid,
+.integrationGrid,
 .resourceGrid {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-}
-
-.featureCard {
-  min-height: 100%;
-  padding: 1.4rem 1.4rem 1.5rem;
-}
-
-.featureTitle {
-  color: var(--page-text);
-  font-family: "Manrope", sans-serif;
-  font-size: 1.18rem;
-  letter-spacing: 0.01em;
-  line-height: 1.25;
-  margin: 0.9rem 0 0.7rem;
-}
-
-.featureDescription {
-  color: var(--page-muted);
-  line-height: 1.72;
-  margin: 0;
-}
-
-.resourceCard {
-  color: inherit;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  min-height: 100%;
-  padding: 1.4rem;
-  text-decoration: none;
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease,
-    transform 0.2s ease;
-}
-
-.resourceTitle {
-  color: var(--page-text);
-  font-size: 1.05rem;
-  font-weight: 700;
-  line-height: 1.3;
-}
-
-.resourceDescription {
-  color: var(--page-muted);
-  line-height: 1.72;
-}
-
-.resourceMeta {
-  margin-top: auto;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .featureCard,
+.workflowCard,
+.integrationCard,
 .resourceCard {
+  background: var(--page-surface);
+  min-height: 100%;
+  padding: 1.45rem 1.4rem 1.5rem;
   transition:
-    border-color 0.2s ease,
     background-color 0.2s ease,
+    border-color 0.2s ease,
     transform 0.2s ease;
 }
 
 .previewFrame,
 .outputCard {
-  transition: transform 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .featureCard:hover,
+.workflowCard:hover,
+.integrationCard:hover,
 .resourceCard:hover {
   background: var(--page-surface-strong);
   border-color: var(--page-border-strong);
@@ -481,7 +533,58 @@
 
 .previewFrame:hover,
 .outputCard:hover {
+  border-color: var(--page-border-strong);
   transform: translateY(-2px);
+}
+
+.featureTitle,
+.workflowTitle,
+.integrationName,
+.resourceTitle {
+  color: var(--page-text);
+  font-family: "Manrope", sans-serif;
+  font-size: 1.18rem;
+  letter-spacing: 0.01em;
+  line-height: 1.28;
+  margin: 0.9rem 0 0.7rem;
+}
+
+.featureDescription,
+.workflowDescription,
+.integrationDescription,
+.resourceDescription {
+  color: var(--page-muted);
+  line-height: 1.72;
+  margin: 0;
+}
+
+.workflowStep {
+  display: block;
+}
+
+.integrationCard,
+.resourceCard {
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-decoration: none;
+}
+
+.integrationHeader {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.integrationName,
+.resourceTitle {
+  margin: 0;
+}
+
+.resourceMeta {
+  margin-top: auto;
 }
 
 @media (max-width: 996px) {
@@ -501,7 +604,7 @@
 
 @media (max-width: 640px) {
   .heroBanner {
-    padding-top: 3.5rem;
+    padding-top: 3.25rem;
   }
 
   .heroActions {
@@ -515,28 +618,48 @@
     width: 100%;
   }
 
-  .previewHeader {
+  .previewHeader,
+  .integrationHeader {
     align-items: flex-start;
     flex-direction: column;
-    gap: 0.45rem;
   }
 
-  .integrationList {
-    gap: 0.55rem;
+  .outputList {
+    grid-template-columns: 1fr;
   }
 
-  .integrationStrip {
-    align-items: flex-start;
+  .outputModalBackdrop {
+    padding: 1rem;
+  }
+
+  .outputModalHeader {
     flex-direction: column;
+  }
+
+  .outputModalClose {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .proofGrid,
+  .featureGrid,
+  .workflowGrid,
+  .integrationGrid,
+  .resourceGrid {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .secondaryAction,
   .featureCard,
+  .workflowCard,
+  .integrationCard,
   .resourceCard,
   .previewFrame,
   .outputCard,
+  .outputButton,
+  .outputModalClose,
   .heroActions :global(.button).primaryAction {
     transition: none;
   }
@@ -548,7 +671,10 @@
     letter-spacing: 0.02em;
   }
 
-  .featureTitle {
+  .featureTitle,
+  .workflowTitle,
+  .integrationName,
+  .resourceTitle {
     letter-spacing: 0.015em;
   }
 }

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -37,7 +37,7 @@ const outputExamples = {
     path: "schemas/",
     note: "Validate payloads and infer exact runtime-safe types.",
     language: "typescript",
-    code: `import { UserSchema } from "./generated/schemas";
+    code: `import { UserSchema } from "./generated/schemas/User.js";
 
 const result = UserSchema.safeParse(apiResponse);
 

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState, type ComponentProps } from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
@@ -12,139 +13,281 @@ const previewCommand = `npx @apical-ts/craft generate \\
   -o ./generated \\
   --client --server`;
 
-const clientPreview = `import { findPetsByStatus } from "./generated/operations/findPetsByStatus.js";
+const heroHighlights = [
+  {
+    label: "Reusable output",
+    value: "Generate schemas, routes, client operations, and server wrappers.",
+  },
+  {
+    label: "Large specs",
+    value: "Selective imports keep very large APIs practical in real apps.",
+  },
+  {
+    label: "Safe responses",
+    value: "Narrowed responses, discriminated by status code and content type.",
+  },
+] as const;
+
+const outputOrder = ["schema", "route", "client", "server"] as const;
+type OutputExampleId = (typeof outputOrder)[number];
+
+const outputExamples = {
+  schema: {
+    title: "Schema",
+    path: "schemas/",
+    note: "Validate payloads and infer exact runtime-safe types.",
+    language: "typescript",
+    code: `import { UserSchema } from "./generated/schemas";
+
+const result = UserSchema.safeParse(apiResponse);
+
+if (result.success) {
+  console.log(result.data.email);
+}`,
+  },
+  route: {
+    title: "Route",
+    path: "routes/",
+    note: "Read generated method/path metadata for adapters and tooling.",
+    language: "typescript",
+    code: `import { getPetByIdRoute } from "./generated/routes/getPetById.js";
+
+const route = getPetByIdRoute();
+
+console.log({
+  method: route.method,
+  path: route.path,
+  responseMap: route.responseMap,
+  requestMap: route.requestMap,
+});`,
+  },
+  client: {
+    title: "Client",
+    path: "client/",
+    note: "Call one operation and branch on typed responses.",
+    language: "typescript",
+    code: `import { findPetsByStatus } from "./generated/client/findPetsByStatus.js";
 
 // Import just the operations you need
 // without pulling in a huge client bundle.
-const r = await findPetsByStatus({
+const response = await findPetsByStatus({
   query: { status: "available" },
 });
 
 // Strict typing over status code and content type
 // using discriminated unions guides agents toward safe code
-if (r.status === "200") {
+if (response.status === "200") {
   // Zod v4 parsed payload
-  console.log(r.parsed.data[0].name);
-}
-`;
+  console.log(response.parsed.data[0].name);
+}`,
+  },
+  server: {
+    title: "Server",
+    path: "server/",
+    note: "Write typed handlers and keep validation inside the wrapper.",
+    language: "typescript",
+    code: `import type { getPetByIdHandler } from "./generated/server/getPetById.js";
 
-const integrationPills = [
+const handler: getPetByIdHandler = async (params) => {
+  if (!params.isValid) return { status: "400" };
+
+  const petId = params.value.path.petId;
+  const pet = mockPets.find((candidate) => candidate.id === petId);
+  if (!pet) return { status: "404" };
+
+  return {
+    status: "200",
+    contentType: "application/json",
+    data: pet,
+  };
+};`,
+  },
+} satisfies Record<
+  OutputExampleId,
+  {
+    title: string;
+    path: string;
+    note: string;
+    language: string;
+    code: string;
+  }
+>;
+
+const featureCards = [
+  {
+    index: "Exact contract layer",
+    title: "Make the generated contract the source of truth",
+    description:
+      "Generate precise request, response, and route shapes once, then reuse them across frontend code, server handlers, tests, and custom tooling.",
+  },
+  {
+    index: "No framework lock-in",
+    title: "Keep your runtime choices open",
+    description:
+      "Apical generates the hard layer first. Plug it into Hono, Express, MSW, React Query, or your own adapters without getting trapped in a plugin.",
+  },
+  {
+    index: "Scales with the spec",
+    title: "Stay practical on very large APIs",
+    description:
+      "Operation-level output and selective imports keep large OpenAPI documents usable in application code instead of collapsing into one oversized client.",
+  },
+  {
+    index: "Agent-friendly typing",
+    title: "Give coding agents safer primitives",
+    description:
+      "Discriminated response unions and exact request shapes help generated and agent-written code branch safely and stay aligned with the API contract.",
+  },
+] as const;
+
+const workflowSteps = [
+  {
+    step: "01",
+    title: "Point at one OpenAPI document",
+    description:
+      "Use a local file or URL and keep one contract as the source of truth for every generated layer.",
+  },
+  {
+    step: "02",
+    title: "Generate the layers you need",
+    description:
+      "Emit Zod schemas, route metadata, client operations, and server wrappers from the same spec.",
+  },
+  {
+    step: "03",
+    title: "Compose your own integrations",
+    description:
+      "Use the generated output directly or build custom adapters around it for frameworks, tests, and internal tooling.",
+  },
+] as const;
+
+const integrationCards = [
   {
     name: "Hono",
     label: "custom handlers",
+    description:
+      "Derive framework routes from generated metadata while keeping validation and contract logic centralized.",
     href: "https://github.com/gunzip/apical-ts/tree/main/examples/hono",
   },
   {
     name: "MSW",
     label: "mock routes",
+    description:
+      "Generate mock handlers from the same operations you use in production clients and test suites.",
     href: "https://github.com/gunzip/apical-ts/tree/main/examples/msw-mock-server",
   },
   {
     name: "React Query",
     label: "client hooks",
+    description:
+      "Wrap operation functions in hooks without giving up tree-shaking or precise response typing.",
     href: "https://github.com/gunzip/apical-ts/tree/main/examples/react-query-hooks",
   },
 ] as const;
 
-const featureCards = [
+const resourceCards = [
   {
-    index: "AI adapters",
-    title: "Precise building blocks for custom integrations",
+    title: "Get started",
     description:
-      "Precise per-operation schemas and route shapes give agents enough structure. Save tokens generating custom Hono, MSW, or React Query adapters deterministically.",
+      "Install the package, run the generator, and inspect the output structure end to end.",
+    to: "/docs/introduction",
+    meta: "Documentation",
   },
   {
-    index: "No rigid plugins",
-    title: "Integrations are vibe-coded starters, not framework lock-in",
+    title: "Learn the CLI",
     description:
-      "No opinionated plugins. Just exact types and small examples you can inspect, extend, and regenerate with AI.",
+      "Review flags like --client, --server, and --routes with concrete command examples.",
+    to: "/docs/cli-usage",
+    meta: "Command reference",
   },
   {
-    index: "Tree shaking",
-    title: "Selective imports stay practical on very large specs",
+    title: "Browse integration patterns",
     description:
-      "Import only the operations you actually call, even when the OpenAPI document defines thousands of endpoints.",
-  },
-  {
-    index: "Typed responses",
-    title: "Discriminated unions guide coding agents toward safe code",
-    description:
-      "Responses narrow by status code and content type, so agent-written code can branch safely with strong typing.",
+      "See how generated contracts plug into framework glue, mock servers, and custom tooling.",
+    to: "/docs/schema-generation/framework-integrations",
+    meta: "Examples and patterns",
   },
 ] as const;
 
+function HomepageLink(props: ComponentProps<typeof Link>) {
+  // @ts-ignore - React 19 includes bigint in ReactNode but Docusaurus uses React 18 types.
+  return <Link {...props} />;
+}
+
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
+  const [openOutputId, setOpenOutputId] = useState<OutputExampleId | null>(
+    null,
+  );
+  const activeOutput = openOutputId ? outputExamples[openOutputId] : null;
+
+  useEffect(() => {
+    if (!openOutputId) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpenOutputId(null);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [openOutputId]);
 
   return (
     <header className={styles.heroBanner}>
       <div className={clsx("container", styles.heroLayout)}>
         <div className={styles.heroBody}>
-          {/* <div className={styles.eyebrow}>{siteConfig.title}</div> */}
           <Heading as="h1" className={styles.heroTitle}>
-            {siteConfig.tagline}
+            From OpenAPI to your TypeScript stack.
           </Heading>
           <p className={styles.heroSummary}>
-            @apical-ts/craft extracts exact Zod v4 schemas from your OpenAPI
-            contract to give your coding agents a rock-solid foundation. The
-            automated client is useful, but the real value is this: you can
-            "vibe-code" <strong>custom integrations</strong> with complete,
-            deterministic confidence that your code will never drift out of sync
-            with the API contract.
-          </p>
-          <div className={styles.integrationStrip}>
-            <ul className={styles.integrationList}>
-              {integrationPills.map((integration) => (
-                <li key={integration.name}>
-                  {/* @ts-ignore - React 19 includes bigint in ReactNode but Docusaurus uses React 18 types */}
-                  <Link
-                    className={styles.integrationItem}
-                    href={integration.href}
-                  >
-                    <span className={styles.integrationName}>
-                      {integration.name}
-                    </span>
-                    <span className={styles.integrationDivider}>/</span>
-                    <span className={styles.integrationLabel}>
-                      {integration.label}
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <p className={styles.heroDetail}>
-            Hand-written glue and AI-generated scaffolding both tend to get
-            route contracts subtly wrong. Apical focuses on that hard layer
-            first, then lets you generate or compose clients, server wrappers,
-            and custom adapters on top of a contract that stays precise.
+            <strong>{siteConfig.title}</strong> generates Zod v4 schemas, route
+            metadata, typed clients, and server wrappers from one OpenAPI
+            document.
           </p>
           <div className={styles.heroActions}>
-            {/* @ts-ignore - React 19 includes bigint in ReactNode but Docusaurus uses React 18 types */}
-            <Link
+            <HomepageLink
               className={clsx(
                 "button button--lg button--primary",
                 styles.primaryAction,
               )}
               to="/docs/introduction"
             >
-              Read the docs
-            </Link>
-            {/* @ts-ignore - React 19 includes bigint in ReactNode but Docusaurus uses React 18 types */}
-            <Link
+              Get started
+            </HomepageLink>
+            <HomepageLink
               className={styles.secondaryAction}
               href="https://github.com/gunzip/apical-ts"
             >
               View on GitHub
-            </Link>
+            </HomepageLink>
           </div>
+          <p className={styles.heroDetail}>
+            Use the generated contract directly or compose Hono, MSW, React
+            Query, and custom adapters without drifting away from the spec. The
+            same precision gives coding agents safer primitives.
+          </p>
+          <ul className={styles.proofGrid}>
+            {heroHighlights.map((highlight) => (
+              <li key={highlight.label} className={styles.proofItem}>
+                <span className={styles.proofLabel}>{highlight.label}</span>
+                <span className={styles.proofValue}>{highlight.value}</span>
+              </li>
+            ))}
+          </ul>
         </div>
+
         <div className={styles.heroPreview}>
           <div className={styles.previewFrame}>
             <div className={styles.previewHeader}>
-              <span className={styles.previewPill}>
-                generate precise route contracts
-              </span>
+              <span className={styles.previewPill}>generate from one spec</span>
+              <span className={styles.previewCaption}>CLI</span>
             </div>
             <CodeBlock
               className={styles.previewCode}
@@ -155,16 +298,85 @@ function HomepageHeader() {
 
           <div className={styles.outputCard}>
             <div className={styles.previewHeader}>
-              <span className={styles.previewPill}>use generated client</span>
+              <span className={styles.previewPill}>generated output</span>
+              <span className={styles.previewCaption}>Reusable layers</span>
             </div>
-            <CodeBlock
-              className={styles.previewCode}
-              code={clientPreview}
-              language="typescript"
-            />
+            <div className={styles.outputBody}>
+              <p className={styles.outputSummary}>
+                Click a layer to open a minimal generated example.
+              </p>
+              <ul className={styles.outputList}>
+                {outputOrder.map((outputId) => {
+                  const output = outputExamples[outputId];
+
+                  return (
+                    <li key={outputId}>
+                      <button
+                        type="button"
+                        className={clsx(
+                          styles.outputButton,
+                          outputId === openOutputId &&
+                            styles.outputButtonActive,
+                        )}
+                        onClick={() => setOpenOutputId(outputId)}
+                        aria-haspopup="dialog"
+                        aria-expanded={outputId === openOutputId}
+                      >
+                        <span className={styles.outputTitle}>
+                          {output.title}
+                        </span>
+                        <span className={styles.outputPath}>{output.path}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
           </div>
         </div>
       </div>
+
+      {activeOutput && (
+        <div
+          className={styles.outputModalBackdrop}
+          onClick={() => setOpenOutputId(null)}
+        >
+          <div
+            className={styles.outputModal}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="homepage-output-example-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className={styles.outputModalHeader}>
+              <div>
+                <span
+                  id="homepage-output-example-title"
+                  className={styles.outputModalTitle}
+                >
+                  {activeOutput.title} example
+                </span>
+                <span className={styles.outputModalMeta}>
+                  {activeOutput.path}
+                </span>
+              </div>
+              <button
+                type="button"
+                className={styles.outputModalClose}
+                onClick={() => setOpenOutputId(null)}
+              >
+                Close
+              </button>
+            </div>
+            <p className={styles.outputModalLead}>{activeOutput.note}</p>
+            <CodeBlock
+              className={clsx(styles.previewCode, styles.outputModalCode)}
+              code={activeOutput.code}
+              language={activeOutput.language}
+            />
+          </div>
+        </div>
+      )}
     </header>
   );
 }
@@ -174,14 +386,14 @@ function FeatureSection() {
     <section className={styles.section}>
       <div className={clsx("container", styles.sectionStack)}>
         <div className={styles.sectionIntro}>
-          <p className={styles.sectionEyebrow}>What matters in practice</p>
+          <p className={styles.sectionEyebrow}>Why teams keep it</p>
           <Heading as="h2" className={styles.sectionTitle}>
-            A hard base for coding agents.
+            A contract layer worth generating once.
           </Heading>
           <p className={styles.sectionLead}>
-            Apical can generate the whole client layer, but the durable asset is
-            the route contract itself: precise Zod v4 schemas that keep client,
-            server, and custom integrations aligned.
+            The generated client is useful, but the durable asset is the exact
+            contract layer underneath it: schemas and route metadata you can
+            reuse everywhere TypeScript touches the API.
           </p>
         </div>
 
@@ -201,16 +413,130 @@ function FeatureSection() {
   );
 }
 
+function WorkflowSection() {
+  return (
+    <section className={styles.section}>
+      <div className={clsx("container", styles.sectionStack)}>
+        <div className={styles.sectionIntro}>
+          <p className={styles.sectionEyebrow}>How it works</p>
+          <Heading as="h2" className={styles.sectionTitle}>
+            One spec in, reusable layers out.
+          </Heading>
+          <p className={styles.sectionLead}>
+            Start from a single OpenAPI document, generate the pieces you need,
+            and keep your app-specific glue code thin and inspectable.
+          </p>
+        </div>
+
+        <div className={styles.workflowGrid}>
+          {workflowSteps.map((step) => (
+            <article key={step.step} className={styles.workflowCard}>
+              <span className={styles.workflowStep}>{step.step}</span>
+              <Heading as="h3" className={styles.workflowTitle}>
+                {step.title}
+              </Heading>
+              <p className={styles.workflowDescription}>{step.description}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function IntegrationSection() {
+  return (
+    <section className={styles.section}>
+      <div className={clsx("container", styles.sectionStack)}>
+        <div className={styles.sectionIntro}>
+          <p className={styles.sectionEyebrow}>Real starting points</p>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Start from examples for the glue code around the contract.
+          </Heading>
+          <p className={styles.sectionLead}>
+            The integrations are meant to be inspectable starters. Copy the
+            pattern you need, adapt it to your stack, and keep the generated
+            contract as the stable base.
+          </p>
+        </div>
+
+        <div className={styles.integrationGrid}>
+          {integrationCards.map((integration) => (
+            <HomepageLink
+              key={integration.name}
+              className={styles.integrationCard}
+              href={integration.href}
+            >
+              <div className={styles.integrationHeader}>
+                <Heading as="h3" className={styles.integrationName}>
+                  {integration.name}
+                </Heading>
+                <span className={styles.integrationLabel}>
+                  {integration.label}
+                </span>
+              </div>
+              <p className={styles.integrationDescription}>
+                {integration.description}
+              </p>
+              <span className={styles.resourceMeta}>View example</span>
+            </HomepageLink>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ResourceSection() {
+  return (
+    <section className={styles.section}>
+      <div className={clsx("container", styles.sectionStack)}>
+        <div className={styles.sectionIntro}>
+          <p className={styles.sectionEyebrow}>Start here</p>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Pick the shortest path to shipping.
+          </Heading>
+          <p className={styles.sectionLead}>
+            Use the docs to get the generator running quickly, then drill into
+            CLI flags and integration patterns only where your stack needs them.
+          </p>
+        </div>
+
+        <div className={styles.resourceGrid}>
+          {resourceCards.map((resource) => (
+            <HomepageLink
+              key={resource.title}
+              className={styles.resourceCard}
+              to={resource.to}
+            >
+              <Heading as="h3" className={styles.resourceTitle}>
+                {resource.title}
+              </Heading>
+              <p className={styles.resourceDescription}>
+                {resource.description}
+              </p>
+              <span className={styles.resourceMeta}>{resource.meta}</span>
+            </HomepageLink>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export default function Home() {
   return (
     <Layout
-      title="OpenAPI to a typed TypeScript stack"
-      description="Generate Zod v4 schemas, typed clients, and server wrappers from one OpenAPI specification."
+      title="Generate exact Zod schemas and typed clients from OpenAPI"
+      description="Turn one OpenAPI specification into exact Zod v4 schemas, route metadata, typed clients, and server wrappers for TypeScript."
     >
       <div className={styles.pageShell}>
         <HomepageHeader />
         <main className={styles.mainContent}>
           <FeatureSection />
+          <WorkflowSection />
+          <IntegrationSection />
+          <ResourceSection />
         </main>
       </div>
     </Layout>

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -254,7 +254,9 @@ function HomepageHeader() {
   const modalRef = useRef<HTMLDivElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
-  const outputButtonRefs = useRef<Record<OutputExampleId, HTMLButtonElement | null>>({
+  const outputButtonRefs = useRef<
+    Record<OutputExampleId, HTMLButtonElement | null>
+  >({
     schema: null,
     route: null,
     client: null,
@@ -267,7 +269,8 @@ function HomepageHeader() {
   ) => {
     restoreFocusRef.current =
       triggerElement ??
-      (outputButtonRefs.current[outputId] ?? restoreFocusRef.current);
+      outputButtonRefs.current[outputId] ??
+      restoreFocusRef.current;
     setOpenOutputId(outputId);
   };
 
@@ -493,10 +496,7 @@ function HomepageHeader() {
       </div>
 
       {activeOutput && (
-        <div
-          className={styles.outputModalBackdrop}
-          onClick={closeOutput}
-        >
+        <div className={styles.outputModalBackdrop} onClick={closeOutput}>
           <div
             ref={modalRef}
             className={styles.outputModal}

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, type ComponentProps } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
@@ -31,13 +38,37 @@ const heroHighlights = [
 const outputOrder = ["schema", "route", "client", "server"] as const;
 type OutputExampleId = (typeof outputOrder)[number];
 
+function getAdjacentOutputId(
+  currentOutputId: OutputExampleId,
+  direction: -1 | 1,
+): OutputExampleId {
+  const currentIndex = outputOrder.indexOf(currentOutputId);
+  const nextIndex =
+    (currentIndex + direction + outputOrder.length) % outputOrder.length;
+
+  return outputOrder[nextIndex];
+}
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => {
+    return (
+      !element.hasAttribute("disabled") &&
+      element.getAttribute("aria-hidden") !== "true"
+    );
+  });
+}
+
 const outputExamples = {
   schema: {
     title: "Schema",
     path: "schemas/",
     note: "Validate payloads and infer exact runtime-safe types.",
     language: "typescript",
-    code: `import { UserSchema } from "./generated/schemas";
+    code: `import { UserSchema } from "./generated/schemas/User.js";
 
 const result = UserSchema.safeParse(apiResponse);
 
@@ -220,15 +251,101 @@ function HomepageHeader() {
     null,
   );
   const activeOutput = openOutputId ? outputExamples[openOutputId] : null;
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const outputButtonRefs = useRef<Record<OutputExampleId, HTMLButtonElement | null>>({
+    schema: null,
+    route: null,
+    client: null,
+    server: null,
+  });
+
+  const openOutput = (
+    outputId: OutputExampleId,
+    triggerElement?: HTMLElement | null,
+  ) => {
+    restoreFocusRef.current =
+      triggerElement ??
+      (outputButtonRefs.current[outputId] ?? restoreFocusRef.current);
+    setOpenOutputId(outputId);
+  };
+
+  const closeOutput = () => {
+    const restoreTarget = restoreFocusRef.current;
+    setOpenOutputId(null);
+    requestAnimationFrame(() => {
+      restoreTarget?.focus();
+    });
+  };
+
+  const showAdjacentOutput = (direction: -1 | 1) => {
+    if (!openOutputId) {
+      return;
+    }
+
+    const nextOutputId = getAdjacentOutputId(openOutputId, direction);
+    restoreFocusRef.current = outputButtonRefs.current[nextOutputId];
+    setOpenOutputId(nextOutputId);
+  };
 
   useEffect(() => {
     if (!openOutputId) {
       return;
     }
 
+    if (!modalRef.current?.contains(document.activeElement)) {
+      closeButtonRef.current?.focus();
+    }
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setOpenOutputId(null);
+        event.preventDefault();
+        closeOutput();
+        return;
+      }
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        showAdjacentOutput(1);
+        return;
+      }
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        showAdjacentOutput(-1);
+        return;
+      }
+
+      if (event.key !== "Tab" || !modalRef.current) {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(modalRef.current);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+      const isInsideModal =
+        activeElement instanceof HTMLElement &&
+        modalRef.current.contains(activeElement);
+
+      if (event.shiftKey) {
+        if (activeElement === firstElement || !isInsideModal) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+
+        return;
+      }
+
+      if (activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
       }
     };
 
@@ -238,6 +355,37 @@ function HomepageHeader() {
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, [openOutputId]);
+
+  const handleOutputButtonClick = (
+    outputId: OutputExampleId,
+    event: ReactMouseEvent<HTMLButtonElement>,
+  ) => {
+    openOutput(outputId, event.currentTarget);
+  };
+
+  const handleOutputButtonKeyDown = (
+    outputId: OutputExampleId,
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      const nextOutputId = getAdjacentOutputId(outputId, 1);
+      openOutput(
+        nextOutputId,
+        outputButtonRefs.current[nextOutputId] ?? event.currentTarget,
+      );
+      return;
+    }
+
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      const previousOutputId = getAdjacentOutputId(outputId, -1);
+      openOutput(
+        previousOutputId,
+        outputButtonRefs.current[previousOutputId] ?? event.currentTarget,
+      );
+    }
+  };
 
   return (
     <header className={styles.heroBanner}>
@@ -313,12 +461,20 @@ function HomepageHeader() {
                     <li key={outputId}>
                       <button
                         type="button"
+                        ref={(element) => {
+                          outputButtonRefs.current[outputId] = element;
+                        }}
                         className={clsx(
                           styles.outputButton,
                           outputId === openOutputId &&
                             styles.outputButtonActive,
                         )}
-                        onClick={() => setOpenOutputId(outputId)}
+                        onClick={(event) =>
+                          handleOutputButtonClick(outputId, event)
+                        }
+                        onKeyDown={(event) =>
+                          handleOutputButtonKeyDown(outputId, event)
+                        }
                         aria-haspopup="dialog"
                         aria-expanded={outputId === openOutputId}
                       >
@@ -339,9 +495,10 @@ function HomepageHeader() {
       {activeOutput && (
         <div
           className={styles.outputModalBackdrop}
-          onClick={() => setOpenOutputId(null)}
+          onClick={closeOutput}
         >
           <div
+            ref={modalRef}
             className={styles.outputModal}
             role="dialog"
             aria-modal="true"
@@ -360,13 +517,32 @@ function HomepageHeader() {
                   {activeOutput.path}
                 </span>
               </div>
-              <button
-                type="button"
-                className={styles.outputModalClose}
-                onClick={() => setOpenOutputId(null)}
-              >
-                Close
-              </button>
+              <div className={styles.outputModalActions}>
+                <button
+                  type="button"
+                  className={styles.outputModalNav}
+                  onClick={() => showAdjacentOutput(-1)}
+                >
+                  <span aria-hidden="true">←</span>
+                  Previous
+                </button>
+                <button
+                  type="button"
+                  className={styles.outputModalNav}
+                  onClick={() => showAdjacentOutput(1)}
+                >
+                  Next
+                  <span aria-hidden="true">→</span>
+                </button>
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  className={styles.outputModalClose}
+                  onClick={closeOutput}
+                >
+                  Close
+                </button>
+              </div>
             </div>
             <p className={styles.outputModalLead}>{activeOutput.note}</p>
             <CodeBlock


### PR DESCRIPTION
## Summary
- clarify the homepage messaging, layout, and metadata copy
- add an accessible generated-output modal with focus management, keyboard escape handling, and previous/next arrow navigation
- update the CLI usage docs to recommend `oxfmt` for formatting generated code

## Validation
- `pnpm format:check`
- `cd apps/website && pnpm run typecheck:code`
- `cd apps/website && pnpm run build`