### PR TITLE
Optimize type constraints in parseApiResponseUnknownData for better performance

### DIFF
--- a/.changeset/three-symbols-design.md
+++ b/.changeset/three-symbols-design.md
@@ -1,0 +1,6 @@
+---
+"@apical-ts/client-generator": patch
+"@apical-ts/craft": patch
+---
+
+Reduce structural type-check cost

--- a/packages/client-generator/src/templates/config/api-response-types.template.ts
+++ b/packages/client-generator/src/templates/config/api-response-types.template.ts
@@ -6,7 +6,7 @@
 export function renderApiResponseParsingUtilities(): string {
   return `/* Overload without deserializers */
 export function parseApiResponseUnknownData<
-  TSchemaMap extends Record<string, { safeParse: (value: unknown) => z.ZodSafeParseResult<unknown> }>
+  TSchemaMap extends Record<string, z.ZodType>
 >(
   response: MinimalResponse,
   data: unknown,
@@ -20,7 +20,7 @@ export function parseApiResponseUnknownData<
 
 /* Overload with deserializers */
 export function parseApiResponseUnknownData<
-  TSchemaMap extends Record<string, { safeParse: (value: unknown) => z.ZodSafeParseResult<unknown> }>
+  TSchemaMap extends Record<string, z.ZodType>
 >(
   response: MinimalResponse,
   data: unknown,
@@ -35,10 +35,7 @@ export function parseApiResponseUnknownData<
 
 /* Implementation */
 export function parseApiResponseUnknownData<
-  TSchemaMap extends Record<
-    string,
-    { safeParse: (value: unknown) => z.ZodSafeParseResult<unknown> }
-  >
+  TSchemaMap extends Record<string, z.ZodType>
 >(
   response: MinimalResponse,
   data: unknown,

--- a/packages/client-generator/tests/strongly-typed-parse.test.ts
+++ b/packages/client-generator/tests/strongly-typed-parse.test.ts
@@ -87,11 +87,21 @@ describe("strongly-typed parseApiResponseUnknownData", () => {
     it("should have correct constraint on TSchemaMap", () => {
       const utilityCode = renderUtilityFunctions();
 
-      /* Should have proper constraint on schema map */
+      /* Should use z.ZodType as the constraint (cheaper for the checker than structural safeParse) */
       expect(utilityCode).toContain(
-        "TSchemaMap extends Record<string, { safeParse:",
+        "TSchemaMap extends Record<string, z.ZodType>",
       );
-      expect(utilityCode).toContain("z.ZodSafeParseResult<unknown>");
+    });
+
+    it("should not use structural safeParse constraint (regression guard for #167)", () => {
+      const utilityCode = renderUtilityFunctions();
+
+      /* The old structural { safeParse: ... } constraint caused expensive
+       * deep structural comparison for every Zod schema at each call site.
+       * Ensure it is not reintroduced. */
+      expect(utilityCode).not.toContain(
+        "{ safeParse: (value: unknown) => z.ZodSafeParseResult<unknown> }",
+      );
     });
   });
 });


### PR DESCRIPTION
Refactor type constraints in `parseApiResponseUnknownData` to use `z.ZodType`, reducing the cost of structural type-checking and improving performance. This change addresses potential inefficiencies in type validation.

Closes #167