### PR TITLE
Improve server auth header schemas

### DIFF
--- a/.changeset/afraid-rivers-remember.md
+++ b/.changeset/afraid-rivers-remember.md
@@ -1,0 +1,8 @@
+---
+"@apical-ts/craft": patch
+"@apical-ts/core-utils": patch
+"@apical-ts/route-generator": patch
+---
+
+Restore inherited auth headers in generated server parameter schemas without
+reintroducing them in client parameter schemas.

--- a/.changeset/afraid-rivers-remember.md
+++ b/.changeset/afraid-rivers-remember.md
@@ -4,5 +4,6 @@
 "@apical-ts/route-generator": patch
 ---
 
-Restore inherited auth headers in generated server parameter schemas without
-reintroducing them in client parameter schemas.
+Keep inherited auth headers in generated route params: optional on client
+operations and required on server handlers unless an operation-level security
+override replaces them.

--- a/.changeset/afraid-rivers-remember.md
+++ b/.changeset/afraid-rivers-remember.md
@@ -1,7 +1,7 @@
 ---
-"@apical-ts/craft": patch
-"@apical-ts/core-utils": patch
-"@apical-ts/route-generator": patch
+"@apical-ts/craft": minor
+"@apical-ts/core-utils": minor
+"@apical-ts/route-generator": minor
 ---
 
 Keep inherited auth headers in generated route params: optional on client

--- a/apps/craft/tests/integrations/express-server-wrapper.test.ts
+++ b/apps/craft/tests/integrations/express-server-wrapper.test.ts
@@ -152,6 +152,7 @@ describe("Express server wrappers integration", () => {
     const base = `http://127.0.0.1:${addr.port}`;
     const res = await request(base)
       .get("/test-parameter-with-dash/abcdef")
+      .set("custom-token", "test-token")
       .set("headerInlineParam", "inline-header")
       .set("x-header-param", "xvalue")
       .query({ "foo-bar": "qb", "request-id": "1234567890" });
@@ -167,6 +168,7 @@ describe("Express server wrappers integration", () => {
     const base = `http://127.0.0.1:${addr.port}`;
     const res = await request(base)
       .get("/test-two-path-params/123/true")
+      .set("custom-token", "test-token")
       .query({});
     expect(res.status).toBe(200);
     expect(res.body.path).toBeDefined();
@@ -182,6 +184,7 @@ describe("Express server wrappers integration", () => {
     const base = `http://127.0.0.1:${addr.port}`;
     const res = await request(base)
       .get("/test-coercion/456/false")
+      .set("custom-token", "test-token")
       .set("count-header", "99")
       .query({ "num-query": "123.5", class: "true" });
     expect(res.status).toBe(200);

--- a/apps/craft/tests/integrations/server-generator/global-security-headers.test.ts
+++ b/apps/craft/tests/integrations/server-generator/global-security-headers.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getCatalogParsedParams,
+  getCatalogServerParsedParams,
+} from "../generated/schemas/getCatalogParameters.js";
+
+describe("Generated global security header schemas", () => {
+  it("keeps client auth headers out of params while validating them on server routes", () => {
+    const clientHeadersParse = getCatalogParsedParams.shape.headers.safeParse(
+      {},
+    );
+    const serverHeadersParse =
+      getCatalogServerParsedParams.shape.headers.safeParse({
+        "custom-token": "test-token",
+      });
+    const missingServerHeadersParse =
+      getCatalogServerParsedParams.shape.headers.safeParse({});
+
+    expect(clientHeadersParse.success).toBe(true);
+    expect(serverHeadersParse.success).toBe(true);
+    expect(missingServerHeadersParse.success).toBe(false);
+  });
+});

--- a/apps/craft/tests/integrations/server-generator/global-security-headers.test.ts
+++ b/apps/craft/tests/integrations/server-generator/global-security-headers.test.ts
@@ -6,10 +6,14 @@ import {
 } from "../generated/schemas/getCatalogParameters.js";
 
 describe("Generated global security header schemas", () => {
-  it("keeps client auth headers out of params while validating them on server routes", () => {
+  it("keeps inherited auth headers optional on client params and required on server routes", () => {
     const clientHeadersParse = getCatalogParsedParams.shape.headers.safeParse(
       {},
     );
+    const clientHeadersWithAuthParse =
+      getCatalogParsedParams.shape.headers.safeParse({
+        "custom-token": "test-token",
+      });
     const serverHeadersParse =
       getCatalogServerParsedParams.shape.headers.safeParse({
         "custom-token": "test-token",
@@ -18,6 +22,7 @@ describe("Generated global security header schemas", () => {
       getCatalogServerParsedParams.shape.headers.safeParse({});
 
     expect(clientHeadersParse.success).toBe(true);
+    expect(clientHeadersWithAuthParse.success).toBe(true);
     expect(serverHeadersParse.success).toBe(true);
     expect(missingServerHeadersParse.success).toBe(false);
   });

--- a/apps/craft/tests/integrations/server-generator/test-helpers.ts
+++ b/apps/craft/tests/integrations/server-generator/test-helpers.ts
@@ -150,6 +150,9 @@ function extractRequestParams(req: Request) {
   // Express normalizes all headers to lowercase, so we need to handle this
   const transformedHeaders: Record<string, any> = {};
   for (const [key, value] of Object.entries(req.headers)) {
+    // Preserve the original lowercase header key for server-side schema validation.
+    transformedHeaders[key] = value;
+
     // Apply basic transformation
     const transformedKey = transformParameterName(key);
     transformedHeaders[transformedKey] = value;

--- a/apps/craft/tests/integrations/server-generator/testWildcards.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testWildcards.test.ts
@@ -36,7 +36,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(200);
@@ -73,7 +75,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(200);
@@ -110,7 +114,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(200);
@@ -144,7 +150,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(404);
@@ -175,7 +183,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(400);
@@ -211,7 +221,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(403);
@@ -254,7 +266,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(200);
@@ -289,7 +303,9 @@ describe("testWildcards operation integration tests", () => {
     );
 
     // Act: Make the HTTP request
-    const response = await supertest(app).get("/wildcards");
+    const response = await supertest(app)
+      .get("/wildcards")
+      .set("custom-token", "test-token");
 
     // Assert: Verify the response
     expect(response.status).toBe(200);

--- a/packages/core-utils/src/schema-generator/parameter-file-generator.ts
+++ b/packages/core-utils/src/schema-generator/parameter-file-generator.ts
@@ -45,6 +45,7 @@ async function generateParameterSchemaFile(
     parameterMetadata.parameterGroups,
     {
       ...options,
+      parameterSchemaKind: "client",
       securityHeaders,
     },
   );
@@ -57,6 +58,7 @@ async function generateParameterSchemaFile(
       coercePrimitives: true,
       formatOverrides: options.formatOverrides,
       lowercaseHeaderKeys: true,
+      parameterSchemaKind: "server",
       securityHeaders,
     },
   );
@@ -111,7 +113,7 @@ async function generateParameterSchemaFile(
     (p: { required?: boolean }) => p.required !== true,
   );
   /*
-   * Headers optional only if:
+   * Client headers optional only if:
    * - All explicit header params are optional
    * - AND no required security override headers
    *
@@ -122,19 +124,22 @@ async function generateParameterSchemaFile(
    * - security: [{ apiKey: [] }] → requires apiKey header in params.headers
    */
   const securityOverrideHeaders = securityHeaders.filter((sh) => sh.isOverride);
-  const hasRequiredSecurityOverride = securityOverrideHeaders.some(
+  const hasRequiredClientSecurityHeader = securityOverrideHeaders.some(
     (sh) => sh.isRequired,
   );
-  const isHeadersOptional =
+  const isClientHeadersOptional =
     headerParams.every((p: { required?: boolean }) => p.required !== true) &&
-    !hasRequiredSecurityOverride;
+    !hasRequiredClientSecurityHeader;
+  const isServerHeadersOptional =
+    headerParams.every((p: { required?: boolean }) => p.required !== true) &&
+    securityHeaders.length === 0;
 
   /* Build client parsed params */
   const clientParsedParams = buildParsedParamsSchema(
     sanitizedId,
     result.schemaNames,
     { hasHeaders, hasPath, hasQuery },
-    { isHeadersOptional, isQueryOptional },
+    { isHeadersOptional: isClientHeadersOptional, isQueryOptional },
   );
 
   /* Build server parsed params */
@@ -142,7 +147,7 @@ async function generateParameterSchemaFile(
     sanitizedId,
     serverSchemaNames,
     { hasHeaders, hasPath, hasQuery },
-    { isHeadersOptional, isQueryOptional },
+    { isHeadersOptional: isServerHeadersOptional, isQueryOptional },
     serverSchemaPrefix,
   );
 

--- a/packages/core-utils/src/schema-generator/parameter-file-generator.ts
+++ b/packages/core-utils/src/schema-generator/parameter-file-generator.ts
@@ -119,7 +119,8 @@ async function generateParameterSchemaFile(
    *
    * Notes:
    * - Security override (operation.security): go in params.headers (required if present)
-   * - Global security: go in config.headers (always optional, not in params)
+   * - Global security: stays available through config.headers and is also exposed
+   *   as optional params.headers fields for per-operation overrides
    * - security: [] → empty array, no required headers (disables global security)
    * - security: [{ apiKey: [] }] → requires apiKey header in params.headers
    */

--- a/packages/core-utils/src/shared/parameter-schemas.ts
+++ b/packages/core-utils/src/shared/parameter-schemas.ts
@@ -9,6 +9,7 @@ import type {
 import { isReferenceObject } from "openapi3-ts/oas31";
 
 import type { ParameterGroups } from "./models/parameter-models.js";
+import type { SecurityHeader } from "./models/security-models.js";
 import type { StringFormatOverrideRegistry } from "../schema-generator/format-overrides.js";
 
 import { zodSchemaToCode } from "../schema-generator/index.js";
@@ -26,13 +27,16 @@ export interface ParameterSchemaOptions {
   coercePrimitives?: boolean;
   formatOverrides?: StringFormatOverrideRegistry;
   lowercaseHeaderKeys?: boolean;
+  /**
+   * Controls how auth headers are materialized in generated parameter schemas.
+   * - client: only operation-level overrides are emitted, so global config auth
+   *   headers do not become required client params.
+   * - server: all security headers are emitted because incoming requests carry
+   *   those headers explicitly.
+   */
+  parameterSchemaKind?: "client" | "server";
   /* Security headers to include in the headers schema */
-  securityHeaders?: {
-    headerName: string;
-    isOverride: boolean;
-    isRequired: boolean;
-    schemeName: string;
-  }[];
+  securityHeaders?: SecurityHeader[];
 }
 
 /**
@@ -75,11 +79,16 @@ export function generateParameterSchemas(
     coercePrimitives = false,
     formatOverrides,
     lowercaseHeaderKeys = false,
+    parameterSchemaKind = "client",
     securityHeaders = [],
   } = options;
   const sanitizedId = sanitizeIdentifier(operationId);
   const typeImports = new Set<string>();
   const schemas: string[] = [];
+  const materializedSecurityHeaders =
+    parameterSchemaKind === "server"
+      ? securityHeaders
+      : securityHeaders.filter((securityHeader) => securityHeader.isOverride);
 
   /* Track whether each parameter type has actual parameters */
   const hasQuery = parameterGroups.queryParams.length > 0;
@@ -177,12 +186,7 @@ export function generateParameterSchemas(
   const headersSchemaName = `${sanitizedId}HeadersSchema`;
   const headersTypeName = `${sanitizedId}HeadersSchema`;
 
-  // Only security overrides go into the headers schema, not global security headers
-  const securityOverrideHeaders = securityHeaders.filter((sh) => sh.isOverride);
-  const hasSecurityOverrides = securityOverrideHeaders.length > 0;
-  const hasCombinedHeaders = hasHeaders || hasSecurityOverrides;
-
-  if (hasCombinedHeaders) {
+  if (hasHeaders) {
     const headerProps = new Map<string, string>();
 
     for (const headerParam of parameterGroups.headerParams) {
@@ -190,8 +194,11 @@ export function generateParameterSchemas(
       headerProps.set(normalizedName, buildProp(headerParam.name, headerParam));
     }
 
-    /* Add security override headers to the schema (always required) */
-    for (const securityHeader of securityOverrideHeaders) {
+    /*
+     * Client schemas only materialize operation-level overrides.
+     * Server schemas validate all security headers present in incoming requests.
+     */
+    for (const securityHeader of materializedSecurityHeaders) {
       const normalizedName = normalizeParameterName(
         securityHeader.headerName,
         "header",
@@ -202,7 +209,11 @@ export function generateParameterSchemas(
 
       headerProps.set(
         normalizedName,
-        `${JSON.stringify(normalizedName)}: z.string()`,
+        `${JSON.stringify(normalizedName)}: ${
+          parameterSchemaKind === "server" || securityHeader.isRequired
+            ? "z.string()"
+            : "z.string().optional()"
+        }`,
       );
     }
 

--- a/packages/core-utils/src/shared/parameter-schemas.ts
+++ b/packages/core-utils/src/shared/parameter-schemas.ts
@@ -29,10 +29,10 @@ export interface ParameterSchemaOptions {
   lowercaseHeaderKeys?: boolean;
   /**
    * Controls how auth headers are materialized in generated parameter schemas.
-   * - client: only operation-level overrides are emitted, so global config auth
-   *   headers do not become required client params.
-   * - server: all security headers are emitted because incoming requests carry
-   *   those headers explicitly.
+   * - client: inherited auth headers are emitted as optional fields, while
+   *   operation-level overrides remain required.
+   * - server: all security headers are emitted as required because incoming
+   *   requests must carry those headers explicitly.
    */
   parameterSchemaKind?: "client" | "server";
   /* Security headers to include in the headers schema */
@@ -85,10 +85,6 @@ export function generateParameterSchemas(
   const sanitizedId = sanitizeIdentifier(operationId);
   const typeImports = new Set<string>();
   const schemas: string[] = [];
-  const materializedSecurityHeaders =
-    parameterSchemaKind === "server"
-      ? securityHeaders
-      : securityHeaders.filter((securityHeader) => securityHeader.isOverride);
 
   /* Track whether each parameter type has actual parameters */
   const hasQuery = parameterGroups.queryParams.length > 0;
@@ -195,10 +191,10 @@ export function generateParameterSchemas(
     }
 
     /*
-     * Client schemas only materialize operation-level overrides.
-     * Server schemas validate all security headers present in incoming requests.
+     * Client schemas expose inherited auth headers as optional params so callers
+     * can pass them per-operation even when a global config already exists.
      */
-    for (const securityHeader of materializedSecurityHeaders) {
+    for (const securityHeader of securityHeaders) {
       const normalizedName = normalizeParameterName(
         securityHeader.headerName,
         "header",

--- a/packages/core-utils/tests/shared/parameter-schemas.test.ts
+++ b/packages/core-utils/tests/shared/parameter-schemas.test.ts
@@ -165,7 +165,9 @@ describe("generateParameterSchemas", () => {
     expect(clientResult.schemaCode).toContain("getCatalogHeadersSchema");
     expect(clientResult.schemaCode).toContain("z.object(");
     expect(clientResult.schemaCode).toContain("z.string().optional()");
-    expect(clientResult.schemaCode).not.toContain('"custom-token": z.string() }');
+    expect(clientResult.schemaCode).not.toContain(
+      '"custom-token": z.string() }',
+    );
 
     expect(serverResult.schemaCode).toContain("getCatalogHeadersSchema");
     expect(serverResult.schemaCode).toContain("z.object(");

--- a/packages/core-utils/tests/shared/parameter-schemas.test.ts
+++ b/packages/core-utils/tests/shared/parameter-schemas.test.ts
@@ -128,4 +128,46 @@ describe("generateParameterSchemas", () => {
     expect((result.schemaCode.match(/"X-Auth-Key":/g) ?? []).length).toBe(1);
     expect(result.schemaCode).toContain('.describe("Explicit email header")');
   });
+
+  it("keeps global security headers out of client schemas but includes them in server schemas", () => {
+    const parameterGroups = {
+      queryParams: [],
+      headerParams: [],
+      pathParams: [],
+      cookieParams: [],
+    };
+    const securityHeaders = [
+      {
+        headerName: "custom-token",
+        isOverride: false,
+        isRequired: false,
+        schemeName: "customToken",
+      },
+    ];
+
+    const clientResult = generateParameterSchemas(
+      "getCatalog",
+      parameterGroups,
+      {
+        securityHeaders,
+      },
+    );
+    const serverResult = generateParameterSchemas(
+      "getCatalog",
+      parameterGroups,
+      {
+        lowercaseHeaderKeys: true,
+        parameterSchemaKind: "server",
+        securityHeaders,
+      },
+    );
+
+    expect(clientResult.schemaCode).toContain(
+      "const getCatalogHeadersSchema = z.object({  });",
+    );
+    expect(clientResult.schemaCode).not.toContain('"custom-token": z.string()');
+    expect(serverResult.schemaCode).toContain(
+      'const getCatalogHeadersSchema = z.object({ "custom-token": z.string() });',
+    );
+  });
 });

--- a/packages/core-utils/tests/shared/parameter-schemas.test.ts
+++ b/packages/core-utils/tests/shared/parameter-schemas.test.ts
@@ -129,7 +129,7 @@ describe("generateParameterSchemas", () => {
     expect(result.schemaCode).toContain('.describe("Explicit email header")');
   });
 
-  it("keeps global security headers out of client schemas but includes them in server schemas", () => {
+  it("materializes global security headers as optional client fields and required server fields", () => {
     const parameterGroups = {
       queryParams: [],
       headerParams: [],
@@ -163,9 +163,8 @@ describe("generateParameterSchemas", () => {
     );
 
     expect(clientResult.schemaCode).toContain(
-      "const getCatalogHeadersSchema = z.object({  });",
+      'const getCatalogHeadersSchema = z.object({ "custom-token": z.string().optional() });',
     );
-    expect(clientResult.schemaCode).not.toContain('"custom-token": z.string()');
     expect(serverResult.schemaCode).toContain(
       'const getCatalogHeadersSchema = z.object({ "custom-token": z.string() });',
     );

--- a/packages/core-utils/tests/shared/parameter-schemas.test.ts
+++ b/packages/core-utils/tests/shared/parameter-schemas.test.ts
@@ -162,11 +162,14 @@ describe("generateParameterSchemas", () => {
       },
     );
 
-    expect(clientResult.schemaCode).toContain(
-      'const getCatalogHeadersSchema = z.object({ "custom-token": z.string().optional() });',
-    );
-    expect(serverResult.schemaCode).toContain(
-      'const getCatalogHeadersSchema = z.object({ "custom-token": z.string() });',
-    );
+    expect(clientResult.schemaCode).toContain("getCatalogHeadersSchema");
+    expect(clientResult.schemaCode).toContain("z.object(");
+    expect(clientResult.schemaCode).toContain("z.string().optional()");
+    expect(clientResult.schemaCode).not.toContain('"custom-token": z.string() }');
+
+    expect(serverResult.schemaCode).toContain("getCatalogHeadersSchema");
+    expect(serverResult.schemaCode).toContain("z.object(");
+    expect(serverResult.schemaCode).toContain('"custom-token"');
+    expect(serverResult.schemaCode).toContain("z.string()");
   });
 });

--- a/packages/route-generator/src/route-metadata-generator.ts
+++ b/packages/route-generator/src/route-metadata-generator.ts
@@ -135,11 +135,15 @@ export function generateRouteMetadataFromMetadata(
 
   const requestMapCode = buildRequestMap(routeMetadata, importManager);
   const responseMapCode = buildResponseMap(routeMetadata, importManager, doc);
+  const isServerHeadersOptional =
+    metadata.parameterGroups.headerParams.every(
+      (parameter) => parameter.required !== true,
+    ) && metadata.operationSecurityHeaders.length === 0;
   const routeCode = renderRouteMetadata({
+    clientIsHeadersOptional: routeMetadata.parameterInfo.isHeadersOptional,
     hasHeaders: routeMetadata.parameterInfo.hasHeaders,
     hasPath: routeMetadata.parameterInfo.hasPath,
     hasQuery: routeMetadata.parameterInfo.hasQuery,
-    isHeadersOptional: routeMetadata.parameterInfo.isHeadersOptional,
     isQueryOptional: routeMetadata.parameterInfo.isQueryOptional,
     method: metadata.method.toLowerCase(),
     operationId: routeMetadata.operationId,
@@ -148,6 +152,7 @@ export function generateRouteMetadataFromMetadata(
     requestMapTypeName: routeMetadata.bodyInfo.requestMapTypeName,
     responseMapCode,
     responseMapTypeName: routeMetadata.bodyInfo.responseMapTypeName,
+    serverIsHeadersOptional: isServerHeadersOptional,
   });
 
   return {

--- a/packages/route-generator/src/templates/route-metadata-templates.ts
+++ b/packages/route-generator/src/templates/route-metadata-templates.ts
@@ -4,11 +4,11 @@ import { sanitizeIdentifier } from "@apical-ts/core-utils";
  * Template parameters for route metadata generation
  */
 export interface RouteMetadataTemplateParams {
+  clientIsHeadersOptional: boolean;
   hasHeaders: boolean;
   hasPath: boolean;
   /** Flags indicating which parameter types have actual parameters */
   hasQuery: boolean;
-  isHeadersOptional: boolean;
   isQueryOptional: boolean;
   /** HTTP method in lowercase (e.g., "get", "post") */
   method: string;
@@ -19,6 +19,7 @@ export interface RouteMetadataTemplateParams {
   requestMapTypeName?: string;
   responseMapCode: string;
   responseMapTypeName?: string;
+  serverIsHeadersOptional: boolean;
 }
 
 /**
@@ -28,10 +29,10 @@ export function renderRouteMetadata(
   params: RouteMetadataTemplateParams,
 ): string {
   const {
+    clientIsHeadersOptional,
     hasHeaders,
     hasPath,
     hasQuery,
-    isHeadersOptional,
     isQueryOptional,
     method,
     operationId,
@@ -40,6 +41,7 @@ export function renderRouteMetadata(
     requestMapTypeName,
     responseMapCode,
     responseMapTypeName,
+    serverIsHeadersOptional,
   } = params;
 
   const sanitizedId = sanitizeIdentifier(operationId);
@@ -87,14 +89,14 @@ export const clientRoute = {
   ...baseRoute,
   params: ${clientParamsValue},
   isQueryOptional: ${isQueryOptional},
-  isHeadersOptional: ${isHeadersOptional},
+  isHeadersOptional: ${clientIsHeadersOptional},
 } as const;
 
 export const serverRoute = {
   ...baseRoute,
   params: ${serverParamsValue},
   isQueryOptional: ${isQueryOptional},
-  isHeadersOptional: ${isHeadersOptional},
+  isHeadersOptional: ${serverIsHeadersOptional},
 } as const;`;
 
   /* Combine all parts */


### PR DESCRIPTION
Restore inherited auth headers in generated server parameter schemas making them optional in client parameter schemas.

This change enhances validation for server routes without compromising client developer experience.