### PR TITLE
Fix default values on allOf schemas

### DIFF
--- a/.changeset/quiet-schools-lose.md
+++ b/.changeset/quiet-schools-lose.md
@@ -1,0 +1,6 @@
+---
+"@apical-ts/core-utils": patch
+"@apical-ts/craft": patch
+---
+
+Fix default values on allOf

--- a/packages/core-utils/src/schema-generator/schema-converter.ts
+++ b/packages/core-utils/src/schema-generator/schema-converter.ts
@@ -134,7 +134,9 @@ export function zodSchemaToCode(
     formatOverrides,
   );
   if (composition) {
-    if (schema.default !== undefined) {
+    /* Apply default only to anyOf/oneOf — allOf produces objects where a
+       primitive default (e.g. "off") would generate invalid Zod code. */
+    if (schema.default !== undefined && !schema.allOf) {
       composition.code = addDefaultValue(
         composition.code,
         schema.default,

--- a/packages/core-utils/tests/zod-schema-to-code.test.ts
+++ b/packages/core-utils/tests/zod-schema-to-code.test.ts
@@ -2037,5 +2037,17 @@ describe("zodSchemaToCode", () => {
       expect(result.code).toBe("Foo");
       expect(result.code).not.toContain(".default(");
     });
+
+    it("should not apply a primitive default on an allOf schema", () => {
+      const schema: SchemaObject = {
+        allOf: [
+          { type: "object", properties: { id: { type: "string" } } },
+          { type: "object", properties: { value: { type: "string" } } },
+        ],
+        default: "off",
+      };
+      const result = zodSchemaToCode(schema);
+      expect(result.code).not.toContain(".default(");
+    });
   });
 });


### PR DESCRIPTION
Prevent applying primitive default values to allOf schemas to avoid generating invalid Zod code. This change ensures that defaults are only applied to anyOf or oneOf schemas.