### PR TITLE
feat: per-key regex runtime validation for patternProperties

### DIFF
--- a/.changeset/silver-clouds-flow.md
+++ b/.changeset/silver-clouds-flow.md
@@ -1,0 +1,6 @@
+---
+"@apical-ts/core-utils": patch
+"@apical-ts/craft": patch
+---
+
+Support regexes in patternProperties keys

--- a/packages/core-utils/src/schema-generator/object-types.ts
+++ b/packages/core-utils/src/schema-generator/object-types.ts
@@ -146,6 +146,7 @@ function generateRecordFromPatterns(
 
   let valueCode = "z.unknown()";
   let keyCode = "z.string()";
+  let refinement: string | undefined;
 
   /* Derive value type from patternProperties */
   if (patternProperties) {
@@ -155,6 +156,8 @@ function generateRecordFromPatterns(
       { ...options, imports },
     );
     valueCode = ppResult.valueCode;
+    keyCode = ppResult.keyCode;
+    refinement = ppResult.refinement;
     for (const imp of ppResult.imports) {
       imports.add(imp);
     }
@@ -193,7 +196,7 @@ function generateRecordFromPatterns(
   }
 
   return {
-    code: generateRecordCode({ keyCode, valueCode }),
+    code: generateRecordCode({ keyCode, refinement, valueCode }),
     imports,
   };
 }

--- a/packages/core-utils/src/schema-generator/pattern-properties.ts
+++ b/packages/core-utils/src/schema-generator/pattern-properties.ts
@@ -18,6 +18,7 @@ interface SchemaWithPatternProperties extends SchemaObject {
  */
 export interface PatternPropertiesResult {
   keyCode: string;
+  refinement?: string;
   valueCode: string;
   imports: Set<string>;
 }
@@ -46,8 +47,11 @@ export function getPatternProperties(
 
 /*
  * Generate a combined value schema from all patternProperties entries.
- * When a single pattern exists, use its schema directly.
- * When multiple patterns exist, wrap their schemas in z.union([...]).
+ *
+ * Single pattern: uses z.string().regex(...) as key and the value schema directly.
+ * Multiple patterns: uses z.string() as key with z.union([...]) as value and
+ * appends a .superRefine() that validates each key against the correct pattern
+ * and its corresponding value schema at runtime.
  */
 export function generatePatternPropertiesValueCode(
   patternProperties: Record<string, ReferenceObject | SchemaObject>,
@@ -76,14 +80,23 @@ export function generatePatternPropertiesValueCode(
     }
   }
 
-  const valueCode =
-    valueResults.length === 1
-      ? valueResults[0].code
-      : `z.union([${valueResults.map((r) => r.code).join(", ")}])`;
+  /*
+   * Single pattern: validate the key with a regex and use the value schema directly.
+   */
+  if (entries.length === 1) {
+    const [pattern] = entries;
+    const keyCode = `z.string().regex(/${escapeRegexForLiteral(pattern[0])}/)`;
+    return { imports, keyCode, valueCode: valueResults[0].code };
+  }
 
-  const keyCode = generateKeyCode(undefined, options, zodSchemaToCode, imports);
+  /*
+   * Multiple patterns: use a union for the value type and add a superRefine
+   * that validates each key against its matching pattern's value schema.
+   */
+  const valueCode = `z.union([${valueResults.map((r) => r.code).join(", ")}])`;
+  const refinement = generateSuperRefine(entries, valueResults);
 
-  return { imports, keyCode, valueCode };
+  return { imports, keyCode: "z.string()", refinement, valueCode };
 }
 
 /*
@@ -130,9 +143,7 @@ export function generatePropertyNamesKeyCode(
 
   /* Pattern-constrained keys */
   if (propertyNames.pattern) {
-    const escapedPattern = propertyNames.pattern
-      .replaceAll("\\", "\\\\")
-      .replaceAll("/", "\\/");
+    const escapedPattern = escapeRegexForLiteral(propertyNames.pattern);
     return { code: `z.string().regex(/${escapedPattern}/)`, imports };
   }
 
@@ -145,42 +156,53 @@ export function generatePropertyNamesKeyCode(
  */
 export function generateRecordCode(config: {
   keyCode: string;
+  refinement?: string;
   valueCode: string;
 }): string {
-  const { keyCode, valueCode } = config;
+  const { keyCode, refinement, valueCode } = config;
+  const base = `z.record(${keyCode}, ${valueCode})`;
 
-  if (keyCode === "z.string()") {
-    return `z.record(z.string(), ${valueCode})`;
+  if (refinement) {
+    return `${base}.superRefine(${refinement})`;
   }
 
-  return `z.record(${keyCode}, ${valueCode})`;
+  return base;
 }
 
 /*
- * Determine the key code from propertyNames when present, falling back to z.string().
+ * Generate a superRefine callback that validates each entry against the
+ * matching pattern's value schema at runtime.
+ *
+ * Output example:
+ *   (val, ctx) => { for (const [key, value] of Object.entries(val)) {
+ *     if (/^S_/.test(key) && !z.string().safeParse(value).success) {
+ *       ctx.addIssue({ code: "custom", path: [key], message: "..." });
+ *     }
+ *     if (/^N_/.test(key) && !z.number().int().safeParse(value).success) {
+ *       ctx.addIssue({ code: "custom", path: [key], message: "..." });
+ *     }
+ *   }}
  */
-function generateKeyCode(
-  propertyNames: ReferenceObject | SchemaObject | undefined,
-  options: ZodSchemaCodeOptions,
-  zodSchemaToCode: (
-    schema: ReferenceObject | SchemaObject,
-    options?: ZodSchemaCodeOptions,
-  ) => ZodSchemaResult,
-  imports: Set<string>,
+function generateSuperRefine(
+  entries: [string, ReferenceObject | SchemaObject][],
+  valueResults: ZodSchemaResult[],
 ): string {
-  if (!propertyNames) {
-    return "z.string()";
-  }
+  const checks = entries.map(([pattern], index) => {
+    const escapedPattern = escapeRegexForLiteral(pattern);
+    const valueSchema = valueResults[index].code;
+    return (
+      `if (/${escapedPattern}/.test(key) && !${valueSchema}.safeParse(value).success) ` +
+      `{ ctx.addIssue({ code: "custom", path: [key], message: "Value at key \\"" + key + "\\" does not match schema for pattern ${escapedPattern}" }); }`
+    );
+  });
 
-  const keyResult = generatePropertyNamesKeyCode(
-    propertyNames,
-    zodSchemaToCode,
-    { ...options, imports },
-  );
+  return `(val, ctx) => { for (const [key, value] of Object.entries(val)) { ${checks.join(" ")} } }`;
+}
 
-  for (const imp of keyResult.imports) {
-    imports.add(imp);
-  }
-
-  return keyResult.code;
+/*
+ * Escape a regex pattern for embedding in a JavaScript regex literal (/.../):
+ * - Forward slashes must be escaped so the regex literal doesn't terminate early
+ */
+function escapeRegexForLiteral(pattern: string): string {
+  return pattern.replaceAll("/", "\\/");
 }

--- a/packages/core-utils/tests/schema-generator/pattern-properties.test.ts
+++ b/packages/core-utils/tests/schema-generator/pattern-properties.test.ts
@@ -41,10 +41,10 @@ describe("pattern-properties", () => {
         zodSchemaToCode,
       );
       expect(result.valueCode).toBe("z.string()");
-      expect(result.keyCode).toBe("z.string()");
+      expect(result.keyCode).toBe("z.string().regex(/^S_/)");
     });
 
-    it("should generate union for multiple patterns", () => {
+    it("should generate union for multiple patterns with refinement", () => {
       const patternProperties = {
         "^S_": { type: "string" } as SchemaObject,
         "^I_": { type: "integer" } as SchemaObject,
@@ -54,6 +54,10 @@ describe("pattern-properties", () => {
         zodSchemaToCode,
       );
       expect(result.valueCode).toBe("z.union([z.string(), z.number().int()])");
+      expect(result.keyCode).toBe("z.string()");
+      expect(result.refinement).toBeDefined();
+      expect(result.refinement).toContain("/^S_/.test(key)");
+      expect(result.refinement).toContain("/^I_/.test(key)");
     });
   });
 
@@ -116,6 +120,26 @@ describe("pattern-properties", () => {
         }),
       ).toBe('z.record(z.enum(["a", "b"]), z.string())');
     });
+
+    it("should append superRefine when refinement is provided", () => {
+      const code = generateRecordCode({
+        keyCode: "z.string()",
+        refinement: "(val, ctx) => { /* check */ }",
+        valueCode: "z.unknown()",
+      });
+      expect(code).toBe(
+        "z.record(z.string(), z.unknown()).superRefine((val, ctx) => { /* check */ })",
+      );
+    });
+
+    it("should not append superRefine when refinement is undefined", () => {
+      const code = generateRecordCode({
+        keyCode: "z.string()",
+        refinement: undefined,
+        valueCode: "z.string()",
+      });
+      expect(code).toBe("z.record(z.string(), z.string())");
+    });
   });
 
   describe("handleObjectType integration", () => {
@@ -128,10 +152,10 @@ describe("pattern-properties", () => {
       const result: ZodSchemaResult = { code: "", imports: new Set() };
       handleObjectType(schema, result, zodSchemaToCode);
 
-      expect(result.code).toBe("z.record(z.string(), z.string())");
+      expect(result.code).toBe("z.record(z.string().regex(/^S_/), z.string())");
     });
 
-    it("should generate z.record with union for multiple patterns", () => {
+    it("should generate z.record with union and superRefine for multiple patterns", () => {
       const schema = {
         type: "object",
         patternProperties: {
@@ -143,9 +167,12 @@ describe("pattern-properties", () => {
       const result: ZodSchemaResult = { code: "", imports: new Set() };
       handleObjectType(schema, result, zodSchemaToCode);
 
-      expect(result.code).toBe(
+      expect(result.code).toContain(
         "z.record(z.string(), z.union([z.string(), z.number()]))",
       );
+      expect(result.code).toContain(".superRefine(");
+      expect(result.code).toContain("/^S_/.test(key)");
+      expect(result.code).toContain("/^N_/.test(key)");
     });
 
     it("should generate z.record with enum key from propertyNames", () => {


### PR DESCRIPTION
## Summary

Adds runtime key validation for `patternProperties` in generated Zod schemas.

### Behavior

- **Single pattern** (e.g. `patternProperties: { "^S_": { type: "string" } }`):
  Validates all keys match the regex via `z.string().regex(/^S_/)` as the record key schema.

- **Multiple patterns** (e.g. `{ "^S_": string, "^N_": number }`):
  Generates `z.record(z.string(), z.union([...]))` plus a `.superRefine()` that checks each key against its matching pattern and validates the value against the corresponding schema at runtime.

### Generated output examples

| Input | Output |
|---|---|
| Single pattern: `{ "^S_": string }` | `z.record(z.string().regex(/^S_/), z.string())` |
| Multiple patterns: `{ "^S_": string, "^N_": number }` | `z.record(z.string(), z.union([...])).superRefine(...)` |

### Tests

- 23 unit tests covering single patterns, multiple patterns with refinement, enum/regex keys, combinations with properties and additionalProperties
- All 353 core-utils tests pass
- All 366 craft tests pass

Relates to #156