### PR TITLE
Generate imports with TypeScript extension

### DIFF
--- a/.changeset/gold-chairs-lose.md
+++ b/.changeset/gold-chairs-lose.md
@@ -1,0 +1,14 @@
+---
+"@apical-ts/tanstack-query-hooks": patch
+"@apical-ts/client-generator": patch
+"@apical-ts/server-generator": patch
+"@apical-ts/examples-msw": patch
+"@apical-ts/route-generator": patch
+"@apical-ts/core-utils": patch
+"@apical-ts/test-core": patch
+"@apical-ts/examples": patch
+"@apical-ts/examples-hono": patch
+"@apical-ts/craft": patch
+---
+
+Generate imports with TypeScript extension

--- a/apps/craft/tests/integrations/allof-schema-composition.test.ts
+++ b/apps/craft/tests/integrations/allof-schema-composition.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import type { AllOfTest } from "./generated/schemas/AllOfTest.js";
-import type { AllOfWithEmptyObjectAndRequireTest } from "./generated/schemas/AllOfWithEmptyObjectAndRequireTest.js";
-import type { AllOfWithMixedTest } from "./generated/schemas/AllOfWithMixedTest.js";
+import type { AllOfTest } from "./generated/schemas/AllOfTest.ts";
+import type { AllOfWithEmptyObjectAndRequireTest } from "./generated/schemas/AllOfWithEmptyObjectAndRequireTest.ts";
+import type { AllOfWithMixedTest } from "./generated/schemas/AllOfWithMixedTest.ts";
 
 describe("AllOf Schema Composition Integration", () => {
   describe("Object spread optimization", () => {
@@ -54,7 +54,7 @@ describe("AllOf Schema Composition Integration", () => {
     it("should validate AllOfTest schema correctly", async () => {
       // Import the actual Zod schema
       const { AllOfTest: AllOfTestSchema } =
-        await import("./generated/schemas/AllOfTest.js");
+        await import("./generated/schemas/AllOfTest.ts");
 
       // Test valid data
       const validData = {
@@ -85,7 +85,7 @@ describe("AllOf Schema Composition Integration", () => {
     it("should validate AllOfWithEmptyObjectAndRequireTest with required items", async () => {
       // Import the actual Zod schema
       const { AllOfWithEmptyObjectAndRequireTest: RequireTestSchema } =
-        await import("./generated/schemas/AllOfWithEmptyObjectAndRequireTest.js");
+        await import("./generated/schemas/AllOfWithEmptyObjectAndRequireTest.ts");
 
       // Test that items is required
       const invalidData = {
@@ -135,7 +135,7 @@ describe("AllOf Schema Composition Integration", () => {
     it("should handle optional items in regular AllOfTest", async () => {
       // Import the actual Zod schema
       const { AllOfTest: AllOfTestSchema } =
-        await import("./generated/schemas/AllOfTest.js");
+        await import("./generated/schemas/AllOfTest.ts");
 
       // Test that items is optional in regular AllOfTest
       const dataWithoutItems = {

--- a/apps/craft/tests/integrations/client.ts
+++ b/apps/craft/tests/integrations/client.ts
@@ -1,8 +1,8 @@
 import {
   configureOperations,
   type GlobalConfig,
-} from "./generated/client/runtime.js";
-import * as operations from "./generated/client/index.js";
+} from "./generated/client/runtime.ts";
+import * as operations from "./generated/client/index.ts";
 
 /**
  * Test client configuration

--- a/apps/craft/tests/integrations/configure-operations-forced-removal.test.ts
+++ b/apps/craft/tests/integrations/configure-operations-forced-removal.test.ts
@@ -3,8 +3,8 @@ import {
   configureOperations,
   globalConfig,
   ApiResponseWithForcedParse,
-} from "./generated/client/runtime.js";
-import { testMultipleSuccess } from "./generated/client/testMultipleSuccess.js";
+} from "./generated/client/runtime.ts";
+import { testMultipleSuccess } from "./generated/client/testMultipleSuccess.ts";
 
 /* This test asserts that when binding with forceValidation:false the returned operation
    type no longer includes any ApiResponseWithForcedParse variants (DX improvement). */

--- a/apps/craft/tests/integrations/configure-operations-overloads.test.ts
+++ b/apps/craft/tests/integrations/configure-operations-overloads.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   configureOperations,
   globalConfig,
-} from "./generated/client/runtime.js";
-import { testMultiContentTypes } from "./generated/client/testMultiContentTypes.js";
+} from "./generated/client/runtime.ts";
+import { testMultiContentTypes } from "./generated/client/testMultiContentTypes.ts";
 
 // These tests are primarily compile-time assertions. If this file type-checks, overloads work.
 describe("configureOperations overloads", () => {

--- a/apps/craft/tests/integrations/configure-operations-typing.test.ts
+++ b/apps/craft/tests/integrations/configure-operations-typing.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   configureOperations,
   globalConfig,
-} from "./generated/client/runtime.js";
-import { testMultiContentTypes } from "./generated/client/testMultiContentTypes.js";
+} from "./generated/client/runtime.ts";
+import { testMultiContentTypes } from "./generated/client/testMultiContentTypes.ts";
 
 // These tests rely on TypeScript compile-time; runtime just sanity checks functions exist.
 describe("configureOperations typing", () => {

--- a/apps/craft/tests/integrations/core-generator/response-reference-resolution.test.ts
+++ b/apps/craft/tests/integrations/core-generator/response-reference-resolution.test.ts
@@ -41,7 +41,7 @@ describe("core-generator response reference resolution", () => {
     const testContent = await fs.readFile(testFile, "utf-8");
 
     expect(testContent).toContain(
-      'from "../routes/testResponseRefWithInlineSchema.js"',
+      'from "../routes/testResponseRefWithInlineSchema.ts"',
     );
   });
 
@@ -58,7 +58,7 @@ describe("core-generator response reference resolution", () => {
     // Server imports the route-level response union, which uses the RouteResponse
     // suffix to avoid colliding with schema response types imported in the same module.
     expect(testContent).toContain(
-      'import type { testResponseRefWithInlineSchemaRouteResponse } from "../routes/testResponseRefWithInlineSchema.js"',
+      'import type { testResponseRefWithInlineSchemaRouteResponse } from "../routes/testResponseRefWithInlineSchema.ts"',
     );
   });
 });

--- a/apps/craft/tests/integrations/core-generator/schema-sanitization-collisions.test.ts
+++ b/apps/craft/tests/integrations/core-generator/schema-sanitization-collisions.test.ts
@@ -3,10 +3,10 @@ import { promises as fs } from "fs";
 import path from "path";
 
 // Import the generated schemas that demonstrate collision detection
-import { Catalog } from "../generated/schemas/Catalog.js";
-import { CatalogMeta } from "../generated/schemas/CatalogMeta.js";
-import { catalog2 } from "../generated/schemas/catalog2.js";
-import { catalogmeta2 } from "../generated/schemas/catalogmeta2.js";
+import { Catalog } from "../generated/schemas/Catalog.ts";
+import { CatalogMeta } from "../generated/schemas/CatalogMeta.ts";
+import { catalog2 } from "../generated/schemas/catalog2.ts";
+import { catalogmeta2 } from "../generated/schemas/catalogmeta2.ts";
 
 describe("schema sanitization collision detection", () => {
   it("should have renamed schemas to avoid case-sensitivity conflicts in the generated client", async () => {

--- a/apps/craft/tests/integrations/create-user-with-request-bodies.test.ts
+++ b/apps/craft/tests/integrations/create-user-with-request-bodies.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { createUnauthenticatedClient } from "./client.js";
 import { getRandomPort, MockServer } from "./setup.js";
-import { Profile } from "./generated/schemas/Profile.js";
+import { Profile } from "./generated/schemas/Profile.ts";
 
 describe("CreateUserWithRequestBodies Operation Tests", () => {
   let mockServer: MockServer;

--- a/apps/craft/tests/integrations/createDocument-reference.test.ts
+++ b/apps/craft/tests/integrations/createDocument-reference.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   createDocument,
   CreateDocumentResponseMap,
-} from "./generated/client/createDocument.js";
+} from "./generated/client/createDocument.ts";
 
 describe("createDocument response reference integration", () => {
   it("should have correctly populated response map", () => {

--- a/apps/craft/tests/integrations/deserializer-map.test.ts
+++ b/apps/craft/tests/integrations/deserializer-map.test.ts
@@ -44,7 +44,7 @@ describe("DeserializerMap Integration Test", () => {
 
     /* Find the deserializer map type definition */
     const deserializerMapMatch = operationContent.match(
-      /export type TestAuthBearerHttpResponseDeserializerMap = Partial<\s*Record<\s*([\s\S]*?),\s*import\('\.\/runtime\.js'\)\.Deserializer\s*>\s*>;/,
+      /export type TestAuthBearerHttpResponseDeserializerMap = Partial<\s*Record<\s*([\s\S]*?),\s*import\('\.\/runtime\.ts'\)\.Deserializer\s*>\s*>;/,
     );
 
     expect(deserializerMapMatch).toBeTruthy();
@@ -89,7 +89,7 @@ describe("DeserializerMap Integration Test", () => {
 
     /* Check that route is imported */
     expect(operationContent).toContain(
-      'from "../routes/testAuthBearerHttp.js"',
+      'from "../routes/testAuthBearerHttp.ts"',
     );
 
     /* Response map structure should be in route file */

--- a/apps/craft/tests/integrations/express-server-wrapper.test.ts
+++ b/apps/craft/tests/integrations/express-server-wrapper.test.ts
@@ -4,15 +4,15 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   route as testParameterWithDashRoute,
   testParameterWithDashWrapper,
-} from "./generated/server/testParameterWithDash.js";
+} from "./generated/server/testParameterWithDash.ts";
 import {
   route as testWithTwoParamsRoute,
   testWithTwoParamsWrapper,
-} from "./generated/server/testWithTwoParams.js";
+} from "./generated/server/testWithTwoParams.ts";
 import {
   route as testCoercionRoute,
   testCoercionWrapper,
-} from "./generated/server/testCoercion.js";
+} from "./generated/server/testCoercion.ts";
 
 /* Minimal local adapter + helpers to decouple test from example implementation. */
 interface LocalServerResponse {

--- a/apps/craft/tests/integrations/force-validation-type-narrowing.test.ts
+++ b/apps/craft/tests/integrations/force-validation-type-narrowing.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   createDocument,
   CreateDocumentResponseMap,
-} from "./generated/client/createDocument.js";
-import type { GlobalConfig } from "./generated/client/runtime.js";
+} from "./generated/client/createDocument.ts";
+import type { GlobalConfig } from "./generated/client/runtime.ts";
 
 /**
  * Integration test for compile-time type narrowing with forceValidation.

--- a/apps/craft/tests/integrations/force-validation.test.ts
+++ b/apps/craft/tests/integrations/force-validation.test.ts
@@ -36,7 +36,7 @@ describe("Dynamic Force Validation Integration Test", () => {
       "export const TestDeserializationResponseMap = testDeserializationResponseMap",
     );
     // Check that route is imported (includes clientRoute alias)
-    expect(content).toContain('from "../routes/testDeserialization.js"');
+    expect(content).toContain('from "../routes/testDeserialization.ts"');
   });
 
   it("multi content type operation has both code paths", async () => {

--- a/apps/craft/tests/integrations/formUrlEncode.test.ts
+++ b/apps/craft/tests/integrations/formUrlEncode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formUrlEncode } from "./generated/client/runtime.js";
+import { formUrlEncode } from "./generated/client/runtime.ts";
 
 describe("formUrlEncode", () => {
   it("encodes arrays with repeat format by default", () => {

--- a/apps/craft/tests/integrations/format-overrides.test.ts
+++ b/apps/craft/tests/integrations/format-overrides.test.ts
@@ -80,11 +80,11 @@ describe("format overrides integration", () => {
 
 function createConsumerSource(): string {
   return `import * as z from "zod";
-import { createProfile } from "./client/createProfile.js";
-import { createProfileRequestMap } from "./routes/createProfile.js";
-import { serverRoute as getProfileByTaxCodeServerRoute } from "./routes/getProfileByTaxCode.js";
-import type { Profile } from "./schemas/Profile.js";
-import type { getProfileByTaxCodeHandler } from "./server/getProfileByTaxCode.js";
+import { createProfile } from "./client/createProfile.ts";
+import { createProfileRequestMap } from "./routes/createProfile.ts";
+import { serverRoute as getProfileByTaxCodeServerRoute } from "./routes/getProfileByTaxCode.ts";
+import type { Profile } from "./schemas/Profile.ts";
+import type { getProfileByTaxCodeHandler } from "./server/getProfileByTaxCode.ts";
 
 const validProfile: Profile = { fiscalCode: "TAX-001" };
 // @ts-expect-error invalid tax code should be rejected by the overridden schema type
@@ -148,9 +148,10 @@ async function generateWithFormatOverride(): Promise<void> {
 }
 
 function getExpectedImportSpecifier(filePath: string): string {
-  const relativePath = relative(dirname(filePath), taxCodeSourcePath)
-    .replaceAll("\\", "/")
-    .replace(/\.ts$/, ".js");
+  const relativePath = relative(
+    dirname(filePath),
+    taxCodeSourcePath,
+  ).replaceAll("\\", "/");
 
   return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
 }

--- a/apps/craft/tests/integrations/operations/deserialization.test.ts
+++ b/apps/craft/tests/integrations/operations/deserialization.test.ts
@@ -88,7 +88,7 @@ describe("Deserialization Operation", () => {
 
   it("captures deserialization-error when custom deserializer throws", async () => {
     const { testDeserialization } =
-      await import("../generated/client/testDeserialization.js");
+      await import("../generated/client/testDeserialization.ts");
 
     const res = await testDeserialization(
       {},
@@ -126,7 +126,7 @@ describe("Deserialization Operation", () => {
 
   it("reports validation error when deserializer returns invalid shape", async () => {
     const { testDeserialization } =
-      await import("../generated/client/testDeserialization.js");
+      await import("../generated/client/testDeserialization.ts");
 
     const res = await testDeserialization(
       {},
@@ -164,7 +164,7 @@ describe("Deserialization Operation", () => {
 
   it("parses XML response via custom XML deserializer", async () => {
     const { testDeserialization } =
-      await import("../generated/client/testDeserialization.js");
+      await import("../generated/client/testDeserialization.ts");
 
     const res = await testDeserialization(
       {
@@ -211,7 +211,7 @@ describe("Deserialization Operation", () => {
 
   it("handles vendor JSON content type with custom deserializer on multi-content operation", async () => {
     const { testMultiContentTypes } =
-      await import("../generated/client/testMultiContentTypes.js");
+      await import("../generated/client/testMultiContentTypes.ts");
 
     const res = await testMultiContentTypes(
       {
@@ -258,7 +258,7 @@ describe("Deserialization Operation", () => {
 
   it("deserializes binary download into length summary", async () => {
     const { testBinaryFileDownload } =
-      await import("../generated/client/testBinaryFileDownload.js");
+      await import("../generated/client/testBinaryFileDownload.ts");
 
     const res = await testBinaryFileDownload(
       {},
@@ -301,7 +301,7 @@ describe("Deserialization Operation", () => {
 
   it("parses response when request sent as x-www-form-urlencoded with custom vendor JSON response", async () => {
     const { testMultiContentTypes } =
-      await import("../generated/client/testMultiContentTypes.js");
+      await import("../generated/client/testMultiContentTypes.ts");
 
     const res = await testMultiContentTypes(
       {

--- a/apps/craft/tests/integrations/parameter-serialization-utilities.test.ts
+++ b/apps/craft/tests/integrations/parameter-serialization-utilities.test.ts
@@ -3,7 +3,7 @@ import {
   serializeQueryParam,
   serializePathParam,
   serializeHeaderParam,
-} from "./generated/client/runtime.js";
+} from "./generated/client/runtime.ts";
 
 describe("Parameter Serialization Utilities", () => {
   describe("serializeQueryParam", () => {

--- a/apps/craft/tests/integrations/query-param-serialization-integration.test.ts
+++ b/apps/craft/tests/integrations/query-param-serialization-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testQueryParamInlineEnum } from "../integrations/generated/client/testQueryParamInlineEnum.js";
+import { testQueryParamInlineEnum } from "../integrations/generated/client/testQueryParamInlineEnum.ts";
 
 describe("Query Parameter Integration", () => {
   it("should correctly serialize complex query parameters in real operations", async () => {

--- a/apps/craft/tests/integrations/query-param-serialization.test.ts
+++ b/apps/craft/tests/integrations/query-param-serialization.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { serializeQueryParam } from "./generated/client/runtime.js";
+import { serializeQueryParam } from "./generated/client/runtime.ts";
 
 describe("Query Parameter Serialization", () => {
   describe("serializeQueryParam", () => {

--- a/apps/craft/tests/integrations/raw-json-schema-input.test.ts
+++ b/apps/craft/tests/integrations/raw-json-schema-input.test.ts
@@ -44,9 +44,9 @@ describe("raw JSON Schema input", () => {
         "index.ts",
       ]),
     );
-    expect(personContent).toContain('import { Address } from "./Address.js";');
+    expect(personContent).toContain('import { Address } from "./Address.ts";');
     expect(personContent).toContain('"address": Address');
-    expect(indexContent).toContain('import { Person } from "./Person.js";');
+    expect(indexContent).toContain('import { Person } from "./Person.ts";');
     expect(indexContent).toContain("  Person,");
   });
 

--- a/apps/craft/tests/integrations/readonly-writeonly-integration.test.ts
+++ b/apps/craft/tests/integrations/readonly-writeonly-integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { ProductWithReadOnlyMetaRequest } from "./generated/schemas/ProductWithReadOnlyMetaRequest.js";
-import { ProductWithReadOnlyMetaResponse } from "./generated/schemas/ProductWithReadOnlyMetaResponse.js";
+import { ProductWithReadOnlyMetaRequest } from "./generated/schemas/ProductWithReadOnlyMetaRequest.ts";
+import { ProductWithReadOnlyMetaResponse } from "./generated/schemas/ProductWithReadOnlyMetaResponse.ts";
 import { createUnauthenticatedClient } from "./client.js";
 import { getRandomPort, MockServer } from "./setup.js";
 

--- a/apps/craft/tests/integrations/recursive-zod-validation.test.ts
+++ b/apps/craft/tests/integrations/recursive-zod-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { Category } from "../integrations/generated/schemas/Category.js";
-import { NotificationEvent } from "../integrations/generated/schemas/NotificationEvent.js";
+import { Category } from "../integrations/generated/schemas/Category.ts";
+import { NotificationEvent } from "../integrations/generated/schemas/NotificationEvent.ts";
 
 describe("Recursive Schema Validation", () => {
   describe("Category (regular recursive schema)", () => {

--- a/apps/craft/tests/integrations/request-bodies.test.ts
+++ b/apps/craft/tests/integrations/request-bodies.test.ts
@@ -4,8 +4,8 @@ import {
   createUserWithRequestBodies,
   CreateUserWithRequestBodiesRequestMap,
   CreateUserWithRequestBodiesResponseMap,
-} from "./generated/client/createUserWithRequestBodies.js";
-import { Profile } from "./generated/schemas/Profile.js";
+} from "./generated/client/createUserWithRequestBodies.ts";
+import { Profile } from "./generated/schemas/Profile.ts";
 
 describe("Request Bodies Unit Tests", () => {
   describe("CreateUserWithRequestBodies operation", () => {

--- a/apps/craft/tests/integrations/response-reference-resolution.test.ts
+++ b/apps/craft/tests/integrations/response-reference-resolution.test.ts
@@ -41,7 +41,7 @@ describe("core-generator response reference resolution", () => {
     const testContent = await fs.readFile(testFile, "utf-8");
 
     expect(testContent).toContain(
-      'from "../routes/testResponseRefWithInlineSchema.js"',
+      'from "../routes/testResponseRefWithInlineSchema.ts"',
     );
   });
 
@@ -58,7 +58,7 @@ describe("core-generator response reference resolution", () => {
     // Server imports the route-level response union, which uses the RouteResponse
     // suffix to avoid colliding with schema response types imported in the same module.
     expect(testContent).toContain(
-      'import type { testResponseRefWithInlineSchemaRouteResponse } from "../routes/testResponseRefWithInlineSchema.js"',
+      'import type { testResponseRefWithInlineSchemaRouteResponse } from "../routes/testResponseRefWithInlineSchema.ts"',
     );
   });
 });

--- a/apps/craft/tests/integrations/schema-generator/recursive-zod-validation.test.ts
+++ b/apps/craft/tests/integrations/schema-generator/recursive-zod-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Category } from "../generated/schemas/Category.js";
+import { Category } from "../generated/schemas/Category.ts";
 
 describe("Recursive Schema Validation", () => {
   describe("Category (regular recursive schema)", () => {

--- a/apps/craft/tests/integrations/schema-sanitization-collisions.test.ts
+++ b/apps/craft/tests/integrations/schema-sanitization-collisions.test.ts
@@ -3,10 +3,10 @@ import { promises as fs } from "fs";
 import path from "path";
 
 // Import the generated schemas that demonstrate collision detection
-import { Catalog } from "../integrations/generated/schemas/Catalog.js";
-import { CatalogMeta } from "../integrations/generated/schemas/CatalogMeta.js";
-import { catalog2 } from "../integrations/generated/schemas/catalog2.js";
-import { catalogmeta2 } from "../integrations/generated/schemas/catalogmeta2.js";
+import { Catalog } from "../integrations/generated/schemas/Catalog.ts";
+import { CatalogMeta } from "../integrations/generated/schemas/CatalogMeta.ts";
+import { catalog2 } from "../integrations/generated/schemas/catalog2.ts";
+import { catalogmeta2 } from "../integrations/generated/schemas/catalogmeta2.ts";
 
 describe("schema sanitization collision detection", () => {
   it("should have renamed schemas to avoid case-sensitivity conflicts in the generated client", async () => {

--- a/apps/craft/tests/integrations/server-generator/global-security-headers.test.ts
+++ b/apps/craft/tests/integrations/server-generator/global-security-headers.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getCatalogParsedParams,
   getCatalogServerParsedParams,
-} from "../generated/schemas/getCatalogParameters.js";
+} from "../generated/schemas/getCatalogParameters.ts";
 
 describe("Generated global security header schemas", () => {
   it("keeps inherited auth headers optional on client params and required on server routes", () => {

--- a/apps/craft/tests/integrations/server-generator/parse-discrimination-usage.test.ts
+++ b/apps/craft/tests/integrations/server-generator/parse-discrimination-usage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import type { ApiResponseWithParse } from "../generated/client/runtime.js";
-import { isParsed } from "../generated/client/runtime.js";
-import type { TestMultiContentTypesResponseMap } from "../generated/client/testMultiContentTypes.js";
+import type { ApiResponseWithParse } from "../generated/client/runtime.ts";
+import { isParsed } from "../generated/client/runtime.ts";
+import type { TestMultiContentTypesResponseMap } from "../generated/client/testMultiContentTypes.ts";
 
 // Type-level narrowing check: if this file type-checks, the discriminated union works.
 describe("parse() discriminated union usage", () => {

--- a/apps/craft/tests/integrations/server-generator/strict-validation-behavior.test.ts
+++ b/apps/craft/tests/integrations/server-generator/strict-validation-behavior.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import {
   testMultiContentTypesWrapper,
   testMultiContentTypesHandler,
-} from "../generated/server/testMultiContentTypes.js";
+} from "../generated/server/testMultiContentTypes.ts";
 import { setupTestRoute, mockData } from "./test-helpers.js";
 
 describe("Additional Properties behavior", () => {

--- a/apps/craft/tests/integrations/server-generator/test-helpers.ts
+++ b/apps/craft/tests/integrations/server-generator/test-helpers.ts
@@ -1,8 +1,8 @@
 import express, { Request } from "express";
-import { Person } from "../generated/schemas/Person.js";
-import { Message } from "../generated/schemas/Message.js";
-import { NewModel } from "../generated/schemas/NewModel.js";
-import { TestDeserUser } from "../generated/schemas/TestDeserUser.js";
+import { Person } from "../generated/schemas/Person.ts";
+import { Message } from "../generated/schemas/Message.ts";
+import { NewModel } from "../generated/schemas/NewModel.ts";
+import { TestDeserUser } from "../generated/schemas/TestDeserUser.ts";
 
 /**
  * Helper function to create a test Express app

--- a/apps/craft/tests/integrations/server-generator/testAuthBearer.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testAuthBearer.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import {
   testAuthBearerWrapper,
   testAuthBearerHandler,
-} from "../generated/server/testAuthBearer.js";
+} from "../generated/server/testAuthBearer.ts";
 import { setupTestRoute, mockData } from "./test-helpers.js";
 
 describe("testAuthBearer operation integration tests", () => {

--- a/apps/craft/tests/integrations/server-generator/testAuthBearerHttp.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testAuthBearerHttp.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import {
   testAuthBearerHttpWrapper,
   testAuthBearerHttpHandler,
-} from "../generated/server/testAuthBearerHttp.js";
+} from "../generated/server/testAuthBearerHttp.ts";
 import { setupTestRoute, mockData } from "./test-helpers.js";
 
 describe("testAuthBearerHttp operation integration tests", () => {

--- a/apps/craft/tests/integrations/server-generator/testMultiContentTypes.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testMultiContentTypes.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import {
   testMultiContentTypesWrapper,
   testMultiContentTypesHandler,
-} from "../generated/server/testMultiContentTypes.js";
+} from "../generated/server/testMultiContentTypes.ts";
 import { setupTestRoute, mockData } from "./test-helpers.js";
 
 describe("testMultiContentTypes operation integration tests", () => {

--- a/apps/craft/tests/integrations/server-generator/testParameterWithDash.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testParameterWithDash.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import {
   testParameterWithDashWrapper,
   testParameterWithDashHandler,
-} from "../generated/server/testParameterWithDash.js";
+} from "../generated/server/testParameterWithDash.ts";
 import { setupTestRoute } from "./test-helpers.js";
 
 // express treat hypens literally and does not support

--- a/apps/craft/tests/integrations/server-generator/testWildcards.test.ts
+++ b/apps/craft/tests/integrations/server-generator/testWildcards.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import {
   testWildcardsWrapper,
   testWildcardsHandler,
-} from "../generated/server/testWildcards.js";
+} from "../generated/server/testWildcards.ts";
 import { setupTestRoute } from "./test-helpers.js";
 
 describe("testWildcards operation integration tests", () => {

--- a/apps/craft/tests/integrations/simple.test.ts
+++ b/apps/craft/tests/integrations/simple.test.ts
@@ -5,7 +5,7 @@ import {
   createUnauthenticatedClient,
 } from "./client.js";
 import { getRandomPort, MockServer } from "./setup.js";
-import * as operations from "./generated/client/index.js";
+import * as operations from "./generated/client/index.ts";
 
 describe("Working Integration Test Demo", () => {
   let mockServer: MockServer;

--- a/apps/craft/tests/integrations/tsconfig.typecheck.json
+++ b/apps/craft/tests/integrations/tsconfig.typecheck.json
@@ -9,7 +9,9 @@
     // Ensure strictness mirrors project settings
     "strict": true,
     // Generated client code uses fetch and Headers from DOM with iterable methods
-    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true
   },
   "include": ["generated/**/*.ts"]
 }

--- a/apps/craft/tsconfig.tests.json
+++ b/apps/craft/tsconfig.tests.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "moduleResolution": "nodenext",
     "module": "nodenext",
     "target": "ES2022",

--- a/examples/express/client-examples/custom-fetch-credentials.ts
+++ b/examples/express/client-examples/custom-fetch-credentials.ts
@@ -1,5 +1,5 @@
-import { globalConfig } from "../generated/client/runtime.js";
-import { findPetsByStatus } from "../generated/client/findPetsByStatus.js";
+import { globalConfig } from "../generated/client/runtime.ts";
+import { findPetsByStatus } from "../generated/client/findPetsByStatus.ts";
 
 // Custom fetch function that includes credentials by default
 const fetchWithCredentials = (

--- a/examples/express/client-examples/force-validation.ts
+++ b/examples/express/client-examples/force-validation.ts
@@ -1,10 +1,10 @@
 import {
   configureOperations,
   globalConfig,
-} from "../generated/client/runtime.js";
-import { findPetsByStatus } from "../generated/client/findPetsByStatus.js";
-import { getInventory } from "../generated/client/getInventory.js";
-import { getPetById } from "../generated/client/getPetById.js";
+} from "../generated/client/runtime.ts";
+import { findPetsByStatus } from "../generated/client/findPetsByStatus.ts";
+import { getInventory } from "../generated/client/getInventory.ts";
+import { getPetById } from "../generated/client/getPetById.ts";
 
 async function demonstrateClient() {
   // Automatic validation bound client

--- a/examples/express/client-examples/multi-content-types-parse.ts
+++ b/examples/express/client-examples/multi-content-types-parse.ts
@@ -1,5 +1,5 @@
-import { globalConfig, isParsed } from "../generated/client/runtime.js";
-import { updatePet } from "../generated/client/updatePet.js";
+import { globalConfig, isParsed } from "../generated/client/runtime.ts";
+import { updatePet } from "../generated/client/updatePet.ts";
 import z from "zod";
 
 const parseXml = () => {

--- a/examples/express/client-examples/multi-content-types.ts
+++ b/examples/express/client-examples/multi-content-types.ts
@@ -1,5 +1,5 @@
-import { globalConfig } from "../generated/client/runtime.js";
-import { updatePet } from "../generated/client/updatePet.js";
+import { globalConfig } from "../generated/client/runtime.ts";
+import { updatePet } from "../generated/client/updatePet.ts";
 
 const parseXml = () => {
   // Implement XML deserialization logic here

--- a/examples/express/client-examples/neverthrow.ts
+++ b/examples/express/client-examples/neverthrow.ts
@@ -1,6 +1,6 @@
-import { findPetsByStatus } from "../generated/client/findPetsByStatus.js";
+import { findPetsByStatus } from "../generated/client/findPetsByStatus.ts";
 import { Result, err, ok } from "neverthrow";
-import { globalConfig } from "../generated/client/runtime.js";
+import { globalConfig } from "../generated/client/runtime.ts";
 
 type ApiError<T> = Exclude<
   T,

--- a/examples/express/server-examples/express-server-example.ts
+++ b/examples/express/server-examples/express-server-example.ts
@@ -4,15 +4,15 @@ import express from "express";
 import {
   findPetsByStatusWrapper,
   type findPetsByStatusHandler,
-} from "../generated/server/findPetsByStatus.js";
+} from "../generated/server/findPetsByStatus.ts";
 import {
   type getPetByIdHandler,
   route as getPetByIdRoute,
-} from "../generated/server/getPetById.js";
+} from "../generated/server/getPetById.ts";
 import {
   type getInventoryHandler,
   route as getInventoryRoute,
-} from "../generated/server/getInventory.js";
+} from "../generated/server/getInventory.ts";
 import {
   createExpressAdapter,
   extractRequestParams,

--- a/examples/express/server-examples/mock-server-example.ts
+++ b/examples/express/server-examples/mock-server-example.ts
@@ -3,7 +3,7 @@
 import express from "express";
 import { zocker } from "zocker";
 import { createExpressAdapter } from "./express-adapter.js";
-import { routes } from "../generated/server/index.js";
+import { routes } from "../generated/server/index.ts";
 
 const app = express();
 const PORT = 3001;

--- a/examples/express/tsconfig.examples.json
+++ b/examples/express/tsconfig.examples.json
@@ -2,6 +2,8 @@
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "moduleResolution": "NodeNext",
     "skipLibCheck": true,
     "module": "NodeNext",

--- a/examples/hono/README.md
+++ b/examples/hono/README.md
@@ -58,7 +58,7 @@ imports a handler file with the same basename.
 Example `handlers/addPet.ts`:
 
 ```ts
-import type { AddPetHandler } from "../generated/hono/operations/addPet.js";
+import type { AddPetHandler } from "../generated/hono/operations/addPet.ts";
 
 export const addPetHandler: AddPetHandler = async (input, _context) => {
   return {
@@ -82,7 +82,7 @@ Then your server only needs:
 ```ts
 import { Hono } from "hono";
 
-import { registerGeneratedRoutes } from "./generated/hono/register-routes.js";
+import { registerGeneratedRoutes } from "./generated/hono/register-routes.ts";
 
 const app = new Hono();
 registerGeneratedRoutes(app);

--- a/examples/hono/scripts/hono-generator/build-handler-module.ts
+++ b/examples/hono/scripts/hono-generator/build-handler-module.ts
@@ -13,7 +13,7 @@ export function buildHandlerModule(
   const handlerTypeName = `${toPascalCase(operation.moduleBasename)}Handler`;
 
   return [
-    `import type { ${handlerTypeName} } from "${options.operationsImportDirectory}/${operation.moduleBasename}.js";`,
+    `import type { ${handlerTypeName} } from "${options.operationsImportDirectory}/${operation.moduleBasename}.ts";`,
     "",
     `export const ${handlerName}: ${handlerTypeName} = async (_input, _context) => {`,
     `  throw new Error(${JSON.stringify(`Implement ${handlerName} for ${operation.operationId}.`)});`,

--- a/examples/hono/scripts/hono-generator/build-mock-handler-module.ts
+++ b/examples/hono/scripts/hono-generator/build-mock-handler-module.ts
@@ -15,7 +15,7 @@ export function buildMockHandlerModule(
   const routeIdentifier = `${toCamelCase(operation.moduleBasename)}Route`;
 
   return [
-    `import { serverRoute as ${routeIdentifier} } from "${options.routesImportDirectory}/${operation.moduleBasename}.js";`,
+    `import { serverRoute as ${routeIdentifier} } from "${options.routesImportDirectory}/${operation.moduleBasename}.ts";`,
     `import { createMockOperationHandler } from "${options.mockRuntimeImportDirectory}";`,
     "",
     `export const ${handlerName} = createMockOperationHandler(${routeIdentifier});`,

--- a/examples/hono/scripts/hono-generator/build-mock-runtime-module.ts
+++ b/examples/hono/scripts/hono-generator/build-mock-runtime-module.ts
@@ -7,7 +7,7 @@ export function buildMockRuntimeModule() {
     "  type GeneratedOperationHandler,",
     "  type GeneratedRouteDefinition,",
     "  type ResponseMap,",
-    '} from "./runtime.js";',
+    '} from "./runtime.ts";',
     "",
     "interface SelectedResponseVariant {",
     "  contentType: string;",

--- a/examples/hono/scripts/hono-generator/build-operation-module.ts
+++ b/examples/hono/scripts/hono-generator/build-operation-module.ts
@@ -225,10 +225,10 @@ export function buildOperationModule(
       : []),
     'import type { Hono } from "hono";',
     operation.hasBody
-      ? `import {\n  ${requestMapName},\n  serverRoute as ${routeIdentifier},\n  type ${routeResponseTypeName},\n} from "${options.routesImportDirectory}/${operation.moduleBasename}.js";`
-      : `import {\n  serverRoute as ${routeIdentifier},\n  type ${routeResponseTypeName},\n} from "${options.routesImportDirectory}/${operation.moduleBasename}.js";`,
-    `import { ${handlerName} } from "${options.handlersImportDirectory}/${operation.moduleBasename}.js";`,
-    'import * as runtime from "../runtime.js";',
+      ? `import {\n  ${requestMapName},\n  serverRoute as ${routeIdentifier},\n  type ${routeResponseTypeName},\n} from "${options.routesImportDirectory}/${operation.moduleBasename}.ts";`
+      : `import {\n  serverRoute as ${routeIdentifier},\n  type ${routeResponseTypeName},\n} from "${options.routesImportDirectory}/${operation.moduleBasename}.ts";`,
+    `import { ${handlerName} } from "${options.handlersImportDirectory}/${operation.moduleBasename}.ts";`,
+    'import * as runtime from "../runtime.ts";',
     "",
     ...(hasCustomParamNames(operation.paramNameMap)
       ? [

--- a/examples/hono/scripts/hono-generator/build-register-routes-module.ts
+++ b/examples/hono/scripts/hono-generator/build-register-routes-module.ts
@@ -5,7 +5,7 @@ export function buildRegisterRoutesModule(operations: OperationDefinition[]) {
   const importLines = operations.map((operation) => {
     const registerFunctionName = `register${toPascalCase(operation.moduleBasename)}Route`;
 
-    return `import { ${registerFunctionName} } from "./operations/${operation.moduleBasename}.js";`;
+    return `import { ${registerFunctionName} } from "./operations/${operation.moduleBasename}.ts";`;
   });
 
   const registerLines = operations.map((operation) => {

--- a/examples/hono/scripts/hono-generator/generate-hono-server.ts
+++ b/examples/hono/scripts/hono-generator/generate-hono-server.ts
@@ -97,7 +97,7 @@ export async function generateHonoServer(options: GenerateHonoServerOptions) {
       return writeFileIfChanged(
         handlerFilePath,
         buildMockHandlerModule(operation, {
-          mockRuntimeImportDirectory: "../mock-runtime.js",
+          mockRuntimeImportDirectory: "../mock-runtime.ts",
           operationsImportDirectory: operationsImportDirectoryFromHandlersDir,
           routesImportDirectory: routesImportDirectoryFromHandlersDir,
         }),

--- a/examples/hono/server-examples/generate-hono-server.test.ts
+++ b/examples/hono/server-examples/generate-hono-server.test.ts
@@ -65,7 +65,7 @@ describe("generateHonoServer", () => {
     const generatedPackageJson = JSON.parse(generatedPackageJsonContent);
 
     expect(operationModule).toContain(
-      'import { addPetHandler } from "../../../handlers/addPet.js";',
+      'import { addPetHandler } from "../../../handlers/addPet.ts";',
     );
     expect(operationModule).toContain("type addPetRouteResponse");
     expect(operationModule).toContain("await addPetHandler(input, context);");
@@ -134,7 +134,7 @@ describe("generateHonoServer", () => {
     const generatedPackageJson = JSON.parse(generatedPackageJsonContent);
 
     expect(operationModule).toContain(
-      'import { addPetHandler } from "../handlers/addPet.js";',
+      'import { addPetHandler } from "../handlers/addPet.ts";',
     );
     expect(mockHandlerModule).toContain(
       "export const addPetHandler = createMockOperationHandler(addPetRoute);",

--- a/examples/hono/server-examples/hono-generator.test.ts
+++ b/examples/hono/server-examples/hono-generator.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import * as z from "zod";
 
-import { createMockOperationHandler } from "../generated/hono/mock-runtime.js";
+import { createMockOperationHandler } from "../generated/hono/mock-runtime.ts";
 import {
   sendRouteResponse,
   type GeneratedOperationContext,
   type GeneratedRouteDefinition,
-} from "../generated/hono/runtime.js";
+} from "../generated/hono/runtime.ts";
 import { toHonoPath } from "../scripts/hono-generator/route-utils.js";
 
 function createRoute(

--- a/examples/hono/server-examples/mock-server-example.test.ts
+++ b/examples/hono/server-examples/mock-server-example.test.ts
@@ -65,7 +65,7 @@ describe("Hono Mock Server", () => {
           "utf8",
         ),
         readFile(
-          path.join(currentDirectoryPath, "../generated/package.json"),
+          path.join(currentDirectoryPath, "../generated/package.tson"),
           "utf8",
         ),
       ]);
@@ -75,7 +75,7 @@ describe("Hono Mock Server", () => {
       'import { zValidator } from "@hono/zod-validator";',
     );
     expect(operationModule).toContain(
-      'import { addPetHandler } from "../handlers/addPet.js";',
+      'import { addPetHandler } from "../handlers/addPet.ts";',
     );
     expect(operationModule).toContain("type addPetRouteResponse");
     expect(operationModule).toContain("await addPetHandler(input, context);");

--- a/examples/hono/server-examples/mock-server-example.test.ts
+++ b/examples/hono/server-examples/mock-server-example.test.ts
@@ -65,7 +65,7 @@ describe("Hono Mock Server", () => {
           "utf8",
         ),
         readFile(
-          path.join(currentDirectoryPath, "../generated/package.tson"),
+          path.join(currentDirectoryPath, "../generated/package.json"),
           "utf8",
         ),
       ]);

--- a/examples/hono/server-examples/mock-server-example.ts
+++ b/examples/hono/server-examples/mock-server-example.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import {
   registerGeneratedRoutes,
   registeredRoutes,
-} from "../generated/hono/register-routes.js";
+} from "../generated/hono/register-routes.ts";
 
 const PORT = 3002;
 

--- a/examples/hono/tsconfig.examples.json
+++ b/examples/hono/tsconfig.examples.json
@@ -2,6 +2,8 @@
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "moduleResolution": "NodeNext",
     "skipLibCheck": true,
     "module": "NodeNext",

--- a/examples/msw-mock-server/server-examples/mock-server-example.ts
+++ b/examples/msw-mock-server/server-examples/mock-server-example.ts
@@ -3,7 +3,7 @@
 import { setupServer } from "msw/node";
 import { zocker } from "zocker";
 import { createMswHandler } from "./msw-adapter.js";
-import { routes } from "../generated/server/index.js";
+import { routes } from "../generated/server/index.ts";
 
 /* Helper function to prettify validation errors */
 const prettifyValidationError = (params: any): string => {

--- a/examples/msw-mock-server/tsconfig.examples.json
+++ b/examples/msw-mock-server/tsconfig.examples.json
@@ -4,6 +4,8 @@
     "lib": ["ES2023"],
     "module": "ESNext",
     "target": "ES2022",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "moduleResolution": "Bundler",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/tanstack-query-hooks/example/Usage.tsx
+++ b/examples/tanstack-query-hooks/example/Usage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { useFindPetsByStatus } from "../generated/tanstack-query-hooks/findPetsByStatus.js";
-import { useAddPetMutation } from "../generated/tanstack-query-hooks/addPet.js";
+import { useFindPetsByStatus } from "../generated/tanstack-query-hooks/findPetsByStatus.ts";
+import { useAddPetMutation } from "../generated/tanstack-query-hooks/addPet.ts";
 
 export default function Usage() {
   const { data, error, isLoading } = useFindPetsByStatus({

--- a/examples/tanstack-query-hooks/scripts/generate-hooks.ts
+++ b/examples/tanstack-query-hooks/scripts/generate-hooks.ts
@@ -5,8 +5,8 @@ import pLimit from "p-limit";
 /**
  * Assume that the generated client and routes are available.
  */
-import * as importedClient from "../generated/client/index.js";
-import * as importedRoutes from "../generated/routes/index.js";
+import * as importedClient from "../generated/client/index.ts";
+import * as importedRoutes from "../generated/routes/index.ts";
 
 const root = process.cwd();
 const apiDir = path.join(root, "generated");
@@ -51,7 +51,7 @@ async function main() {
       imports.push(
         "import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';",
       );
-      imports.push("import * as ops from '../client/index.js';");
+      imports.push("import * as ops from '../client/index.ts';");
 
       const body: string[] = [];
       body.push(`// Hook for operation ${fnName}`);
@@ -89,9 +89,9 @@ ${body.join("\n\n")}
       await fs.promises.writeFile(filePath, content, "utf8");
       console.log("Wrote", filePath);
 
-      // Export compiled JS files for ESM compatibility in the published output
+      // Re-export the generated TypeScript modules directly.
       indexExports.push(
-        `export * from './${fileName.replace(/\.ts$/, "")}.js';`,
+        `export * from './${fileName.replace(/\.ts$/, "")}.ts';`,
       );
     }),
   );

--- a/examples/tanstack-query-hooks/tsconfig.generated.json
+++ b/examples/tanstack-query-hooks/tsconfig.generated.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": false,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,

--- a/examples/tanstack-query-hooks/tsconfig.json
+++ b/examples/tanstack-query-hooks/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "moduleResolution": "nodenext",
     "module": "nodenext",
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "esModuleInterop": true,
     "allowJs": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noEmit": true
   },
   "include": ["scripts/**/*", "src/**/*", "generated/**/*"]
 }

--- a/packages/client-generator/src/file-writer.ts
+++ b/packages/client-generator/src/file-writer.ts
@@ -46,7 +46,7 @@ export async function writeIndexFile(
   const sanitizedOperations = createSanitizedOperationEntries(operations);
   const operationImports = sanitizedOperations.map(
     ({ sanitizedOperationId }) =>
-      `import { ${sanitizedOperationId} } from './${sanitizedOperationId}.js';`,
+      `import { ${sanitizedOperationId} } from './${sanitizedOperationId}.ts';`,
   );
   const operationExports = sanitizedOperations.map(
     ({ sanitizedOperationId }) => sanitizedOperationId,

--- a/packages/client-generator/src/templates/operation-templates.ts
+++ b/packages/client-generator/src/templates/operation-templates.ts
@@ -227,9 +227,9 @@ export function buildTypeAliasesFromRoute(config: {
   if (config.shouldGenerateResponseMap) {
     typeAliases += `export type ${config.responseMapTypeName.replace(/Map$/u, "DeserializerMap")} = Partial<Record<{
   [Status in keyof ${config.responseMapTypeName}]: keyof ${config.responseMapTypeName}[Status]
-}[keyof ${config.responseMapTypeName}], import('./runtime.js').Deserializer>>;\n\n`;
+}[keyof ${config.responseMapTypeName}], import('./runtime.ts').Deserializer>>;\n\n`;
   } else {
-    typeAliases += `export type ${config.responseMapTypeName.replace(/Map$/u, "DeserializerMap")} = import('./runtime.js').DeserializerMap;\n\n`;
+    typeAliases += `export type ${config.responseMapTypeName.replace(/Map$/u, "DeserializerMap")} = import('./runtime.ts').DeserializerMap;\n\n`;
   }
 
   return typeAliases;

--- a/packages/core-utils/src/core-generator/build-script-template.ts
+++ b/packages/core-utils/src/core-generator/build-script-template.ts
@@ -3,6 +3,7 @@ import {
   readdirSync,
   rmSync,
   writeFileSync,
+  mkdirSync,
 } from "node:fs";
 import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/core-utils/src/core-generator/build-script-template.ts
+++ b/packages/core-utils/src/core-generator/build-script-template.ts
@@ -1,7 +1,5 @@
 export const buildScriptContent = String.raw`import { spawnSync } from "node:child_process";
 import {
-  mkdirSync,
-  readFileSync,
   readdirSync,
   rmSync,
   writeFileSync,
@@ -12,7 +10,6 @@ import { fileURLToPath } from "node:url";
 const DEFAULT_CHUNK_SIZE = 100;
 const root = dirname(fileURLToPath(import.meta.url));
 const buildDir = join(root, ".apical-ts-build");
-const distDir = join(root, "dist");
 const forwardedArgs = process.argv.slice(2);
 const tsgoCommand =
   process.platform === "win32"
@@ -20,7 +17,7 @@ const tsgoCommand =
     : "node_modules/.bin/tsgo";
 
 function logBuild(message) {
-  console.log("[build] " + message);
+  console.log("[typecheck] " + message);
 }
 
 function readChunkSize() {
@@ -63,10 +60,14 @@ function listTypeScriptFiles(directory) {
 }
 
 function runTsgo(configPath) {
-  const result = spawnSync(tsgoCommand, ["-p", configPath, ...forwardedArgs], {
-    cwd: root,
-    stdio: "inherit",
-  });
+  const result = spawnSync(
+    tsgoCommand,
+    ["--noEmit", "-p", configPath, ...forwardedArgs],
+    {
+      cwd: root,
+      stdio: "inherit",
+    },
+  );
 
   if (result.error) {
     throw result.error;
@@ -80,30 +81,6 @@ function runTsgo(configPath) {
 
 function toBuildConfigFilePath(file) {
   return "../" + file;
-}
-
-function isIndexFile(file) {
-  return file === "index.ts" || file.endsWith("/index.ts");
-}
-
-function toOutputJavaScriptPath(file) {
-  return join(distDir, file.replace(/\.ts$/, ".js"));
-}
-
-function stripIndexTypeScript(source) {
-  return source
-    .replace(/^\s*export\s+type\s+\{[^;]*\}\s+from\s+["'][^"']+["'];\s*$/gm, "")
-    .replace(/\s+as const/g, "");
-}
-
-function emitIndexFile(file) {
-  const outputPath = toOutputJavaScriptPath(file);
-
-  mkdirSync(dirname(outputPath), { recursive: true });
-  writeFileSync(
-    outputPath,
-    stripIndexTypeScript(readFileSync(join(root, file), "utf8")),
-  );
 }
 
 let configIndex = 0;
@@ -136,7 +113,7 @@ function compileFiles(files, label) {
 
   if (files.length === 1) {
     console.error(
-      "[build] " + label + ": tsgo failed for " + files[0] + signalSuffix,
+      "[typecheck] " + label + ": tsgo failed for " + files[0] + signalSuffix,
     );
     return result.code;
   }
@@ -164,17 +141,14 @@ let exitCode = 0;
 
 try {
   rmSync(buildDir, { force: true, recursive: true });
-  rmSync(distDir, { force: true, recursive: true });
   mkdirSync(buildDir, { recursive: true });
 
   const files = listTypeScriptFiles(root).sort();
-  const indexFiles = files.filter(isIndexFile);
-  const compilationFiles = files.filter((file) => !isIndexFile(file));
-  const totalChunks = Math.ceil(compilationFiles.length / chunkSize);
+  const totalChunks = Math.ceil(files.length / chunkSize);
 
   logBuild(
-    "compiling " +
-      compilationFiles.length +
+    "typechecking " +
+      files.length +
       " TypeScript files in " +
       totalChunks +
       " chunk(s) of up to " +
@@ -182,12 +156,12 @@ try {
       " files",
   );
 
-  for (let start = 0; start < compilationFiles.length; start += chunkSize) {
-    const chunk = compilationFiles.slice(start, start + chunkSize);
+  for (let start = 0; start < files.length; start += chunkSize) {
+    const chunk = files.slice(start, start + chunkSize);
     const chunkNumber = Math.floor(start / chunkSize) + 1;
     const chunkLabel = "chunk " + chunkNumber + "/" + totalChunks;
 
-    logBuild(chunkLabel + ": compiling " + chunk.length + " file(s)");
+    logBuild(chunkLabel + ": typechecking " + chunk.length + " file(s)");
 
     exitCode = compileFiles(chunk, chunkLabel);
     if (exitCode !== 0) {
@@ -196,9 +170,7 @@ try {
   }
 
   if (exitCode === 0) {
-    logBuild("emitting " + indexFiles.length + " index file(s)");
-    indexFiles.forEach(emitIndexFile);
-    logBuild("build completed");
+    logBuild("typecheck completed");
   }
 } finally {
   rmSync(buildDir, { force: true, recursive: true });

--- a/packages/core-utils/src/core-generator/file-writer.ts
+++ b/packages/core-utils/src/core-generator/file-writer.ts
@@ -39,10 +39,10 @@ function buildImportStatements(
   /* Add config imports */
   const configImports = getConfigImports(functionCode);
   imports.push(
-    `import type { ${configImports.typeImports.join(", ")} } from "./runtime.js";`,
+    `import type { ${configImports.typeImports.join(", ")} } from "./runtime.ts";`,
   );
   imports.push(
-    `import { ${configImports.valueImports.join(", ")} } from "./runtime.js";`,
+    `import { ${configImports.valueImports.join(", ")} } from "./runtime.ts";`,
   );
 
   /* Add Zod import if needed (either explicit via ImportManager or implicit via z.infer usage) */

--- a/packages/core-utils/src/core-generator/import-types.ts
+++ b/packages/core-utils/src/core-generator/import-types.ts
@@ -38,7 +38,7 @@ export class ImportManager {
     const clientRouteName = `${operationId}ClientRoute`;
     const importInfo: ImportInfo = {
       alias: clientRouteName,
-      filePath: `../routes/${operationId}.js`,
+      filePath: `../routes/${operationId}.ts`,
       name: "clientRoute",
       operationId,
       type: "route",
@@ -53,7 +53,7 @@ export class ImportManager {
 
   addConfigImport(configName: string): void {
     const importInfo: ImportInfo = {
-      filePath: "./runtime.js",
+      filePath: "./runtime.ts",
       name: configName,
       type: "config",
     };
@@ -71,7 +71,7 @@ export class ImportManager {
    */
   addParsedParamsTypeImport(operationId: string, typeName: string): void {
     const importInfo: ImportInfo = {
-      filePath: `../schemas/${operationId}Parameters.js`,
+      filePath: `../schemas/${operationId}Parameters.ts`,
       name: typeName,
       operationId,
       type: "parsed-params-type",
@@ -153,7 +153,7 @@ export class ImportManager {
     // Import request map (both type and value with same name, distinguished by TypeScript automatically)
     const requestMapImportInfo: ImportInfo = {
       alias: requestMapAlias,
-      filePath: `../routes/${operationId}.js`,
+      filePath: `../routes/${operationId}.ts`,
       name: requestMapName,
       operationId,
       requestMapName,
@@ -169,7 +169,7 @@ export class ImportManager {
     // Import response map (both type and value with same name)
     const responseMapImportInfo: ImportInfo = {
       alias: responseMapAlias,
-      filePath: `../routes/${operationId}.js`,
+      filePath: `../routes/${operationId}.ts`,
       name: responseMapName,
       operationId,
       responseMapName,
@@ -185,7 +185,7 @@ export class ImportManager {
 
   addSchemaImport(schemaName: string): void {
     const importInfo: ImportInfo = {
-      filePath: `../schemas/${schemaName}.js`,
+      filePath: `../schemas/${schemaName}.ts`,
       name: schemaName,
       type: "schema",
     };

--- a/packages/core-utils/src/core-generator/package-generator.ts
+++ b/packages/core-utils/src/core-generator/package-generator.ts
@@ -6,6 +6,7 @@ import type { StringFormatOverride } from "../schema-generator/format-overrides.
 import { buildScriptContent } from "./build-script-template.js";
 
 const baseCompilerOptions: Record<string, unknown> = {
+  noEmit: true,
   allowSyntheticDefaultImports: true,
   erasableSyntaxOnly: true,
   allowImportingTsExtensions: true,
@@ -14,8 +15,6 @@ const baseCompilerOptions: Record<string, unknown> = {
   lib: ["es2024"],
   module: "NodeNext",
   moduleResolution: "NodeNext",
-  noEmitOnError: false,
-  outDir: "dist",
   resolveJsonModule: true,
   skipLibCheck: true,
   strict: true,

--- a/packages/core-utils/src/core-generator/package-generator.ts
+++ b/packages/core-utils/src/core-generator/package-generator.ts
@@ -7,6 +7,8 @@ import { buildScriptContent } from "./build-script-template.js";
 
 const baseCompilerOptions: Record<string, unknown> = {
   allowSyntheticDefaultImports: true,
+  erasableSyntaxOnly: true,
+  allowImportingTsExtensions: true,
   esModuleInterop: true,
   forceConsistentCasingInFileNames: true,
   lib: ["es2024"],
@@ -89,7 +91,7 @@ export async function createPackageFiles(
     },
     name: "generated-client",
     scripts: {
-      build: useChunkedBuild ? "node ./build.mjs" : "tsgo",
+      typecheck: useChunkedBuild ? "node ./typecheck.mjs" : "tsgo",
     },
     type: "module",
     version: "0.1.0",
@@ -108,11 +110,11 @@ export async function createPackageFiles(
 
   if (useChunkedBuild) {
     packageFileWrites.push(
-      fs.writeFile(path.join(output, "build.mjs"), buildScriptContent),
+      fs.writeFile(path.join(output, "typecheck.mjs"), buildScriptContent),
     );
   } else {
     packageFileWrites.push(
-      fs.rm(path.join(output, "build.mjs"), { force: true }),
+      fs.rm(path.join(output, "typecheck.mjs"), { force: true }),
     );
   }
 

--- a/packages/core-utils/src/core-generator/schema-index-generator.ts
+++ b/packages/core-utils/src/core-generator/schema-index-generator.ts
@@ -114,12 +114,12 @@ function buildImportLines(entry: SchemaIndexEntry): string[] {
     entry.exportNames.length === 1 &&
     !entry.fileName.includes("Parameters.ts")
   ) {
-    return [`import { ${entry.exportNames[0]} } from "./${fileBaseName}.js";`];
+    return [`import { ${entry.exportNames[0]} } from "./${fileBaseName}.ts";`];
   }
 
   return [
     "import {",
     ...entry.exportNames.map((exportName) => `  ${exportName},`),
-    `} from "./${fileBaseName}.js";`,
+    `} from "./${fileBaseName}.ts";`,
   ];
 }

--- a/packages/core-utils/src/schema-generator/file-generators.ts
+++ b/packages/core-utils/src/schema-generator/file-generators.ts
@@ -319,7 +319,7 @@ function generateImportsSection(
         !findStringFormatOverrideByReferenceName(importName, formatOverrides),
     )
     .sort()
-    .map((importName) => `import { ${importName} } from "./${importName}.js";`)
+    .map((importName) => `import { ${importName} } from "./${importName}.ts";`)
     .join("\n");
   const externalImportStatements = renderStringFormatOverrideImports(
     imports,

--- a/packages/core-utils/src/schema-generator/format-overrides.ts
+++ b/packages/core-utils/src/schema-generator/format-overrides.ts
@@ -219,22 +219,21 @@ function getImportSpecifier(
 }
 
 /*
- * Rewrites TypeScript source extensions to the runtime module extension that
- * generated ESM code must import. This keeps path-based overrides compatible
- * with the emitted `.js`/`.mjs`/`.cjs` files.
+ * Preserves TypeScript source extensions so generated code can run directly
+ * under runtimes that execute TypeScript modules natively.
  */
 function rewriteTypeScriptExtension(importPath: string): string {
   if (importPath.endsWith(".d.ts")) {
-    return `${importPath.slice(0, -5)}.js`;
+    return `${importPath.slice(0, -5)}.ts`;
   }
   if (importPath.endsWith(".mts")) {
-    return `${importPath.slice(0, -4)}.mjs`;
+    return importPath;
   }
   if (importPath.endsWith(".cts")) {
-    return `${importPath.slice(0, -4)}.cjs`;
+    return importPath;
   }
   if (importPath.endsWith(".ts") || importPath.endsWith(".tsx")) {
-    return `${importPath.slice(0, importPath.lastIndexOf("."))}.js`;
+    return importPath;
   }
   return importPath;
 }

--- a/packages/core-utils/src/schema-generator/helpers-content.ts
+++ b/packages/core-utils/src/schema-generator/helpers-content.ts
@@ -46,7 +46,7 @@ export function buildGeneratedSchemaHelpersImport(
     return "";
   }
 
-  return `import { ${helperImports.join(", ")} } from "./runtime.js";\n`;
+  return `import { ${helperImports.join(", ")} } from "./runtime.ts";\n`;
 }
 
 export function getHelpersFileContent(): string {

--- a/packages/core-utils/src/schema-generator/parameter-file-generator.ts
+++ b/packages/core-utils/src/schema-generator/parameter-file-generator.ts
@@ -157,7 +157,7 @@ async function generateParameterSchemaFile(
       )
       .sort();
     for (const typeImport of typeImportsList) {
-      imports.push(`import { ${typeImport} } from "./${typeImport}.js";`);
+      imports.push(`import { ${typeImport} } from "./${typeImport}.ts";`);
     }
   }
 

--- a/packages/core-utils/tests/core-generator/schema-index-generator.test.ts
+++ b/packages/core-utils/tests/core-generator/schema-index-generator.test.ts
@@ -40,14 +40,14 @@ describe("core-generator schema-index-generator", () => {
       },
     ]);
 
-    expect(content).toContain(`import { Pet } from "./Pet.js";`);
-    expect(content).toContain(`import { PetRequest } from "./PetRequest.js";`);
+    expect(content).toContain(`import { Pet } from "./Pet.ts";`);
+    expect(content).toContain(`import { PetRequest } from "./PetRequest.ts";`);
     expect(content).toContain(
       [
         "import {",
         "  listPetsQuerySchema,",
         "  listPetsHeadersSchema,",
-        '} from "./listPetsParameters.js";',
+        '} from "./listPetsParameters.ts";',
       ].join("\n"),
     );
     expect(content).not.toContain("emptyParameters");
@@ -77,8 +77,8 @@ describe("core-generator schema-index-generator", () => {
       },
     ]);
 
-    expect(content.match(/from "\.\/Pet\.js";/g)).toHaveLength(1);
-    expect(content.match(/from "\.\/listPetsParameters\.js";/g)).toHaveLength(
+    expect(content.match(/from "\.\/Pet\.ts";/g)).toHaveLength(1);
+    expect(content.match(/from "\.\/listPetsParameters\.ts";/g)).toHaveLength(
       1,
     );
     expect(content).toContain("  listPetsHeadersSchema,");

--- a/packages/core-utils/tests/package-generator.test.ts
+++ b/packages/core-utils/tests/package-generator.test.ts
@@ -40,7 +40,7 @@ describe("package generator", () => {
         },
         name: "generated-client",
         scripts: {
-          build: "tsgo",
+          typecheck: "tsgo",
         },
         type: "module",
         version: "0.1.0",
@@ -50,13 +50,14 @@ describe("package generator", () => {
       expect(tsConfig).toEqual({
         compilerOptions: {
           allowSyntheticDefaultImports: true,
+          allowImportingTsExtensions: true,
+          erasableSyntaxOnly: true,
           esModuleInterop: true,
           forceConsistentCasingInFileNames: true,
           lib: ["es2024"],
           module: "NodeNext",
           moduleResolution: "NodeNext",
-          noEmitOnError: false,
-          outDir: "dist",
+          noEmit: true,
           resolveJsonModule: true,
           rootDir: ".",
           skipLibCheck: true,
@@ -95,11 +96,11 @@ describe("package generator", () => {
         "utf8",
       );
 
-      expect(packageJson.scripts.build).toBe("node ./typecheck.mjs");
+      expect(packageJson.scripts.typecheck).toBe("node ./typecheck.mjs");
       expect(buildScript).toContain("APICAL_TS_BUILD_CHUNK_SIZE");
-      expect(buildScript).toContain("[build] ");
+      expect(buildScript).toContain("[typecheck] ");
       expect(buildScript).toContain("chunk ");
-      expect(buildScript).toContain("emitIndexFile");
+      expect(buildScript).toContain("typecheck completed");
       expect(buildScript).toContain('return "../" + file;');
     } finally {
       await rm(outputDir, { recursive: true, force: true });
@@ -129,13 +130,14 @@ describe("package generator", () => {
       expect(tsConfig).toEqual({
         compilerOptions: {
           allowSyntheticDefaultImports: true,
+          allowImportingTsExtensions: true,
+          erasableSyntaxOnly: true,
           esModuleInterop: true,
           forceConsistentCasingInFileNames: true,
           lib: ["es2024"],
           module: "NodeNext",
           moduleResolution: "NodeNext",
-          noEmitOnError: false,
-          outDir: "dist",
+          noEmit: true,
           resolveJsonModule: true,
           skipLibCheck: true,
           strict: true,

--- a/packages/core-utils/tests/package-generator.test.ts
+++ b/packages/core-utils/tests/package-generator.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "vitest";
 import { createPackageFiles } from "../src/core-generator/package-generator.js";
 
 describe("package generator", () => {
-  it("uses plain tsgo for generated outputs at or below the chunking threshold", async () => {
+  it("uses plain tsgo to typecheck at or below the chunking threshold", async () => {
     const outputDir = await mkdtemp(join(tmpdir(), "core-utils-package-"));
 
     try {

--- a/packages/core-utils/tests/package-generator.test.ts
+++ b/packages/core-utils/tests/package-generator.test.ts
@@ -20,7 +20,7 @@ describe("package generator", () => {
     const outputDir = await mkdtemp(join(tmpdir(), "core-utils-package-"));
 
     try {
-      await writeFile(join(outputDir, "build.mjs"), "stale");
+      await writeFile(join(outputDir, "typecheck.mjs"), "stale");
       await createPackageFiles(outputDir);
 
       const packageJson = JSON.parse(
@@ -45,7 +45,7 @@ describe("package generator", () => {
         type: "module",
         version: "0.1.0",
       });
-      await expect(access(join(outputDir, "build.mjs"))).rejects.toThrow();
+      await expect(access(join(outputDir, "typecheck.mjs"))).rejects.toThrow();
 
       expect(tsConfig).toEqual({
         compilerOptions: {
@@ -70,7 +70,7 @@ describe("package generator", () => {
     }
   });
 
-  it("writes build.mjs for generated outputs above the chunking threshold", async () => {
+  it("writes typecheck.mjs for generated outputs above the chunking threshold", async () => {
     const outputDir = await mkdtemp(join(tmpdir(), "core-utils-package-"));
     const schemasDir = join(outputDir, "schemas");
 
@@ -90,9 +90,12 @@ describe("package generator", () => {
       const packageJson = JSON.parse(
         await readFile(join(outputDir, "package.json"), "utf8"),
       );
-      const buildScript = await readFile(join(outputDir, "build.mjs"), "utf8");
+      const buildScript = await readFile(
+        join(outputDir, "typecheck.mjs"),
+        "utf8",
+      );
 
-      expect(packageJson.scripts.build).toBe("node ./build.mjs");
+      expect(packageJson.scripts.build).toBe("node ./typecheck.mjs");
       expect(buildScript).toContain("APICAL_TS_BUILD_CHUNK_SIZE");
       expect(buildScript).toContain("[build] ");
       expect(buildScript).toContain("chunk ");

--- a/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
@@ -356,10 +356,10 @@ describe("file-generators - recursive generated types compile", () => {
         "requestTracerTrace.ts": requestTracerTrace.content,
         "workersKvAny.ts": workersKvAny.content,
         "recursive-types.ts": `
-import type { requestTracerTrace as RequestTracerTrace } from "./requestTracerTrace.js";
-import { requestTracerTrace } from "./requestTracerTrace.js";
-import type { workersKvAny as WorkersKvAny } from "./workersKvAny.js";
-import { workersKvAny } from "./workersKvAny.js";
+import type { requestTracerTrace as RequestTracerTrace } from "./requestTracerTrace.ts";
+import { requestTracerTrace } from "./requestTracerTrace.ts";
+import type { workersKvAny as WorkersKvAny } from "./workersKvAny.ts";
+import { workersKvAny } from "./workersKvAny.ts";
 
 type IsUnknown<T> = unknown extends T ? ([T] extends [unknown] ? true : false) : false;
 
@@ -425,8 +425,8 @@ void invalidKv;
         "Category.ts": category.content,
         "CategoryParent.ts": categoryParent.content,
         "indirect-cycle.ts": `
-import type { Category } from "./Category.js";
-import type { CategoryParent } from "./CategoryParent.js";
+import type { Category } from "./Category.ts";
+import type { CategoryParent } from "./CategoryParent.ts";
 
 const categoryValue: Category = {};
 const parentValue: CategoryParent = { child: categoryValue };
@@ -467,8 +467,8 @@ void parentValue;
       typecheckGeneratedSchemas({
         "NotificationEvent.ts": notificationEvent.content,
         "notification-event.ts": `
-import type { NotificationEvent } from "./NotificationEvent.js";
-import { NotificationEvent as NotificationEventSchema } from "./NotificationEvent.js";
+import type { NotificationEvent } from "./NotificationEvent.ts";
+import { NotificationEvent as NotificationEventSchema } from "./NotificationEvent.ts";
 
 const value: NotificationEvent = {};
 const parsedValue: NotificationEvent = NotificationEventSchema.parse(value);

--- a/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators-direct-ref.test.ts
@@ -505,6 +505,8 @@ async function typecheckGeneratedSchemas(
       path.join(workspaceDir, "tsconfig.json"),
       JSON.stringify({
         compilerOptions: {
+          allowImportingTsExtensions: true,
+          erasableSyntaxOnly: true,
           module: "ESNext",
           moduleResolution: "bundler",
           noEmit: true,

--- a/packages/core-utils/tests/schema-generator/file-generators.test.ts
+++ b/packages/core-utils/tests/schema-generator/file-generators.test.ts
@@ -127,7 +127,7 @@ describe("schema-generator file-generators", () => {
 
       const result = await generateSchemaFile("Profile", schema);
 
-      expect(result.content).toContain(`import { User } from "./User.js";`);
+      expect(result.content).toContain(`import { User } from "./User.ts";`);
     });
 
     it("should not import itself", async () => {
@@ -211,8 +211,8 @@ describe("schema-generator file-generators", () => {
 
       const result = await generateSchemaFile("Profile", schema);
 
-      expect(result.content).toMatch(/import \{ Role \} from "\.\/Role\.js";/);
-      expect(result.content).toMatch(/import \{ User \} from "\.\/User\.js";/);
+      expect(result.content).toMatch(/import \{ Role \} from "\.\/Role\.ts";/);
+      expect(result.content).toMatch(/import \{ User \} from "\.\/User\.ts";/);
     });
     it("should include helpers import when schema uses exclusiveUnion", async () => {
       const schema: SchemaObject = {
@@ -230,7 +230,7 @@ describe("schema-generator file-generators", () => {
       const result = await generateSchemaFile("SearchHit", schema);
 
       expect(result.content).toContain(
-        'import { exclusiveUnion } from "./runtime.js";',
+        'import { exclusiveUnion } from "./runtime.ts";',
       );
       expect(result.content).toContain("export const SearchHit =");
     });
@@ -251,7 +251,7 @@ describe("schema-generator file-generators", () => {
       const result = await generateSchemaFile("User", schema);
 
       expect(result.content).not.toContain(
-        'import { exclusiveUnion } from "./runtime.js";',
+        'import { exclusiveUnion } from "./runtime.ts";',
       );
     });
 
@@ -271,7 +271,7 @@ describe("schema-generator file-generators", () => {
       const result = await generateSchemaFile("User", schema);
 
       expect(result.content).not.toContain(
-        'import { exclusiveUnion } from "./runtime.js";',
+        'import { exclusiveUnion } from "./runtime.ts";',
       );
     });
   });

--- a/packages/route-generator/src/file-writer.ts
+++ b/packages/route-generator/src/file-writer.ts
@@ -35,7 +35,7 @@ export async function writeRouteMetadataFile(
   const schemaImports: string[] = [];
 
   categorized.regularImports.forEach((imp) => {
-    schemaImports.push(`import { ${imp} } from "../schemas/${imp}.js";`);
+    schemaImports.push(`import { ${imp} } from "../schemas/${imp}.ts";`);
   });
 
   /* Build imports section */
@@ -62,14 +62,14 @@ export async function writeRoutesIndexFile(
   /* Generate individual route exports for both client and server */
   const exports = sanitizedOperations
     .map(({ sanitizedOperationId }) => {
-      return `export { clientRoute as ${sanitizedOperationId}ClientRoute, serverRoute as ${sanitizedOperationId}ServerRoute } from "./${sanitizedOperationId}.js";`;
+      return `export { clientRoute as ${sanitizedOperationId}ClientRoute, serverRoute as ${sanitizedOperationId}ServerRoute } from "./${sanitizedOperationId}.ts";`;
     })
     .join("\n");
 
   /* Generate route imports for routes object - use server routes by default */
   const routeImports = sanitizedOperations
     .map(({ sanitizedOperationId }) => {
-      return `import { serverRoute as ${sanitizedOperationId}Route } from "./${sanitizedOperationId}.js";`;
+      return `import { serverRoute as ${sanitizedOperationId}Route } from "./${sanitizedOperationId}.ts";`;
     })
     .join("\n");
 

--- a/packages/route-generator/src/templates/route-metadata-templates.ts
+++ b/packages/route-generator/src/templates/route-metadata-templates.ts
@@ -56,7 +56,7 @@ export function renderRouteMetadata(
     ? `import {
   ${parsedParamsName},
   ${serverParsedParamsName},
-} from "../schemas/${sanitizedId}Parameters.js";`
+} from "../schemas/${sanitizedId}Parameters.ts";`
     : "";
 
   /* Build request/response maps if needed */

--- a/packages/route-generator/tests/file-writer.test.ts
+++ b/packages/route-generator/tests/file-writer.test.ts
@@ -42,7 +42,7 @@ describe("route-generator file writer", () => {
       "addonPropertiesResource.deleteAddonProperty_delete.ts",
     );
     expect(indexContent).toContain(
-      "./addonPropertiesResourceDeleteAddonPropertyDelete.js",
+      "./addonPropertiesResourceDeleteAddonPropertyDelete.ts",
     );
   });
 

--- a/packages/server-generator/src/file-writer.ts
+++ b/packages/server-generator/src/file-writer.ts
@@ -27,14 +27,14 @@ export async function writeServerIndexFile(
   const sanitizedOperations = createSanitizedOperationEntries(operations);
   const exports = sanitizedOperations
     .map(({ sanitizedOperationId }) => {
-      return `export { ${sanitizedOperationId}Wrapper } from "./${sanitizedOperationId}.js";`;
+      return `export { ${sanitizedOperationId}Wrapper } from "./${sanitizedOperationId}.ts";`;
     })
     .join("\n");
 
   /* Generate routes object with all route functions properly aliased */
   const routeImports = sanitizedOperations
     .map(({ sanitizedOperationId }) => {
-      return `import { route as ${sanitizedOperationId}Route } from "./${sanitizedOperationId}.js";`;
+      return `import { route as ${sanitizedOperationId}Route } from "./${sanitizedOperationId}.ts";`;
     })
     .join("\n");
 
@@ -55,7 +55,7 @@ ${exports}
 /* Re-export all handlers */
   ${sanitizedOperations
     .map(({ sanitizedOperationId }) => {
-      return `export type { ${sanitizedOperationId}Handler } from "./${sanitizedOperationId}.js";`;
+      return `export type { ${sanitizedOperationId}Handler } from "./${sanitizedOperationId}.ts";`;
     })
     .join("\n")}
 

--- a/packages/server-generator/src/templates/server-operation-templates.ts
+++ b/packages/server-generator/src/templates/server-operation-templates.ts
@@ -43,21 +43,21 @@ export function renderServerOperationWrapper(
 
   /* Import request/response maps and response type from route metadata */
   const responseTypeImport = responseMapTypeName
-    ? `import type { ${routeResponseType} } from "../routes/${sanitizedId}.js";`
+    ? `import type { ${routeResponseType} } from "../routes/${sanitizedId}.ts";`
     : "";
   /* Import runtime request/response map values; use typeof for types */
   const requestMapImport = requestMapTypeName
-    ? `import { ${requestMapTypeName} } from "../routes/${sanitizedId}.js";`
+    ? `import { ${requestMapTypeName} } from "../routes/${sanitizedId}.ts";`
     : "";
   const responseMapImport = responseMapTypeName
-    ? `import { ${responseMapTypeName} } from "../routes/${sanitizedId}.js";`
+    ? `import { ${responseMapTypeName} } from "../routes/${sanitizedId}.ts";`
     : "";
 
   /* Import pre-computed server parsed params type to avoid expensive z.infer inference */
   const hasAnyParams = hasQuery || hasPath || hasHeaders;
   const serverParsedParamsTypeName = `${sanitizedId}ServerParsedParamsType`;
   const parsedParamsTypeImport = hasAnyParams
-    ? `import type { ${serverParsedParamsTypeName} } from "../schemas/${sanitizedId}Parameters.js";`
+    ? `import type { ${serverParsedParamsTypeName} } from "../schemas/${sanitizedId}Parameters.ts";`
     : "";
 
   const validationLogic = renderValidationLogic(
@@ -120,7 +120,7 @@ ${validationLogic}
   /* Combine all parts */
   const parts = [
     `import * as z from "zod";`,
-    `import { serverRoute as ${sanitizedId}RouteMetadata } from "../routes/${sanitizedId}.js";`,
+    `import { serverRoute as ${sanitizedId}RouteMetadata } from "../routes/${sanitizedId}.ts";`,
     responseTypeImport,
     requestMapImport,
     responseMapImport,

--- a/packages/server-generator/tests/file-writer.test.ts
+++ b/packages/server-generator/tests/file-writer.test.ts
@@ -40,7 +40,7 @@ describe("server-generator file writer", () => {
       "addonPropertiesResource.deleteAddonProperty_delete.ts",
     );
     expect(indexContent).toContain(
-      "./addonPropertiesResourceDeleteAddonPropertyDelete.js",
+      "./addonPropertiesResourceDeleteAddonPropertyDelete.ts",
     );
   });
 

--- a/packages/server-generator/tests/server-generator-comprehensive.test.ts
+++ b/packages/server-generator/tests/server-generator-comprehensive.test.ts
@@ -75,7 +75,7 @@ describe("server-generator comprehensive validation", () => {
 
     /* Verify response type is imported from routes */
     expect(result.wrapperCode).toContain(
-      'import type { petFindByStatusRouteResponse } from "../routes/petFindByStatus.js"',
+      'import type { petFindByStatusRouteResponse } from "../routes/petFindByStatus.ts"',
     );
     expect(result.wrapperCode).toContain("petFindByStatusRouteResponse");
 

--- a/packages/server-generator/tests/server-generator-exact-match.test.ts
+++ b/packages/server-generator/tests/server-generator-exact-match.test.ts
@@ -97,7 +97,7 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify response type is imported from routes */
     expect(result.wrapperCode).toContain(
-      'import type { petFindByStatusRouteResponse } from "../routes/petFindByStatus.js"',
+      'import type { petFindByStatusRouteResponse } from "../routes/petFindByStatus.ts"',
     );
     expect(result.wrapperCode).toContain("petFindByStatusRouteResponse");
 

--- a/packages/server-generator/tests/server-generator.test.ts
+++ b/packages/server-generator/tests/server-generator.test.ts
@@ -177,7 +177,7 @@ describe("server-generator operation wrapper", () => {
     expect(result.wrapperCode).toContain("schema.safeParse(req.body)");
     expect(result.wrapperCode).toContain("testStrictBodyValidationRequestMap");
     expect(result.wrapperCode).toContain(
-      'from "../routes/testStrictBodyValidation.js"',
+      'from "../routes/testStrictBodyValidation.ts"',
     );
     expect(result.wrapperCode).toContain("testStrictBodyValidationWrapper");
     expect(result.wrapperCode).toContain("body-error");

--- a/packages/test-core/tests/integrations/client.ts
+++ b/packages/test-core/tests/integrations/client.ts
@@ -1,8 +1,8 @@
 import {
   configureOperations,
   type GlobalConfig,
-} from "./generated/client/runtime.js";
-import * as operations from "./generated/client/index.js";
+} from "./generated/client/runtime.ts";
+import * as operations from "./generated/client/index.ts";
 
 /**
  * Test client configuration

--- a/packages/test-core/tests/integrations/deserializer-map.test.ts
+++ b/packages/test-core/tests/integrations/deserializer-map.test.ts
@@ -44,7 +44,7 @@ describe("DeserializerMap Integration Test", () => {
 
     /* Find the deserializer map type definition */
     const deserializerMapMatch = operationContent.match(
-      /export type TestAuthBearerHttpResponseDeserializerMap = Partial<\s*Record<\s*([\s\S]*?),\s*import\('\.\/runtime\.js'\)\.Deserializer\s*>\s*>;/,
+      /export type TestAuthBearerHttpResponseDeserializerMap = Partial<\s*Record<\s*([\s\S]*?),\s*import\('\.\/runtime\.ts'\)\.Deserializer\s*>\s*>;/,
     );
 
     expect(deserializerMapMatch).toBeTruthy();
@@ -89,7 +89,7 @@ describe("DeserializerMap Integration Test", () => {
 
     /* Check that route is imported */
     expect(operationContent).toContain(
-      'from "../routes/testAuthBearerHttp.js"',
+      'from "../routes/testAuthBearerHttp.ts"',
     );
 
     /* Response map structure should be in route file */

--- a/packages/test-core/tests/integrations/force-validation.test.ts
+++ b/packages/test-core/tests/integrations/force-validation.test.ts
@@ -36,7 +36,7 @@ describe("Dynamic Force Validation Integration Test", () => {
       "export const TestDeserializationResponseMap = testDeserializationResponseMap",
     );
     // Check that route is imported (includes clientRoute alias)
-    expect(content).toContain('from "../routes/testDeserialization.js"');
+    expect(content).toContain('from "../routes/testDeserialization.ts"');
   });
 
   it("multi content type operation has both code paths", async () => {

--- a/packages/test-core/tests/integrations/tsconfig.typecheck.json
+++ b/packages/test-core/tests/integrations/tsconfig.typecheck.json
@@ -7,6 +7,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "rootDir": "../../",
     "incremental": false,
     "strict": true,

--- a/packages/test-core/tests/schema-generator/file-generators.test.ts
+++ b/packages/test-core/tests/schema-generator/file-generators.test.ts
@@ -124,7 +124,7 @@ describe("schema-generator file-generators", () => {
 
       const result = await generateSchemaFile("Profile", schema);
 
-      expect(result.content).toContain(`import { User } from "./User.js";`);
+      expect(result.content).toContain(`import { User } from "./User.ts";`);
     });
 
     it("should not import itself", async () => {
@@ -192,8 +192,8 @@ describe("schema-generator file-generators", () => {
 
       const result = await generateSchemaFile("Profile", schema);
 
-      expect(result.content).toMatch(/import \{ Role \} from "\.\/Role\.js";/);
-      expect(result.content).toMatch(/import \{ User \} from "\.\/User\.js";/);
+      expect(result.content).toMatch(/import \{ Role \} from "\.\/Role\.ts";/);
+      expect(result.content).toMatch(/import \{ User \} from "\.\/User\.ts";/);
     });
   });
 


### PR DESCRIPTION
Update TypeScript configuration to allow importing files with the `.ts` extension and modify import statements across various examples and tests to reflect this change. This enhances compatibility with TypeScript's module resolution.