### PR TITLE
Implement fallback to plain union for inline array members in discriminated unions

### DIFF
--- a/.changeset/wise-weeks-rest.md
+++ b/.changeset/wise-weeks-rest.md
@@ -1,0 +1,5 @@
+---
+"@apical-ts/core-utils": patch
+---
+
+Fallback to simple union when one of the member in oneOf is an array

--- a/packages/core-utils/src/schema-generator/discriminated-union.ts
+++ b/packages/core-utils/src/schema-generator/discriminated-union.ts
@@ -22,6 +22,19 @@ export function buildDiscriminatedUnionCode(
 ): string {
   const { discriminatorProperty, members, resolvedSchemas } = options;
   const memberCodes = members.map((member) => member.code);
+
+  if (
+    !members.every((member) =>
+      isDiscriminatedUnionMemberCompatible(
+        member.schema,
+        discriminatorProperty,
+        resolvedSchemas,
+      ),
+    )
+  ) {
+    return renderPlainUnion(memberCodes);
+  }
+
   const nullableFlags = members.map((member) =>
     isDiscriminatedUnionMemberNullable(member.schema, resolvedSchemas),
   );
@@ -82,6 +95,47 @@ function unwrapNullableDiscriminatedUnionMember(
   return stripTopLevelNullableWrapper(member.code);
 }
 
+function isDiscriminatedUnionMemberCompatible(
+  schema: ReferenceObject | SchemaObject,
+  discriminatorProperty: string,
+  resolvedSchemas?: ResolvedSchemas,
+  seenRefs = new Set<string>(),
+): boolean {
+  if (isReferenceObject(schema)) {
+    const refName = parseSchemaReference(schema.$ref);
+    if (!refName || seenRefs.has(refName.originalName) || !resolvedSchemas) {
+      return true;
+    }
+
+    const resolvedSchema = resolvedSchemas[refName.originalName];
+    if (!resolvedSchema || !isSchemaObject(resolvedSchema)) {
+      return true;
+    }
+
+    return isDiscriminatedUnionMemberCompatible(
+      resolvedSchema,
+      discriminatorProperty,
+      resolvedSchemas,
+      new Set(seenRefs).add(refName.originalName),
+    );
+  }
+
+  if (!isObjectLikeDiscriminatedUnionMember(schema)) {
+    return false;
+  }
+
+  const discriminatorSchema = schema.properties?.[discriminatorProperty];
+  if (!discriminatorSchema) {
+    return false;
+  }
+
+  return isStaticDiscriminatorSchema(
+    discriminatorSchema,
+    resolvedSchemas,
+    seenRefs,
+  );
+}
+
 function isDiscriminatedUnionMemberNullable(
   schema: ReferenceObject | SchemaObject,
   resolvedSchemas?: ResolvedSchemas,
@@ -117,6 +171,45 @@ function resolveReferencedSchema(
   return resolvedSchema && isSchemaObject(resolvedSchema)
     ? resolvedSchema
     : null;
+}
+
+function isObjectLikeDiscriminatedUnionMember(schema: SchemaObject): boolean {
+  if (schema.allOf || schema.anyOf || schema.oneOf) {
+    return false;
+  }
+
+  if (Array.isArray(schema.type)) {
+    const nonNullTypes = schema.type.filter((type) => type !== "null");
+    return nonNullTypes.length === 1 && nonNullTypes[0] === "object";
+  }
+
+  return !schema.type || schema.type === "object";
+}
+
+function isStaticDiscriminatorSchema(
+  schema: ReferenceObject | SchemaObject,
+  resolvedSchemas?: ResolvedSchemas,
+  seenRefs = new Set<string>(),
+): boolean {
+  if (isReferenceObject(schema)) {
+    const refName = parseSchemaReference(schema.$ref);
+    if (!refName || seenRefs.has(refName.originalName) || !resolvedSchemas) {
+      return true;
+    }
+
+    const resolvedSchema = resolvedSchemas[refName.originalName];
+    if (!resolvedSchema || !isSchemaObject(resolvedSchema)) {
+      return true;
+    }
+
+    return isStaticDiscriminatorSchema(
+      resolvedSchema,
+      resolvedSchemas,
+      new Set(seenRefs).add(refName.originalName),
+    );
+  }
+
+  return schema.const !== undefined || Boolean(schema.enum?.length);
 }
 
 function stripTopLevelNullableWrapper(code: string): null | string {

--- a/packages/core-utils/tests/zod-schema-to-code.test.ts
+++ b/packages/core-utils/tests/zod-schema-to-code.test.ts
@@ -759,6 +759,105 @@ describe("zodSchemaToCode", () => {
     expect(result.code).toBe("z.union([NullableMember, NonNullableMember])");
   });
 
+  it("should fall back to plain z.union when a discriminated union contains an inline array member", () => {
+    const schema: SchemaObject = {
+      discriminator: {
+        propertyName: "type",
+      },
+      oneOf: [
+        {
+          items: { type: "string" },
+          type: "array",
+        },
+        {
+          properties: {
+            name: { type: "string" },
+            type: { enum: ["file"], type: "string" },
+          },
+          required: ["type", "name"],
+          type: "object",
+        },
+      ],
+    };
+    const result = zodSchemaToCode(schema);
+
+    expect(result.code).toContain("z.union([");
+    expect(result.code).not.toContain("discriminatedUnion");
+    expect(result.code).not.toContain("superRefine");
+
+    const zodSchema = evalZod(result.code);
+    expect(zodSchema.safeParse(["README.md"]).success).toBe(true);
+    expect(
+      zodSchema.safeParse({ name: "README.md", type: "file" }).success,
+    ).toBe(true);
+  });
+
+  it("should keep using z.discriminatedUnion for resolved $ref members with discriminator tags", () => {
+    const schema: SchemaObject = {
+      discriminator: {
+        propertyName: "type",
+      },
+      oneOf: [
+        { $ref: "#/components/schemas/Circle" },
+        { $ref: "#/components/schemas/Square" },
+      ],
+    };
+    const result = zodSchemaToCode(schema, {
+      resolvedSchemas: {
+        Circle: {
+          properties: {
+            radius: { type: "number" },
+            type: { enum: ["circle"], type: "string" },
+          },
+          required: ["type", "radius"],
+          type: "object",
+        },
+        Square: {
+          properties: {
+            size: { type: "number" },
+            type: { enum: ["square"], type: "string" },
+          },
+          required: ["type", "size"],
+          type: "object",
+        },
+      },
+    });
+
+    expect(result.code).toBe('z.discriminatedUnion("type", [Circle, Square])');
+  });
+
+  it("should fall back to z.union when a referenced discriminated union member resolves to an array schema", () => {
+    const schema: SchemaObject = {
+      discriminator: {
+        propertyName: "type",
+      },
+      oneOf: [
+        { $ref: "#/components/schemas/ContentDirectory" },
+        { $ref: "#/components/schemas/ContentFile" },
+      ],
+    };
+    const result = zodSchemaToCode(schema, {
+      resolvedSchemas: {
+        ContentDirectory: {
+          items: { type: "string" },
+          type: "array",
+        },
+        ContentFile: {
+          properties: {
+            name: { type: "string" },
+            type: { enum: ["file"], type: "string" },
+          },
+          required: ["type", "name"],
+          type: "object",
+        },
+      },
+    });
+
+    expect(result.code).toBe("z.union([ContentDirectory, ContentFile])");
+    expect(result.imports.has("ContentDirectory")).toBe(true);
+    expect(result.imports.has("ContentFile")).toBe(true);
+  });
+
   it("should keep inline nullable discriminated union members with descriptions discriminable", () => {
     const schema: SchemaObject = {
       discriminator: {


### PR DESCRIPTION
Introduce a fallback mechanism to use a plain union when a discriminated union contains an inline array member. This change enhances compatibility and ensures correct schema generation in such cases.