### PR TITLE
Add support for patternProperties and propertyNames in schema handling

### DIFF
--- a/.changeset/light-phones-worry.md
+++ b/.changeset/light-phones-worry.md
@@ -1,0 +1,6 @@
+---
+"@apical-ts/core-utils": minor
+"@apical-ts/craft": minor
+---
+
+Add support for patternProperties and propertyNames

--- a/packages/core-utils/src/schema-generator/object-types.ts
+++ b/packages/core-utils/src/schema-generator/object-types.ts
@@ -4,6 +4,12 @@ import { isSchemaObject } from "openapi3-ts/oas31";
 import { shouldIncludeProperty } from "../shared/types.js";
 import type { ZodSchemaCodeOptions, ZodSchemaResult } from "./types.js";
 import { generateObjectCode } from "./object-properties.js";
+import {
+  generatePatternPropertiesValueCode,
+  generatePropertyNamesKeyCode,
+  generateRecordCode,
+  getPatternProperties,
+} from "./pattern-properties.js";
 import { addDefaultValue, addDescription } from "./utils.js";
 
 /**
@@ -59,12 +65,50 @@ export function handleObjectType(
     }
   }
 
+  const patternProperties = getPatternProperties(schema);
+  const codeOptions: ZodSchemaCodeOptions = {
+    currentSchemaName,
+    extraProps,
+    formatOverrides: options.formatOverrides,
+    imports: result.imports,
+    recursiveContext,
+    resolvedSchemas,
+  };
+
   /*
-   * Handle additionalProperties according to OpenAPI specification using the common function
+   * When patternProperties or propertyNames are present without named properties,
+   * generate a z.record(...) schema instead of z.object({}).
    */
+  if (
+    shape.length === 0 &&
+    !schema.properties &&
+    (patternProperties || schema.propertyNames)
+  ) {
+    const recordResult = generateRecordFromPatterns(
+      schema,
+      patternProperties,
+      zodSchemaToCode,
+      codeOptions,
+    );
+    result.imports = recordResult.imports;
+    let code = recordResult.code;
+    code = addDefaultValue(code, schema.default, { schemaType: "object" });
+    result.code = code;
+    return result;
+  }
+
+  /*
+   * When named properties exist alongside patternProperties, use the pattern
+   * value schema as the catchall (overriding additionalProperties if not explicitly set).
+   */
+  const effectiveAdditionalProperties = resolveAdditionalProperties(
+    schema.additionalProperties,
+    patternProperties,
+  );
+
   const objectCodeResult = generateObjectCode(
     shape,
-    schema.additionalProperties,
+    effectiveAdditionalProperties,
     zodSchemaToCode,
     {
       currentSchemaName,
@@ -79,9 +123,123 @@ export function handleObjectType(
   result.imports = objectCodeResult.imports;
   let code = objectCodeResult.code;
 
-  // Add default value if present
   code = addDefaultValue(code, schema.default, { schemaType: "object" });
 
   result.code = code;
   return result;
+}
+
+/*
+ * Generate a z.record() schema from patternProperties and/or propertyNames
+ * when no named properties are present.
+ */
+function generateRecordFromPatterns(
+  schema: SchemaObject,
+  patternProperties: Record<string, ReferenceObject | SchemaObject> | undefined,
+  zodSchemaToCode: (
+    schema: ReferenceObject | SchemaObject,
+    options?: ZodSchemaCodeOptions,
+  ) => ZodSchemaResult,
+  options: ZodSchemaCodeOptions,
+): { code: string; imports: Set<string> } {
+  const imports = options.imports || new Set<string>();
+
+  let valueCode = "z.unknown()";
+  let keyCode = "z.string()";
+
+  /* Derive value type from patternProperties */
+  if (patternProperties) {
+    const ppResult = generatePatternPropertiesValueCode(
+      patternProperties,
+      zodSchemaToCode,
+      { ...options, imports },
+    );
+    valueCode = ppResult.valueCode;
+    for (const imp of ppResult.imports) {
+      imports.add(imp);
+    }
+  }
+
+  /* Derive key constraint from propertyNames */
+  if (schema.propertyNames) {
+    const keyResult = generatePropertyNamesKeyCode(
+      schema.propertyNames,
+      zodSchemaToCode,
+      { ...options, imports },
+    );
+    keyCode = keyResult.code;
+    for (const imp of keyResult.imports) {
+      imports.add(imp);
+    }
+  }
+
+  /*
+   * If additionalProperties is explicitly a schema and no patternProperties
+   * provided a value, use the additionalProperties schema as the value.
+   */
+  if (!patternProperties && requiresValueSchema(schema.additionalProperties)) {
+    const addResult = zodSchemaToCode(schema.additionalProperties, {
+      currentSchemaName: options.currentSchemaName,
+      formatOverrides: options.formatOverrides,
+      imports,
+      recursiveContext: options.recursiveContext,
+      resolvedSchemas: options.resolvedSchemas,
+      skipDescription: true,
+    });
+    valueCode = addResult.code;
+    for (const imp of addResult.imports) {
+      imports.add(imp);
+    }
+  }
+
+  return {
+    code: generateRecordCode({ keyCode, valueCode }),
+    imports,
+  };
+}
+
+/*
+ * When patternProperties exist alongside named properties and additionalProperties
+ * is not explicitly set, synthesize an additionalProperties schema object whose
+ * value type matches the merged patternProperties value schemas.
+ *
+ * This causes generateObjectCode to emit a .catchall(...) with the correct type
+ * rather than degrading to z.unknown() or applying extraProps defaults.
+ */
+function resolveAdditionalProperties(
+  additionalProperties: SchemaObject["additionalProperties"],
+  patternProperties: Record<string, ReferenceObject | SchemaObject> | undefined,
+): SchemaObject["additionalProperties"] {
+  /* If additionalProperties is explicitly set, honour it */
+  if (additionalProperties !== undefined) {
+    return additionalProperties;
+  }
+
+  /* No patternProperties — fall through to default behavior */
+  if (!patternProperties) {
+    return additionalProperties;
+  }
+
+  /*
+   * Synthesize a schema that generateObjectCode will pass through zodSchemaToCode
+   * to produce the correct catchall. We use an anyOf wrapper when multiple pattern
+   * schemas exist, or the single schema directly.
+   */
+  const valueSchemas = Object.values(patternProperties);
+  if (valueSchemas.length === 1) {
+    return valueSchemas[0];
+  }
+
+  return { anyOf: valueSchemas } as SchemaObject;
+}
+
+function requiresValueSchema(
+  additionalProperties: SchemaObject["additionalProperties"],
+): additionalProperties is ReferenceObject | SchemaObject {
+  return (
+    additionalProperties !== undefined &&
+    additionalProperties !== false &&
+    additionalProperties !== true &&
+    typeof additionalProperties === "object"
+  );
 }

--- a/packages/core-utils/src/schema-generator/pattern-properties.ts
+++ b/packages/core-utils/src/schema-generator/pattern-properties.ts
@@ -1,0 +1,186 @@
+import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
+
+import { isSchemaObject } from "openapi3-ts/oas31";
+
+import type { ZodSchemaCodeOptions, ZodSchemaResult } from "./types.js";
+
+/*
+ * patternProperties is a valid JSON Schema keyword preserved at runtime in
+ * OpenAPI 3.1 schemas but not explicitly typed on openapi3-ts SchemaObject.
+ * This interface provides typed access to that runtime data.
+ */
+interface SchemaWithPatternProperties extends SchemaObject {
+  patternProperties?: Record<string, ReferenceObject | SchemaObject>;
+}
+
+/**
+ * Result of analyzing pattern properties for code generation
+ */
+export interface PatternPropertiesResult {
+  keyCode: string;
+  valueCode: string;
+  imports: Set<string>;
+}
+
+/*
+ * Extract patternProperties from a schema. Returns undefined when absent.
+ */
+export function getPatternProperties(
+  schema: SchemaObject,
+): Record<string, ReferenceObject | SchemaObject> | undefined {
+  const extended = schema as SchemaWithPatternProperties;
+  if (
+    !extended.patternProperties ||
+    typeof extended.patternProperties !== "object"
+  ) {
+    return undefined;
+  }
+
+  const entries = Object.entries(extended.patternProperties);
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return extended.patternProperties;
+}
+
+/*
+ * Generate a combined value schema from all patternProperties entries.
+ * When a single pattern exists, use its schema directly.
+ * When multiple patterns exist, wrap their schemas in z.union([...]).
+ */
+export function generatePatternPropertiesValueCode(
+  patternProperties: Record<string, ReferenceObject | SchemaObject>,
+  zodSchemaToCode: (
+    schema: ReferenceObject | SchemaObject,
+    options?: ZodSchemaCodeOptions,
+  ) => ZodSchemaResult,
+  options: ZodSchemaCodeOptions = {},
+): PatternPropertiesResult {
+  const imports = options.imports || new Set<string>();
+  const entries = Object.entries(patternProperties);
+  const valueResults = entries.map(([, valueSchema]) =>
+    zodSchemaToCode(valueSchema, {
+      currentSchemaName: options.currentSchemaName,
+      formatOverrides: options.formatOverrides,
+      imports,
+      recursiveContext: options.recursiveContext,
+      resolvedSchemas: options.resolvedSchemas,
+      skipDescription: true,
+    }),
+  );
+
+  for (const r of valueResults) {
+    for (const imp of r.imports) {
+      imports.add(imp);
+    }
+  }
+
+  const valueCode =
+    valueResults.length === 1
+      ? valueResults[0].code
+      : `z.union([${valueResults.map((r) => r.code).join(", ")}])`;
+
+  const keyCode = generateKeyCode(undefined, options, zodSchemaToCode, imports);
+
+  return { imports, keyCode, valueCode };
+}
+
+/*
+ * Generate a key schema from propertyNames.
+ * - enum → z.enum([...])
+ * - pattern → z.string().regex(...)
+ * - fallback → z.string()
+ */
+export function generatePropertyNamesKeyCode(
+  propertyNames: ReferenceObject | SchemaObject,
+  zodSchemaToCode: (
+    schema: ReferenceObject | SchemaObject,
+    options?: ZodSchemaCodeOptions,
+  ) => ZodSchemaResult,
+  options: ZodSchemaCodeOptions = {},
+): { code: string; imports: Set<string> } {
+  const imports = options.imports || new Set<string>();
+
+  if (!isSchemaObject(propertyNames)) {
+    /* Reference — delegate to zodSchemaToCode */
+    const refResult = zodSchemaToCode(propertyNames, {
+      currentSchemaName: options.currentSchemaName,
+      imports,
+      recursiveContext: options.recursiveContext,
+      resolvedSchemas: options.resolvedSchemas,
+      skipDescription: true,
+    });
+    for (const imp of refResult.imports) {
+      imports.add(imp);
+    }
+    return { code: refResult.code, imports };
+  }
+
+  /* Enumerable keys */
+  if (propertyNames.enum && Array.isArray(propertyNames.enum)) {
+    const literals = propertyNames.enum
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => JSON.stringify(v));
+
+    if (literals.length > 0) {
+      return { code: `z.enum([${literals.join(", ")}])`, imports };
+    }
+  }
+
+  /* Pattern-constrained keys */
+  if (propertyNames.pattern) {
+    const escapedPattern = propertyNames.pattern
+      .replaceAll("\\", "\\\\")
+      .replaceAll("/", "\\/");
+    return { code: `z.string().regex(/${escapedPattern}/)`, imports };
+  }
+
+  return { code: "z.string()", imports };
+}
+
+/*
+ * Build the full z.record(...) code for a schema that uses patternProperties
+ * and/or propertyNames without named properties.
+ */
+export function generateRecordCode(config: {
+  keyCode: string;
+  valueCode: string;
+}): string {
+  const { keyCode, valueCode } = config;
+
+  if (keyCode === "z.string()") {
+    return `z.record(z.string(), ${valueCode})`;
+  }
+
+  return `z.record(${keyCode}, ${valueCode})`;
+}
+
+/*
+ * Determine the key code from propertyNames when present, falling back to z.string().
+ */
+function generateKeyCode(
+  propertyNames: ReferenceObject | SchemaObject | undefined,
+  options: ZodSchemaCodeOptions,
+  zodSchemaToCode: (
+    schema: ReferenceObject | SchemaObject,
+    options?: ZodSchemaCodeOptions,
+  ) => ZodSchemaResult,
+  imports: Set<string>,
+): string {
+  if (!propertyNames) {
+    return "z.string()";
+  }
+
+  const keyResult = generatePropertyNamesKeyCode(
+    propertyNames,
+    zodSchemaToCode,
+    { ...options, imports },
+  );
+
+  for (const imp of keyResult.imports) {
+    imports.add(imp);
+  }
+
+  return keyResult.code;
+}

--- a/packages/core-utils/src/schema-generator/utils.ts
+++ b/packages/core-utils/src/schema-generator/utils.ts
@@ -288,13 +288,31 @@ export function cloneWithoutDefault(schema: SchemaObject): SchemaObject {
 export function inferEffectiveType(schema: SchemaObject): EffectiveType {
   let effectiveType = schema.type as EffectiveType;
   if (!effectiveType) {
-    if (schema.properties || schema.additionalProperties) {
+    if (
+      schema.properties ||
+      schema.additionalProperties ||
+      hasPatternProperties(schema) ||
+      schema.propertyNames
+    ) {
       effectiveType = "object";
     } else if (schema.items) {
       effectiveType = "array";
     }
   }
   return effectiveType;
+}
+
+/*
+ * Check if a schema has patternProperties.
+ * This keyword is a valid JSON Schema keyword preserved at runtime but not
+ * explicitly typed on openapi3-ts SchemaObject.
+ */
+function hasPatternProperties(schema: SchemaObject): boolean {
+  return (
+    "patternProperties" in schema &&
+    schema.patternProperties != null &&
+    typeof schema.patternProperties === "object"
+  );
 }
 
 /**

--- a/packages/core-utils/tests/schema-generator/pattern-properties.test.ts
+++ b/packages/core-utils/tests/schema-generator/pattern-properties.test.ts
@@ -1,0 +1,267 @@
+import type { SchemaObject } from "openapi3-ts/oas31";
+import { describe, expect, it } from "vitest";
+
+import { handleObjectType } from "../../src/schema-generator/object-types.js";
+import {
+  generatePatternPropertiesValueCode,
+  generatePropertyNamesKeyCode,
+  generateRecordCode,
+  getPatternProperties,
+} from "../../src/schema-generator/pattern-properties.js";
+import { zodSchemaToCode } from "../../src/schema-generator/schema-converter.js";
+import type { ZodSchemaResult } from "../../src/schema-generator/types.js";
+
+describe("pattern-properties", () => {
+  describe("getPatternProperties", () => {
+    it("should return undefined when patternProperties is absent", () => {
+      const schema: SchemaObject = { type: "object" };
+      expect(getPatternProperties(schema)).toBeUndefined();
+    });
+
+    it("should return undefined for empty patternProperties", () => {
+      const schema = { type: "object", patternProperties: {} } as SchemaObject;
+      expect(getPatternProperties(schema)).toBeUndefined();
+    });
+
+    it("should return the patternProperties map when present", () => {
+      const schema = {
+        type: "object",
+        patternProperties: { "^S_": { type: "string" } },
+      } as SchemaObject;
+      const result = getPatternProperties(schema);
+      expect(result).toEqual({ "^S_": { type: "string" } });
+    });
+  });
+
+  describe("generatePatternPropertiesValueCode", () => {
+    it("should generate value code for a single pattern", () => {
+      const patternProperties = { "^S_": { type: "string" } as SchemaObject };
+      const result = generatePatternPropertiesValueCode(
+        patternProperties,
+        zodSchemaToCode,
+      );
+      expect(result.valueCode).toBe("z.string()");
+      expect(result.keyCode).toBe("z.string()");
+    });
+
+    it("should generate union for multiple patterns", () => {
+      const patternProperties = {
+        "^S_": { type: "string" } as SchemaObject,
+        "^I_": { type: "integer" } as SchemaObject,
+      };
+      const result = generatePatternPropertiesValueCode(
+        patternProperties,
+        zodSchemaToCode,
+      );
+      expect(result.valueCode).toBe("z.union([z.string(), z.number().int()])");
+    });
+  });
+
+  describe("generatePropertyNamesKeyCode", () => {
+    it("should generate z.enum for enumerable propertyNames", () => {
+      const propertyNames: SchemaObject = {
+        enum: ["foo", "bar", "baz"],
+      };
+      const result = generatePropertyNamesKeyCode(
+        propertyNames,
+        zodSchemaToCode,
+      );
+      expect(result.code).toBe('z.enum(["foo", "bar", "baz"])');
+    });
+
+    it("should generate regex for pattern propertyNames", () => {
+      const propertyNames: SchemaObject = {
+        pattern: "^[a-z]+$",
+      };
+      const result = generatePropertyNamesKeyCode(
+        propertyNames,
+        zodSchemaToCode,
+      );
+      expect(result.code).toBe("z.string().regex(/^[a-z]+$/)");
+    });
+
+    it("should generate z.string() for generic propertyNames", () => {
+      const propertyNames: SchemaObject = { type: "string" };
+      const result = generatePropertyNamesKeyCode(
+        propertyNames,
+        zodSchemaToCode,
+      );
+      expect(result.code).toBe("z.string()");
+    });
+
+    it("should handle propertyNames with slashes in pattern", () => {
+      const propertyNames: SchemaObject = {
+        pattern: "^/api/v[0-9]+",
+      };
+      const result = generatePropertyNamesKeyCode(
+        propertyNames,
+        zodSchemaToCode,
+      );
+      expect(result.code).toBe("z.string().regex(/^\\/api\\/v[0-9]+/)");
+    });
+  });
+
+  describe("generateRecordCode", () => {
+    it("should generate record with string key", () => {
+      expect(
+        generateRecordCode({ keyCode: "z.string()", valueCode: "z.number()" }),
+      ).toBe("z.record(z.string(), z.number())");
+    });
+
+    it("should generate record with enum key", () => {
+      expect(
+        generateRecordCode({
+          keyCode: 'z.enum(["a", "b"])',
+          valueCode: "z.string()",
+        }),
+      ).toBe('z.record(z.enum(["a", "b"]), z.string())');
+    });
+  });
+
+  describe("handleObjectType integration", () => {
+    it("should generate z.record for patternProperties without named properties", () => {
+      const schema = {
+        type: "object",
+        patternProperties: { "^S_": { type: "string" } },
+      } as SchemaObject;
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe("z.record(z.string(), z.string())");
+    });
+
+    it("should generate z.record with union for multiple patterns", () => {
+      const schema = {
+        type: "object",
+        patternProperties: {
+          "^S_": { type: "string" },
+          "^N_": { type: "number" },
+        },
+      } as SchemaObject;
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe(
+        "z.record(z.string(), z.union([z.string(), z.number()]))",
+      );
+    });
+
+    it("should generate z.record with enum key from propertyNames", () => {
+      const schema: SchemaObject = {
+        type: "object",
+        propertyNames: { enum: ["alpha", "beta"] },
+      };
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe(
+        'z.record(z.enum(["alpha", "beta"]), z.unknown())',
+      );
+    });
+
+    it("should generate z.record with both propertyNames and patternProperties", () => {
+      const schema = {
+        type: "object",
+        patternProperties: { "^x-": { type: "string" } },
+        propertyNames: { pattern: "^x-" },
+      } as SchemaObject;
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe("z.record(z.string().regex(/^x-/), z.string())");
+    });
+
+    it("should use patternProperties value as catchall when named properties exist", () => {
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        patternProperties: { "^x-": { type: "number" } },
+      } as SchemaObject;
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe(
+        'z.object({"name": z.string().optional()}).catchall(z.number())',
+      );
+    });
+
+    it("should honour explicit additionalProperties over patternProperties", () => {
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        additionalProperties: false,
+        patternProperties: { "^x-": { type: "number" } },
+      } as SchemaObject;
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe(
+        'z.strictObject({"name": z.string().optional()})',
+      );
+    });
+
+    it("should honour additionalProperties: true over patternProperties", () => {
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        additionalProperties: true,
+        patternProperties: { "^x-": { type: "number" } },
+      } as SchemaObject;
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe(
+        'z.object({"name": z.string().optional()}).catchall(z.unknown())',
+      );
+    });
+
+    it("should generate z.record with additionalProperties schema when no patternProperties", () => {
+      const schema: SchemaObject = {
+        type: "object",
+        propertyNames: { enum: ["a", "b", "c"] },
+        additionalProperties: { type: "number" },
+      };
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe('z.record(z.enum(["a", "b", "c"]), z.number())');
+    });
+
+    it("should still generate standard object for schemas without pattern keywords", () => {
+      const schema: SchemaObject = {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      };
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe('z.object({"id": z.string()})');
+    });
+
+    it("should handle patternProperties with required fields and named properties", () => {
+      const schema = {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+        patternProperties: { "^meta_": { type: "string" } },
+      } as SchemaObject;
+
+      const result: ZodSchemaResult = { code: "", imports: new Set() };
+      handleObjectType(schema, result, zodSchemaToCode);
+
+      expect(result.code).toBe(
+        'z.object({"id": z.string()}).catchall(z.string())',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Enhance schema handling by adding support for `patternProperties` and `propertyNames`, allowing for more flexible schema definitions. This update improves the ability to generate code for schemas that utilize these JSON Schema features.