### PR TITLE
Preserve defaults in generated schema for $ref, anyOf, and oneOf

### DIFF
--- a/.changeset/twelve-bananas-lose.md
+++ b/.changeset/twelve-bananas-lose.md
@@ -1,0 +1,6 @@
+---
+"@apical-ts/core-utils": patch
+"@apical-ts/craft": patch
+---
+
+Preserve defaults on $ref, anyOf, and oneOf generated schema

--- a/apps/craft/CHANGELOG.md
+++ b/apps/craft/CHANGELOG.md
@@ -198,7 +198,6 @@
 ### Minor Changes
 
 - 0a04a4e: ## Breaking changes
-
   - The generated `GlobalConfig.headers` now only accepts the declared auth
     header keys. Supplying fewer keys or injecting arbitrary default headers now
     fails type-checking, so update your configuration factories to fill every
@@ -208,7 +207,6 @@
     client calls when the OpenAPI spec actually defined them.
 
   ## Migration guidance
-
   1. Regenerate your client/server and update any helper that builds
      `globalConfig` so it hydrates all generated auth headers (you can store
      credentials elsewhere and spread them in).

--- a/packages/core-utils/src/schema-generator/schema-converter.ts
+++ b/packages/core-utils/src/schema-generator/schema-converter.ts
@@ -59,12 +59,16 @@ export function zodSchemaToCode(
     return res;
   };
 
-  /* References */
+  /* References — OpenAPI 3.1 allows $ref with sibling keywords like default */
   if (!isSchemaObject(schema)) {
-    return handleReferenceWithContext(schema, result, {
+    const refResult = handleReferenceWithContext(schema, result, {
       currentSchemaName,
       recursiveContext,
     });
+    if ("default" in schema && schema.default !== undefined) {
+      refResult.code = addDefaultValue(refResult.code, schema.default);
+    }
+    return refResult;
   }
 
   const effectiveType = inferEffectiveType(schema);
@@ -122,7 +126,12 @@ export function zodSchemaToCode(
     extraProps,
     formatOverrides,
   );
-  if (composition) return applyDesc(composition);
+  if (composition) {
+    if (schema.default !== undefined) {
+      composition.code = addDefaultValue(composition.code, schema.default);
+    }
+    return applyDesc(composition);
+  }
 
   /* Primitives & structured */
   const primitiveHandled = handlePrimitive(

--- a/packages/core-utils/src/schema-generator/schema-converter.ts
+++ b/packages/core-utils/src/schema-generator/schema-converter.ts
@@ -19,6 +19,7 @@ import {
   handleStringType,
 } from "./primitive-types.js";
 import { handleReferenceWithContext } from "./reference-handlers.js";
+import { parseSchemaReference } from "./schema-references.js";
 import { handleAllOfSchema, handleUnionSchema } from "./union-types.js";
 import {
   addDefaultValue,
@@ -32,6 +33,7 @@ import {
   mergeImports,
   toLiteralCode,
 } from "./utils.js";
+import type { DefaultValueOptions } from "./utils.js";
 
 /**
  * Converts an OpenAPI schema object to Zod validation code
@@ -66,7 +68,12 @@ export function zodSchemaToCode(
       recursiveContext,
     });
     if ("default" in schema && schema.default !== undefined) {
-      refResult.code = addDefaultValue(refResult.code, schema.default);
+      const defaultOpts = resolveRefDefaultOptions(schema, resolvedSchemas);
+      refResult.code = addDefaultValue(
+        refResult.code,
+        schema.default,
+        defaultOpts,
+      );
     }
     return refResult;
   }
@@ -128,7 +135,11 @@ export function zodSchemaToCode(
   );
   if (composition) {
     if (schema.default !== undefined) {
-      composition.code = addDefaultValue(composition.code, schema.default);
+      composition.code = addDefaultValue(
+        composition.code,
+        schema.default,
+        getDefaultValueOptions(schema),
+      );
     }
     return applyDesc(composition);
   }
@@ -341,4 +352,27 @@ function tryHandleCompositions(
     );
   }
   return undefined;
+}
+
+/*
+ * Resolve DefaultValueOptions for a $ref schema by looking up the referenced
+ * schema in resolvedSchemas. Falls back to undefined when the ref cannot be
+ * resolved, letting addDefaultValue use its default (untyped) behavior.
+ */
+function resolveRefDefaultOptions(
+  schema: ReferenceObject,
+  resolvedSchemas?: ResolvedSchemas,
+): DefaultValueOptions | undefined {
+  if (!resolvedSchemas || !schema.$ref) {
+    return undefined;
+  }
+  const parsed = parseSchemaReference(schema.$ref);
+  if (!parsed) {
+    return undefined;
+  }
+  const resolved = resolvedSchemas[parsed.originalName];
+  if (!resolved || !isSchemaObject(resolved)) {
+    return undefined;
+  }
+  return getDefaultValueOptions(resolved);
 }

--- a/packages/core-utils/tests/zod-schema-to-code.test.ts
+++ b/packages/core-utils/tests/zod-schema-to-code.test.ts
@@ -1964,6 +1964,17 @@ describe("zodSchemaToCode", () => {
       expect(result.imports.has("Item")).toBe(true);
     });
 
+    it("should coerce an int64 $ref default to bigint literal", () => {
+      const schema = { $ref: "#/components/schemas/BigId", default: 42 };
+      const result = zodSchemaToCode(schema, {
+        resolvedSchemas: {
+          BigId: { type: "integer", format: "int64" },
+        },
+      });
+      expect(result.code).toBe("BigId.default(42n)");
+      expect(result.imports.has("BigId")).toBe(true);
+    });
+
     it("should preserve a primitive default on an anyOf schema", () => {
       const schema: SchemaObject = {
         anyOf: [{ type: "string" }, { type: "number" }],

--- a/packages/core-utils/tests/zod-schema-to-code.test.ts
+++ b/packages/core-utils/tests/zod-schema-to-code.test.ts
@@ -1938,4 +1938,93 @@ describe("zodSchemaToCode", () => {
       expect(result.code).not.toContain("discriminatedUnion");
     });
   });
+
+  describe("default preservation on $ref, anyOf, and oneOf", () => {
+    it("should preserve a primitive default on a $ref schema", () => {
+      const schema = { $ref: "#/components/schemas/Status", default: "active" };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('Status.default("active")');
+      expect(result.imports.has("Status")).toBe(true);
+    });
+
+    it("should preserve an object default on a $ref schema", () => {
+      const schema = {
+        $ref: "#/components/schemas/Config",
+        default: { enabled: true },
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe('Config.default({"enabled":true})');
+      expect(result.imports.has("Config")).toBe(true);
+    });
+
+    it("should preserve a null default on a $ref schema", () => {
+      const schema = { $ref: "#/components/schemas/Item", default: null };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe("Item.default(null)");
+      expect(result.imports.has("Item")).toBe(true);
+    });
+
+    it("should preserve a primitive default on an anyOf schema", () => {
+      const schema: SchemaObject = {
+        anyOf: [{ type: "string" }, { type: "number" }],
+        default: "hello",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe(
+        'z.union([z.string(), z.number()]).default("hello")',
+      );
+    });
+
+    it("should preserve a primitive default on a oneOf schema", () => {
+      const schema: SchemaObject = {
+        oneOf: [{ type: "string" }, { type: "number" }],
+        default: 42,
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toContain(".default(42)");
+      expect(result.code).toContain("z.union([z.string(), z.number()])");
+    });
+
+    it("should preserve a null default on an anyOf schema", () => {
+      const schema: SchemaObject = {
+        anyOf: [{ type: "string" }, { type: "number" }],
+        default: null,
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe(
+        "z.union([z.string(), z.number()]).default(null)",
+      );
+    });
+
+    it("should preserve an object default on an anyOf schema", () => {
+      const schema: SchemaObject = {
+        anyOf: [
+          {
+            type: "object",
+            properties: { name: { type: "string" } },
+          },
+          { type: "string" },
+        ],
+        default: { name: "test" },
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toContain('.default({"name":"test"})');
+    });
+
+    it("should not apply .default() when no default is present on anyOf", () => {
+      const schema: SchemaObject = {
+        anyOf: [{ type: "string" }, { type: "number" }],
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe("z.union([z.string(), z.number()])");
+      expect(result.code).not.toContain(".default(");
+    });
+
+    it("should not apply .default() when no default is present on $ref", () => {
+      const schema = { $ref: "#/components/schemas/Foo" };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).toBe("Foo");
+      expect(result.code).not.toContain(".default(");
+    });
+  });
 });


### PR DESCRIPTION
Enhance schema generation by preserving default values for $ref, anyOf, and oneOf constructs. This change ensures that defaults are correctly applied in the generated code, improving usability and consistency.