### PR TITLE
Upgrade Zod package

### DIFF
--- a/.changeset/strong-readers-stare.md
+++ b/.changeset/strong-readers-stare.md
@@ -1,0 +1,11 @@
+---
+"@apical-ts/tanstack-query-hooks": patch
+"@apical-ts/examples-msw": patch
+"@apical-ts/core-utils": patch
+"@apical-ts/test-core": patch
+"@apical-ts/examples": patch
+"@apical-ts/examples-hono": patch
+"@apical-ts/craft": patch
+---
+
+Upgrade Zod package

--- a/apps/craft/CHANGELOG.md
+++ b/apps/craft/CHANGELOG.md
@@ -181,7 +181,6 @@
 ### Minor Changes
 
 - 0a04a4e: ## Breaking changes
-
   - The generated `GlobalConfig.headers` now only accepts the declared auth
     header keys. Supplying fewer keys or injecting arbitrary default headers now
     fails type-checking, so update your configuration factories to fill every
@@ -191,7 +190,6 @@
     client calls when the OpenAPI spec actually defined them.
 
   ## Migration guidance
-
   1. Regenerate your client/server and update any helper that builds
      `globalConfig` so it hydrates all generated auth headers (you can store
      credentials elsewhere and spread them in).

--- a/apps/craft/package.json
+++ b/apps/craft/package.json
@@ -59,7 +59,7 @@
     "tsup": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "zod": "^4.3.6"
+    "zod": "catalog:"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.2.2",

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -22,7 +22,7 @@
     "express": "^5.2.1",
     "neverthrow": "^8.2.0",
     "zocker": "^3.0.0",
-    "zod": "^4.3.6"
+    "zod": "catalog:"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@hono/zod-validator": "^0.7.6",
     "hono": "^4.12.18",
-    "zod": "^4.3.6"
+    "zod": "catalog:"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/examples/msw-mock-server/package.json
+++ b/examples/msw-mock-server/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "msw": "^2.6.8",
     "zocker": "^3.0.0",
-    "zod": "^4.3.6"
+    "zod": "catalog:"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/examples/tanstack-query-hooks/package.json
+++ b/examples/tanstack-query-hooks/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-query": "^4.34.0",
     "react": "^18.3.1",
     "tsx": "^4.21.0",
-    "zod": "^4.3.6"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@apical-ts/craft": "workspace:*",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -54,7 +54,7 @@
     "openapi3-ts": "^4.3.0",
     "p-limit": "^7.1.0",
     "swagger2openapi": "^7.0.8",
-    "zod": "^4.3.6"
+    "zod": "catalog:"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/test-core/package.json
+++ b/packages/test-core/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "openapi3-ts": "^4.3.0",
-    "zod": "^4.3.6"
+    "zod": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     vitest:
       specifier: ^4.1.5
       version: 4.1.5
+    zod:
+      specifier: ^4.4.3
+      version: 4.4.3
 
 overrides:
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': '>=7.29.4'
@@ -165,8 +168,8 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/coverage-v8@4.1.4)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.7)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.4))
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.3
 
   apps/website:
     dependencies:
@@ -218,10 +221,10 @@ importers:
         version: 8.2.0
       zocker:
         specifier: ^3.0.0
-        version: 3.0.0(zod@4.3.6)
+        version: 3.0.0(zod@4.4.3)
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@apical-ts/craft':
         specifier: workspace:*
@@ -243,13 +246,13 @@ importers:
     dependencies:
       '@hono/zod-validator':
         specifier: ^0.7.6
-        version: 0.7.6(hono@4.12.18)(zod@4.3.6)
+        version: 0.7.6(hono@4.12.18)(zod@4.4.3)
       hono:
         specifier: ^4.12.18
         version: 4.12.18
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@apical-ts/craft':
         specifier: workspace:*
@@ -280,7 +283,7 @@ importers:
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/coverage-v8@4.1.4)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.7)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.4))
       zocker:
         specifier: ^3.0.0
-        version: 3.0.0(zod@4.3.6)
+        version: 3.0.0(zod@4.4.3)
 
   examples/msw-mock-server:
     dependencies:
@@ -289,10 +292,10 @@ importers:
         version: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
       zocker:
         specifier: ^3.0.0
-        version: 3.0.0(zod@4.3.6)
+        version: 3.0.0(zod@4.4.3)
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@apical-ts/craft':
         specifier: workspace:*
@@ -331,8 +334,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@apical-ts/craft':
         specifier: workspace:*
@@ -399,8 +402,8 @@ importers:
         specifier: ^7.0.8
         version: 7.0.8
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@tsconfig/node22':
         specifier: 'catalog:'
@@ -501,8 +504,8 @@ importers:
         specifier: ^4.3.0
         version: 4.5.0
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@apical-ts/core-utils':
         specifier: workspace:*
@@ -8364,6 +8367,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -10691,10 +10697,10 @@ snapshots:
     dependencies:
       hono: 4.12.18
 
-  '@hono/zod-validator@0.7.6(hono@4.12.18)(zod@4.3.6)':
+  '@hono/zod-validator@0.7.6(hono@4.12.18)(zod@4.4.3)':
     dependencies:
       hono: 4.12.18
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -17801,12 +17807,14 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
-  zocker@3.0.0(zod@4.3.6):
+  zocker@3.0.0(zod@4.4.3):
     dependencies:
       '@faker-js/faker': 10.0.0
       randexp: 0.5.3
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,15 +4,16 @@ packages:
   - examples/*
 
 catalog:
-  '@tsconfig/node22': ^22.0.5
-  '@types/node': ^22.16.2
-  '@typescript/native-preview': ^7.0.0-dev.20260124.1
-  '@vitest/coverage-v8': ^4.1.4
+  "@tsconfig/node22": ^22.0.5
+  "@types/node": ^22.16.2
+  "@typescript/native-preview": ^7.0.0-dev.20260124.1
+  "@vitest/coverage-v8": ^4.1.4
   embedme: ^1.22.1
   oxfmt: ^0.41.0
   tsup: ^8.5.1
   vite: ^7.3.3
   vitest: ^4.1.5
+  zod: ^4.4.3
 
 cleanupUnusedCatalogs: true
 
@@ -22,35 +23,35 @@ onlyBuiltDependencies:
   - esbuild
 
 overrides:
-  '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': '>=7.29.4'
-  '@tootallnate/once@<3.0.1': '>=3.0.1'
-  ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
-  fast-uri@<=3.1.1: '>=3.1.2'
-  fast-xml-builder@<=1.1.6: '>=1.1.7'
-  fast-xml-parser@>=5.5.7 <5.7.0: '>=5.7.0'
-  fast-xml-parser@>=4.1.3 <4.5.4: '>=4.5.4'
-  fast-xml-parser@>=5.0.0 <5.5.7: '>=5.5.7'
-  flatted@<3.4.0: '>=3.4.1'
-  follow-redirects@<=1.15.11: '>=1.16.0'
+  "@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": ">=7.29.4"
+  "@tootallnate/once@<3.0.1": ">=3.0.1"
+  ajv@>=7.0.0-alpha.0 <8.18.0: ">=8.18.0"
+  fast-uri@<=3.1.1: ">=3.1.2"
+  fast-xml-builder@<=1.1.6: ">=1.1.7"
+  fast-xml-parser@>=5.5.7 <5.7.0: ">=5.7.0"
+  fast-xml-parser@>=4.1.3 <4.5.4: ">=4.5.4"
+  fast-xml-parser@>=5.0.0 <5.5.7: ">=5.5.7"
+  flatted@<3.4.0: ">=3.4.1"
+  follow-redirects@<=1.15.11: ">=1.16.0"
   json-schema-faker@0.5.8>json-schema-ref-parser: npm:@apidevtools/json-schema-ref-parser@15.2.2
-  lodash@<=4.17.23: '>=4.18.1'
-  minimatch@<3.1.4: '>=3.1.4'
-  minimatch@>=9.0.0 <9.0.7: '>=9.0.7'
-  node-forge@<1.4.0: '>=1.4.0'
+  lodash@<=4.17.23: ">=4.18.1"
+  minimatch@<3.1.4: ">=3.1.4"
+  minimatch@>=9.0.0 <9.0.7: ">=9.0.7"
+  node-forge@<1.4.0: ">=1.4.0"
   path-to-regexp@<0.1.13: 0.1.13
-  path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.2'
-  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
-  postcss@<8.5.10: '>=8.5.10'
+  path-to-regexp@>=8.0.0 <8.4.0: ">=8.4.2"
+  picomatch@>=4.0.0 <4.0.4: ">=4.0.4"
+  postcss@<8.5.10: ">=8.5.10"
   postman-collection@4.5.0>@faker-js/faker: 6.3.1
-  qs@<6.14.1: '>=6.14.1'
-  qs@>=6.7.0 <=6.14.1: '>=6.14.2'
-  rollup@>=4.0.0 <4.59.0: '>=4.59.0'
-  serialize-javascript@<7.0.5: '>=7.0.5'
+  qs@<6.14.1: ">=6.14.1"
+  qs@>=6.7.0 <=6.14.1: ">=6.14.2"
+  rollup@>=4.0.0 <4.59.0: ">=4.59.0"
+  serialize-javascript@<7.0.5: ">=7.0.5"
   sucrase@3.35.0>glob: 13.0.6
-  svgo@>=3.0.0 <3.3.3: '>=3.3.3'
-  vite@>=7.0.0 <=7.3.1: '>=7.3.2'
-  webpack-dev-server@<=5.2.0: '>=5.2.1'
-  yaml@>=1.0.0 <1.10.3: '>=1.10.3'
-  yaml@>=2.0.0 <2.8.3: '>=2.8.3'
+  svgo@>=3.0.0 <3.3.3: ">=3.3.3"
+  vite@>=7.0.0 <=7.3.1: ">=7.3.2"
+  webpack-dev-server@<=5.2.0: ">=5.2.1"
+  yaml@>=1.0.0 <1.10.3: ">=1.10.3"
+  yaml@>=2.0.0 <2.8.3: ">=2.8.3"
 
 packageImportMethod: clone-or-copy


### PR DESCRIPTION
Upgrade the Zod package to version 4.4.3 across various applications and examples, ensuring compatibility and leveraging the latest features.